### PR TITLE
修复主菜单在无活动 run 时错误隐藏 open_character_select

### DIFF
--- a/STS2AIAgent/Game/GameStateService.cs
+++ b/STS2AIAgent/Game/GameStateService.cs
@@ -857,7 +857,15 @@ internal static class GameStateService
         }
 
         var singleplayerButton = GetMainMenuSingleplayerButton(mainMenu);
-        return singleplayerButton != null && singleplayerButton.IsVisibleInTree() && singleplayerButton.IsEnabled;
+        if (singleplayerButton != null && singleplayerButton.IsVisibleInTree() && singleplayerButton.IsEnabled)
+        {
+            return true;
+        }
+
+        // Some main-menu states still allow the singleplayer submenu to open even when the
+        // button has not become visible in the scene tree. If there is no active run flow to
+        // continue or abandon, prefer exposing character select instead of hard-blocking.
+        return !CanContinueRun(currentScreen) && !CanAbandonRun(currentScreen);
     }
 
     public static bool CanOpenTimeline(IScreenContext? currentScreen)


### PR DESCRIPTION
## 变更概述

这个 PR 修复了主菜单上一处 `open_character_select` 的假阴性判定。

在异常状态下，`available_actions` 只会暴露 `open_timeline`，即使当前并没有活动 run，而且单人角色选择界面实际上仍然可以被正常打开。这样会导致自动化客户端卡死在主菜单。

关闭 #7。

## 根因

`CanOpenCharacterSelect()` 当前把“能否打开角色选择”与 `MainMenuTextButtons/SingleplayerButton` 的可见性绑定在一起。

但 `ExecuteOpenCharacterSelectAsync()` 的真实执行路径并不是模拟点击这个按钮，而是直接初始化并 push `NCharacterSelectScreen`。也就是说：

- 可用性判断依赖按钮是否可见
- 实际执行依赖子菜单是否可直接打开

两者不一致，导致在某些主菜单状态下动作被错误隐藏。

## 修复方式

保留原有快速路径：

- 如果 `SingleplayerButton` 可见且可点击，仍然直接返回 `true`

新增兜底：

- 当前是可见的 `NMainMenu`
- 没有 submenu 打开
- 不存在 `continue_run` / `abandon_run`

满足以上条件时，也允许暴露 `open_character_select`。

## 验证

手工验证环境：macOS，游戏 `v0.98.3`，mod `0.3.0`。

验证结果：

- 修复前：`available_actions = ["open_timeline"]`
- 修复后：`available_actions = ["open_character_select", "open_timeline"]`
- 已确认可以进入 `CHARACTER_SELECT`
- 已确认可以成功 `embark` 并开始新 run
