### PR TITLE
fix: Open-source license could not be identified (MIT/X11)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -282,7 +282,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
       "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
-      "license": "MIT/X11",
+      "license": "MIT",
       "dependencies": {
         "traverse": ">=0.3.0 <0.4"
       },
@@ -1450,7 +1450,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
       "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
-      "license": "MIT/X11",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }


### PR DESCRIPTION
Update MIT/X11 license to MIT in package-lock.json

## Summary by Sourcery

Chores:
- Align package-lock.json license metadata from MIT/X11 to MIT to match expected open-source license naming.