### PR TITLE
feat(mcp): add act2 decision support scorers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ _bmad-output/
 .claude/
 .serena/
 node_modules/
+
+# Runtime artifacts
+agent_knowledge/logs/

--- a/STS2AIAgent/Game/GameActionService.cs
+++ b/STS2AIAgent/Game/GameActionService.cs
@@ -1397,6 +1397,24 @@ internal static class GameActionService
             await WaitForNextFrameAsync();
         }
 
+        var alternatives = GameStateService.GetCardRewardAlternativeButtons(cardRewardScreen);
+        var skipButton = alternatives.FirstOrDefault();
+        if (skipButton != null)
+        {
+            skipButton.ForceClick();
+
+            while (DateTime.UtcNow < deadline)
+            {
+                await WaitForNextFrameAsync();
+
+                if (!GodotObject.IsInstanceValid(cardRewardScreen) ||
+                    ActiveScreenContext.Instance.GetCurrentScreen() is not NCardRewardSelectionScreen)
+                {
+                    return true;
+                }
+            }
+        }
+
         var options = GameStateService.GetCardRewardOptions(cardRewardScreen);
         var selected = options.FirstOrDefault();
         if (selected == null)

--- a/STS2AIAgent/Game/GameStateService.cs
+++ b/STS2AIAgent/Game/GameStateService.cs
@@ -1393,6 +1393,125 @@ internal static class GameStateService
         return value.ToString() ?? string.Empty;
     }
 
+    /// <summary>
+    /// Attempt to get the formatted (resolved) card description with actual computed values
+    /// instead of template strings like {Damage:diff()}.
+    /// </summary>
+    private static string? GetCardFormattedDescription(CardModel? card)
+    {
+        if (card == null) return null;
+
+        const BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+
+        try
+        {
+            // Try Description property — in many card implementations this is a rich text object
+            var descProp = card.GetType().GetProperty("Description", flags);
+            if (descProp != null)
+            {
+                var descValue = descProp.GetValue(card);
+                if (descValue != null && descValue is not string)
+                {
+                    // It's a rich text object — call GetFormattedText() to resolve templates
+                    var fmt = descValue.GetType().GetMethod("GetFormattedText", flags, null, Type.EmptyTypes, null);
+                    if (fmt != null)
+                    {
+                        var resolved = fmt.Invoke(descValue, null) as string;
+                        if (!string.IsNullOrWhiteSpace(resolved))
+                        {
+                            return NormalizeCardRulesText(resolved);
+                        }
+                    }
+                }
+            }
+        }
+        catch { }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Extract computed damage/block values from a CardModel via reflection.
+    /// Returns (damage, block, hitCount) — any may be null if not applicable.
+    /// </summary>
+    private static (int? damage, int? block, int? hitCount) TryExtractCardValues(CardModel? card)
+    {
+        if (card == null) return (null, null, null);
+
+        const BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+        int? damage = null;
+        int? block = null;
+        int? hitCount = null;
+
+        try
+        {
+            // Try common property names for damage
+            foreach (var name in new[] { "Damage", "BaseDamage", "AttackDamage", "DamageAmount" })
+            {
+                var prop = card.GetType().GetProperty(name, flags);
+                if (prop != null && (prop.PropertyType == typeof(int) || prop.PropertyType == typeof(int?)))
+                {
+                    var val = prop.GetValue(card);
+                    if (val is int d && d > 0) { damage = d; break; }
+                }
+
+                var field = card.GetType().GetField(name, flags);
+                if (field != null && (field.FieldType == typeof(int) || field.FieldType == typeof(int?)))
+                {
+                    var val = field.GetValue(card);
+                    if (val is int d && d > 0) { damage = d; break; }
+                }
+            }
+        }
+        catch { }
+
+        try
+        {
+            // Try common property names for block
+            foreach (var name in new[] { "Block", "BaseBlock", "BlockAmount", "DefenseBlock" })
+            {
+                var prop = card.GetType().GetProperty(name, flags);
+                if (prop != null && (prop.PropertyType == typeof(int) || prop.PropertyType == typeof(int?)))
+                {
+                    var val = prop.GetValue(card);
+                    if (val is int b && b > 0) { block = b; break; }
+                }
+
+                var field = card.GetType().GetField(name, flags);
+                if (field != null && (field.FieldType == typeof(int) || field.FieldType == typeof(int?)))
+                {
+                    var val = field.GetValue(card);
+                    if (val is int b && b > 0) { block = b; break; }
+                }
+            }
+        }
+        catch { }
+
+        try
+        {
+            // Try to extract hit count / repeats
+            foreach (var name in new[] { "HitCount", "Repeats", "AttackCount", "MultiHit" })
+            {
+                var prop = card.GetType().GetProperty(name, flags);
+                if (prop != null && (prop.PropertyType == typeof(int) || prop.PropertyType == typeof(int?)))
+                {
+                    var val = prop.GetValue(card);
+                    if (val is int h && h > 1) { hitCount = h; break; }
+                }
+
+                var field = card.GetType().GetField(name, flags);
+                if (field != null && (field.FieldType == typeof(int) || field.FieldType == typeof(int?)))
+                {
+                    var val = field.GetValue(card);
+                    if (val is int h && h > 1) { hitCount = h; break; }
+                }
+            }
+        }
+        catch { }
+
+        return (damage, block, hitCount);
+    }
+
     private static string NormalizeCardRulesText(string value)
     {
         if (string.IsNullOrWhiteSpace(value))
@@ -2283,16 +2402,23 @@ internal static class GameStateService
         var keywords = GetGlossaryMatches(card.rules_text, mods);
         CollectGlossaryTerms(glossaryTerms, card.rules_text, mods);
 
+        // Use resolved_text (actual numbers) in the line if available, fallback to rules_text (templates)
+        var displayText = card.resolved_text ?? card.rules_text;
+
         return new
         {
             i = card.index,
-            line = FormatCardLine(card.name, card.upgraded, 1, card.energy_cost, card.star_cost, card.costs_x, card.star_costs_x, card.rules_text),
+            line = FormatCardLine(card.name, card.upgraded, 1, card.energy_cost, card.star_cost, card.costs_x, card.star_costs_x, displayText),
             playable = card.playable,
             target = card.requires_target ? NormalizeTargetHint(card.target_index_space ?? card.target_type) : null,
             targets = card.requires_target ? card.valid_target_indices : Array.Empty<int>(),
             why = card.playable ? null : card.unplayable_reason,
             keywords,
-            mods
+            mods,
+            dmg = card.computed_damage,
+            blk = card.computed_block,
+            hits = card.hit_count,
+            type = string.IsNullOrEmpty(card.card_type) ? null : card.card_type
         };
     }
 
@@ -3354,6 +3480,8 @@ internal static class GameStateService
         var targetSupported = IsCardTargetSupported(card);
         var targetIndexSpace = GetCardTargetIndexSpace(card);
         var validTargetIndices = GetCardTargetIndices(combatState, card);
+        var (computedDamage, computedBlock, hitCount) = TryExtractCardValues(card);
+        var resolvedText = GetCardFormattedDescription(card);
 
         return new CombatHandCardPayload
         {
@@ -3370,10 +3498,15 @@ internal static class GameStateService
             energy_cost = card.EnergyCost.GetWithModifiers(CostModifiers.All),
             star_cost = Math.Max(0, card.GetStarCostWithModifiers()),
             rules_text = GetCardRulesText(card),
+            resolved_text = resolvedText,
             playable = targetSupported && reason == UnplayableReason.None,
             unplayable_reason = targetSupported
                 ? GetUnplayableReasonCode(reason)
-                : "unsupported_target_type"
+                : "unsupported_target_type",
+            computed_damage = computedDamage,
+            computed_block = computedBlock,
+            hit_count = hitCount,
+            card_type = card.Type.ToString()
         };
     }
 
@@ -3381,6 +3514,7 @@ internal static class GameStateService
     {
         var moveId = enemy.Monster?.NextMove?.Id;
         var intents = BuildEnemyIntentPayloads(enemy);
+        var (moveHistory, turnCount) = TryExtractMoveHistory(enemy);
 
         return new CombatEnemyPayload
         {
@@ -3395,8 +3529,89 @@ internal static class GameStateService
             powers = BuildCreaturePowerPayloads(enemy),
             intent = moveId,
             move_id = moveId,
-            intents = intents
+            intents = intents,
+            move_history = moveHistory,
+            turn_count = turnCount
         };
+    }
+
+    /// <summary>
+    /// Try to extract the enemy's move history and turn count via reflection.
+    /// This helps the agent predict future moves based on patterns.
+    /// </summary>
+    private static (string[]? moveHistory, int? turnCount) TryExtractMoveHistory(Creature enemy)
+    {
+        const BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+
+        try
+        {
+            var monster = enemy.Monster;
+            if (monster == null) return (null, null);
+
+            var monsterType = monster.GetType();
+
+            // Try to get move history
+            string[]? history = null;
+            foreach (var name in new[] { "MoveHistory", "PreviousMoves", "UsedMoves", "MoveLog" })
+            {
+                var prop = monsterType.GetProperty(name, flags);
+                if (prop != null)
+                {
+                    var val = prop.GetValue(monster);
+                    if (val is System.Collections.IEnumerable enumerable)
+                    {
+                        var moves = new System.Collections.Generic.List<string>();
+                        foreach (var item in enumerable)
+                        {
+                            var str = item?.ToString();
+                            if (!string.IsNullOrEmpty(str)) moves.Add(str);
+                        }
+                        if (moves.Count > 0) { history = moves.ToArray(); break; }
+                    }
+                }
+
+                var field = monsterType.GetField(name, flags);
+                if (field != null)
+                {
+                    var val = field.GetValue(monster);
+                    if (val is System.Collections.IEnumerable enumerable)
+                    {
+                        var moves = new System.Collections.Generic.List<string>();
+                        foreach (var item in enumerable)
+                        {
+                            var str = item?.ToString();
+                            if (!string.IsNullOrEmpty(str)) moves.Add(str);
+                        }
+                        if (moves.Count > 0) { history = moves.ToArray(); break; }
+                    }
+                }
+            }
+
+            // Try to get turn count
+            int? turnCount = null;
+            foreach (var name in new[] { "TurnCount", "MoveIndex", "CurrentTurn", "Turn" })
+            {
+                var prop = monsterType.GetProperty(name, flags);
+                if (prop != null && (prop.PropertyType == typeof(int) || prop.PropertyType == typeof(int?)))
+                {
+                    var val = prop.GetValue(monster);
+                    if (val is int t) { turnCount = t; break; }
+                }
+
+                var field = monsterType.GetField(name, flags);
+                if (field != null && (field.FieldType == typeof(int) || field.FieldType == typeof(int?)))
+                {
+                    var val = field.GetValue(monster);
+                    if (val is int t) { turnCount = t; break; }
+                }
+            }
+
+            return (history, turnCount);
+        }
+        catch
+        {
+            return (null, null);
+        }
     }
 
     private static CombatPowerPayload[] BuildCreaturePowerPayloads(Creature creature)
@@ -5243,9 +5458,19 @@ internal sealed class CombatHandCardPayload
 
     public string rules_text { get; init; } = string.Empty;
 
+    public string? resolved_text { get; init; }
+
     public bool playable { get; init; }
 
     public string? unplayable_reason { get; init; }
+
+    public int? computed_damage { get; init; }
+
+    public int? computed_block { get; init; }
+
+    public int? hit_count { get; init; }
+
+    public string card_type { get; init; } = string.Empty;
 }
 
 internal sealed class CombatEnemyPayload
@@ -5273,6 +5498,10 @@ internal sealed class CombatEnemyPayload
     public string? move_id { get; init; }
 
     public CombatEnemyIntentPayload[] intents { get; init; } = Array.Empty<CombatEnemyIntentPayload>();
+
+    public string[]? move_history { get; init; }
+
+    public int? turn_count { get; init; }
 }
 
 internal sealed class CombatEnemyIntentPayload

--- a/STS2AIAgent/Game/GameStateService.cs
+++ b/STS2AIAgent/Game/GameStateService.cs
@@ -1941,13 +1941,42 @@ internal static class GameStateService
         {
             player = new
             {
+                current_hp = combat.player.current_hp,
+                max_hp = combat.player.max_hp,
                 hp = $"{combat.player.current_hp}/{combat.player.max_hp}",
                 block = combat.player.block,
                 energy = combat.player.energy,
                 stars = combat.player.stars,
                 focus = combat.player.focus,
+                powers = combat.player.powers.Select(power => new
+                {
+                    i = power.index,
+                    power_id = power.power_id,
+                    name = power.name,
+                    amount = power.amount,
+                    debuff = power.is_debuff
+                }).ToArray(),
+                base_orb_slots = combat.player.base_orb_slots,
+                orb_capacity = combat.player.orb_capacity,
+                empty_orb_slots = combat.player.empty_orb_slots,
                 orbs = combat.player.orbs.Select(orb => FormatOrbLine(orb)).ToArray()
             },
+            players = combat.players.Select(player => new
+            {
+                player_id = player.player_id,
+                slot = player.slot_index,
+                local = player.is_local,
+                connected = player.is_connected,
+                character_id = player.character_id,
+                character = player.character_name,
+                current_hp = player.current_hp,
+                max_hp = player.max_hp,
+                block = player.block,
+                energy = player.energy,
+                stars = player.stars,
+                focus = player.focus,
+                alive = player.is_alive
+            }).ToArray(),
             hand = combat.hand.Select(card =>
                 BuildAgentHandCardPayload(
                     card,
@@ -1959,10 +1988,32 @@ internal static class GameStateService
             enemies = combat.enemies.Select(enemy => new
             {
                 i = enemy.index,
+                enemy_id = enemy.enemy_id,
                 name = enemy.name,
+                current_hp = enemy.current_hp,
+                max_hp = enemy.max_hp,
                 hp = $"{enemy.current_hp}/{enemy.max_hp}",
                 block = enemy.block,
                 intent = enemy.intent,
+                move_id = enemy.move_id,
+                powers = enemy.powers.Select(power => new
+                {
+                    i = power.index,
+                    power_id = power.power_id,
+                    name = power.name,
+                    amount = power.amount,
+                    debuff = power.is_debuff
+                }).ToArray(),
+                intents = enemy.intents.Select(intent => new
+                {
+                    i = intent.index,
+                    type = intent.intent_type,
+                    label = intent.label,
+                    damage = intent.damage,
+                    hits = intent.hits,
+                    total_damage = intent.total_damage,
+                    status_card_count = intent.status_card_count
+                }).ToArray(),
                 alive = enemy.is_alive,
                 hittable = enemy.is_hittable
             }).ToArray()
@@ -1986,24 +2037,42 @@ internal static class GameStateService
 
         return new
         {
+            character_id = run.character_id,
             character = run.character_name,
             floor = run.floor,
+            current_hp = run.current_hp,
+            max_hp = run.max_hp,
             hp = $"{run.current_hp}/{run.max_hp}",
             gold = run.gold,
             max_energy = run.max_energy,
             base_orb_slots = run.base_orb_slots,
+            deck_size = deckCards.Length > 0 ? deckCards.Length : run.deck.Length,
             deck = deckCards.Length > 0
                 ? BuildAgentCardStacks(deckCards, glossaryTerms)
                 : BuildAgentCardStacks(run.deck, glossaryTerms),
             relics = run.relics
                 .Select(relic => relic.is_melted ? $"{relic.name} (熔毁)" : relic.name)
                 .ToArray(),
+            relic_items = run.relics.Select(relic => new
+            {
+                i = relic.index,
+                relic_id = relic.relic_id,
+                name = relic.name,
+                description = relic.description,
+                stack = relic.stack,
+                melted = relic.is_melted
+            }).ToArray(),
             potions = run.potions.Select(potion => new
             {
                 i = potion.index,
+                potion_id = potion.potion_id,
+                name = potion.name,
+                rarity = potion.rarity,
+                occupied = potion.occupied,
                 line = FormatPotionLine(potion),
                 usable = potion.can_use,
                 discard = potion.can_discard,
+                requires_target = potion.requires_target,
                 target = NormalizeTargetHint(potion.target_type),
                 targets = potion.valid_target_indices
             }).ToArray(),
@@ -2033,7 +2102,7 @@ internal static class GameStateService
             max = selection.max_select,
             selected = selection.selected_count,
             confirm = selection.can_confirm,
-            cards = selection.cards.Select(card => BuildAgentChoiceCardPayload(card.index, card.name, card.upgraded, card.energy_cost, card.star_cost, card.costs_x, card.star_costs_x, card.rules_text, glossaryTerms)).ToArray()
+            cards = selection.cards.Select(card => BuildAgentChoiceCardPayload(card.index, card.card_id, card.name, card.upgraded, card.energy_cost, card.star_cost, card.costs_x, card.star_costs_x, card.rules_text, glossaryTerms)).ToArray()
         };
     }
 
@@ -2056,10 +2125,12 @@ internal static class GameStateService
             rewards = reward.rewards.Select(option => new
             {
                 i = option.index,
+                reward_type = option.reward_type,
+                description = option.description,
                 line = $"{option.reward_type}: {option.description}",
                 claimable = option.claimable
             }).ToArray(),
-            cards = reward.card_options.Select(card => BuildAgentChoiceCardPayload(card.index, card.name, card.upgraded, null, null, false, false, card.rules_text, glossaryTerms)).ToArray(),
+            cards = reward.card_options.Select(card => BuildAgentChoiceCardPayload(card.index, card.card_id, card.name, card.upgraded, null, null, false, false, card.rules_text, glossaryTerms)).ToArray(),
             alternatives = reward.alternatives.Select(option => new
             {
                 i = option.index,
@@ -2079,13 +2150,17 @@ internal static class GameStateService
         {
             id = eventPayload.event_id,
             title = eventPayload.title,
+            description = eventPayload.description,
             finished = eventPayload.is_finished,
             options = eventPayload.options.Select(option => new
             {
                 i = option.index,
+                text_key = option.text_key,
                 line = FormatEventOptionLine(option),
                 locked = option.is_locked,
-                proceed = option.is_proceed
+                proceed = option.is_proceed,
+                lethal = option.will_kill_player,
+                relic_preview = option.has_relic_preview
             }).ToArray()
         };
     }
@@ -2105,8 +2180,11 @@ internal static class GameStateService
             cards = shop.cards.Select(card =>
                 BuildAgentPricedCardPayload(
                     card.index,
+                    card.card_id,
                     card.name,
                     card.upgraded,
+                    card.card_type,
+                    card.rarity,
                     card.energy_cost,
                     card.star_cost,
                     card.costs_x,
@@ -2118,14 +2196,23 @@ internal static class GameStateService
             relics = shop.relics.Select(relic => new
             {
                 i = relic.index,
+                relic_id = relic.relic_id,
+                name = relic.name,
+                rarity = relic.rarity,
                 line = $"{relic.name} [{relic.rarity}] | {relic.price}g",
+                price = relic.price,
                 affordable = relic.enough_gold,
                 stocked = relic.is_stocked
             }).ToArray(),
             potions = shop.potions.Select(potion => new
             {
                 i = potion.index,
+                potion_id = potion.potion_id,
+                name = potion.name,
+                rarity = potion.rarity,
+                usage = potion.usage,
                 line = $"{potion.name ?? "空"}{(string.IsNullOrWhiteSpace(potion.usage) ? string.Empty : $"：{potion.usage}")} | {potion.price}g",
+                price = potion.price,
                 affordable = potion.enough_gold,
                 stocked = potion.is_stocked
             }).ToArray(),
@@ -2153,6 +2240,7 @@ internal static class GameStateService
             options = rest.options.Select(option => new
             {
                 i = option.index,
+                option_id = option.option_id,
                 line = string.IsNullOrWhiteSpace(option.description)
                     ? option.title
                     : $"{option.title}: {option.description}",
@@ -2171,10 +2259,33 @@ internal static class GameStateService
         return new
         {
             current = map.current_node == null ? null : $"{map.current_node.row},{map.current_node.col}",
+            rows = map.rows,
+            cols = map.cols,
+            boss = map.boss_node == null ? null : $"{map.boss_node.row},{map.boss_node.col}",
+            second_boss = map.second_boss_node == null ? null : $"{map.second_boss_node.row},{map.second_boss_node.col}",
             options = map.available_nodes.Select(node => new
             {
                 i = node.index,
+                row = node.row,
+                col = node.col,
+                type = node.node_type,
+                state = node.state,
                 line = $"{node.node_type} ({node.row},{node.col})"
+            }).ToArray(),
+            nodes = map.nodes.Select(node => new
+            {
+                row = node.row,
+                col = node.col,
+                type = node.node_type,
+                state = node.state,
+                visited = node.visited,
+                current = node.is_current,
+                available = node.is_available,
+                start = node.is_start,
+                boss = node.is_boss,
+                second_boss = node.is_second_boss,
+                parents = node.parents.Select(parent => $"{parent.row},{parent.col}").ToArray(),
+                children = node.children.Select(child => $"{child.row},{child.col}").ToArray()
             }).ToArray()
         };
     }
@@ -2286,11 +2397,21 @@ internal static class GameStateService
         return new
         {
             i = card.index,
+            card_id = card.card_id,
+            name = card.name,
+            upgraded = card.upgraded,
+            energy_cost = card.energy_cost,
+            star_cost = card.star_cost,
+            costs_x = card.costs_x,
+            star_costs_x = card.star_costs_x,
             line = FormatCardLine(card.name, card.upgraded, 1, card.energy_cost, card.star_cost, card.costs_x, card.star_costs_x, card.rules_text),
             playable = card.playable,
+            requires_target = card.requires_target,
+            target_type = card.target_type,
             target = card.requires_target ? NormalizeTargetHint(card.target_index_space ?? card.target_type) : null,
             targets = card.requires_target ? card.valid_target_indices : Array.Empty<int>(),
             why = card.playable ? null : card.unplayable_reason,
+            rules_text = card.rules_text,
             keywords,
             mods
         };
@@ -2298,6 +2419,7 @@ internal static class GameStateService
 
     private static object BuildAgentChoiceCardPayload(
         int index,
+        string cardId,
         string name,
         bool upgraded,
         int? energyCost,
@@ -2313,7 +2435,15 @@ internal static class GameStateService
         return new
         {
             i = index,
+            card_id = cardId,
+            name,
+            upgraded,
+            energy_cost = energyCost,
+            star_cost = starCost,
+            costs_x = costsX,
+            star_costs_x = starCostsX,
             line = FormatCardLine(name, upgraded, 1, energyCost, starCost, costsX, starCostsX, rulesText),
+            rules_text = rulesText,
             keywords,
             mods = Array.Empty<string>()
         };
@@ -2321,8 +2451,11 @@ internal static class GameStateService
 
     private static object BuildAgentPricedCardPayload(
         int index,
+        string cardId,
         string name,
         bool upgraded,
+        string cardType,
+        string rarity,
         int energyCost,
         int starCost,
         bool costsX,
@@ -2338,7 +2471,18 @@ internal static class GameStateService
         return new
         {
             i = index,
+            card_id = cardId,
+            name,
+            upgraded,
+            card_type = cardType,
+            rarity,
+            energy_cost = energyCost,
+            star_cost = starCost,
+            costs_x = costsX,
+            star_costs_x = starCostsX,
             line = $"{FormatCardLine(name, upgraded, 1, energyCost, starCost, costsX, starCostsX, rulesText)} | {price}g",
+            rules_text = rulesText,
+            price,
             affordable = enoughGold,
             keywords,
             mods = Array.Empty<string>()
@@ -2374,7 +2518,16 @@ internal static class GameStateService
 
                 return new
                 {
+                    card_id = first.card_id,
+                    name = first.name,
+                    upgraded = first.upgraded,
+                    count = group.Count(),
+                    energy_cost = first.energy_cost,
+                    star_cost = first.star_cost,
+                    costs_x = first.costs_x,
+                    star_costs_x = first.star_costs_x,
                     line,
+                    rules_text = first.rules_text,
                     keywords = first.keywords,
                     mods = first.mods
                 };
@@ -2392,6 +2545,7 @@ internal static class GameStateService
         CollectGlossaryTerms(glossaryTerms, rulesText, mods);
 
         return new AgentCardDescriptor(
+            card.Id.Entry,
             card.Title,
             card.IsUpgraded,
             card.EnergyCost.GetWithModifiers(CostModifiers.All),
@@ -2409,6 +2563,7 @@ internal static class GameStateService
         CollectGlossaryTerms(glossaryTerms, card.rules_text);
 
         return new AgentCardDescriptor(
+            card.card_id,
             card.name,
             card.upgraded,
             card.energy_cost,
@@ -5476,6 +5631,7 @@ internal sealed class RunPotionPayload
 }
 
 internal readonly record struct AgentCardDescriptor(
+    string card_id,
     string name,
     bool upgraded,
     int energy_cost,
@@ -5489,6 +5645,7 @@ internal readonly record struct AgentCardDescriptor(
     public string GroupKey =>
         string.Join(
             "\u001f",
+            card_id,
             name,
             upgraded ? "1" : "0",
             energy_cost.ToString(),

--- a/docs/agent-combat-intelligence-tracker.md
+++ b/docs/agent-combat-intelligence-tracker.md
@@ -30,7 +30,7 @@
 |---|------|---------|--------|-------|
 | 3.1 | Run-level strategy context persistence | `server.py`, `handoff.py` | TODO | Track build direction |
 | 3.2 | Card pick recommendation tool | `server.py` | ✅ DONE | `evaluate_card_rewards` tool |
-| 3.3 | Boss preparation check tool | `server.py` | TODO | Deck capability analysis |
+| 3.3 | Boss preparation check tool | `server.py` | ✅ DONE | `check_boss_readiness` tool |
 | 3.4 | Economy management rules | `SKILL.md` | ✅ DONE | Gold priority, saving rules, skip rules |
 
 ## Phase 4: Polish (Priority: Low)
@@ -38,7 +38,7 @@
 | # | Task | File(s) | Status | Notes |
 |---|------|---------|--------|-------|
 | 4.1 | Cross-run knowledge learning | `knowledge.py` | TODO | What works vs what Boss |
-| 4.2 | Elite fight risk assessment | `server.py` | TODO | HP threshold heuristics |
+| 4.2 | Elite fight risk assessment | `server.py` | ✅ DONE | `assess_elite_risk` tool |
 | 4.3 | Potion timing optimization | `SKILL.md` | ✅ DONE | Boss/elite/lethal timing rules |
 | 4.4 | Full character coverage | `SKILL.md`, `docs/` | TODO | Silent, Regent, etc. |
 
@@ -67,3 +67,8 @@
   - Scores cards by deck composition balance, efficiency, draw, AoE gap-filling
 - **Phase 3.4 DONE**: Economy management rules added to SKILL.md
   - Gold spending priority, saving rules, skip reward heuristics
+- **Phase 3.3 DONE**: Added `check_boss_readiness` MCP tool + `_check_boss_readiness` function
+  - Checks: HP, deck size, damage output, block coverage, vulnerable sources, draw, potions
+  - Returns pass/fail per check + overall readiness score
+- **Phase 4.2 DONE**: Added `assess_elite_risk` MCP tool + `_assess_elite_risk` function
+  - TAKE/AVOID recommendation based on HP ratio, deck size, potion count

--- a/docs/agent-combat-intelligence-tracker.md
+++ b/docs/agent-combat-intelligence-tracker.md
@@ -10,16 +10,16 @@
 
 | # | Task | File(s) | Status | Notes |
 |---|------|---------|--------|-------|
-| 1.1 | Expose computed damage/block on hand cards | `GameStateService.cs` | TODO | Most impactful single change |
+| 1.1 | Expose computed damage/block on hand cards | `GameStateService.cs` | ✅ DONE | Via TryExtractCardValues reflection |
 | 1.2 | Ensure draw/discard/exhaust piles always exposed | `GameStateService.cs` | ✅ DONE | Already in BuildAgentCombatPayload |
 | 1.3 | Add combat_analysis pre-computation in MCP | `server.py` | ✅ DONE | Lethal calc, max damage/block |
-| 1.4 | Replace template strings with actual values in agent_view | `GameStateService.cs` | TODO | `{Damage:diff()}` → `9` |
+| 1.4 | Replace template strings with actual values in agent_view | `GameStateService.cs` | ✅ DONE | GetCardFormattedDescription + resolved_text |
 
 ## Phase 2: Let the Agent "Plan Ahead" (Priority: High)
 
 | # | Task | File(s) | Status | Notes |
 |---|------|---------|--------|-------|
-| 2.1 | Expose enemy move rotation + current index | `GameStateService.cs` | TODO | Deterministic enemy patterns |
+| 2.1 | Expose enemy move rotation + current index | `GameStateService.cs` | ✅ DONE | move_history + turn_count via reflection |
 | 2.2 | Add deck-building strategy to SKILL.md | `SKILL.md` | ✅ DONE | Ironclad archetypes + combat heuristics |
 | 2.3 | Add route planning heuristics | `SKILL.md`, `server.py` | ✅ DONE | HP thresholds, elite/shop/rest rules |
 | 2.4 | Add Boss-specific strategy guide | `docs/game-knowledge/` | ✅ DONE | Queen, Lagavulin, MechaKnight, OwlMagistrate |
@@ -72,3 +72,13 @@
   - Returns pass/fail per check + overall readiness score
 - **Phase 4.2 DONE**: Added `assess_elite_risk` MCP tool + `_assess_elite_risk` function
   - TAKE/AVOID recommendation based on HP ratio, deck size, potion count
+- **Phase 1.1 DONE**: C# mod — `TryExtractCardValues` reflection extracts Damage/Block/HitCount from CardModel
+  - Added `computed_damage`, `computed_block`, `hit_count`, `card_type` to CombatHandCardPayload
+  - Agent view now includes `dmg`, `blk`, `hits`, `type` fields per hand card
+- **Phase 1.4 DONE**: C# mod — `GetCardFormattedDescription` resolves template strings via GetFormattedText()
+  - `resolved_text` field added to CombatHandCardPayload (actual numbers instead of `{Damage:diff()}`)
+  - Agent view `line` now uses resolved text when available
+- **Phase 2.1 DONE**: C# mod — `TryExtractMoveHistory` reflection extracts move history from Monster
+  - Added `move_history` (string[]) and `turn_count` to CombatEnemyPayload
+  - Python combat analysis updated to prefer C#-computed values over static data fallback
+- **All C# changes need game testing** — reflection-based extraction depends on actual game class structure

--- a/docs/agent-combat-intelligence-tracker.md
+++ b/docs/agent-combat-intelligence-tracker.md
@@ -1,0 +1,69 @@
+# Agent Combat Intelligence - Improvement Tracker
+
+**Branch:** `feature/agent-combat-intelligence`
+**Goal:** Enable the AI agent to beat the Act 1 Boss
+**Created:** 2026-03-20
+
+---
+
+## Phase 1: Let the Agent "See" (Priority: Critical)
+
+| # | Task | File(s) | Status | Notes |
+|---|------|---------|--------|-------|
+| 1.1 | Expose computed damage/block on hand cards | `GameStateService.cs` | TODO | Most impactful single change |
+| 1.2 | Ensure draw/discard/exhaust piles always exposed | `GameStateService.cs` | ✅ DONE | Already in BuildAgentCombatPayload |
+| 1.3 | Add combat_analysis pre-computation in MCP | `server.py` | ✅ DONE | Lethal calc, max damage/block |
+| 1.4 | Replace template strings with actual values in agent_view | `GameStateService.cs` | TODO | `{Damage:diff()}` → `9` |
+
+## Phase 2: Let the Agent "Plan Ahead" (Priority: High)
+
+| # | Task | File(s) | Status | Notes |
+|---|------|---------|--------|-------|
+| 2.1 | Expose enemy move rotation + current index | `GameStateService.cs` | TODO | Deterministic enemy patterns |
+| 2.2 | Add deck-building strategy to SKILL.md | `SKILL.md` | ✅ DONE | Ironclad archetypes + combat heuristics |
+| 2.3 | Add route planning heuristics | `SKILL.md`, `server.py` | ✅ DONE | HP thresholds, elite/shop/rest rules |
+| 2.4 | Add Boss-specific strategy guide | `docs/game-knowledge/` | ✅ DONE | Queen, Lagavulin, MechaKnight, OwlMagistrate |
+
+## Phase 3: Let the Agent "Strategize" (Priority: Medium)
+
+| # | Task | File(s) | Status | Notes |
+|---|------|---------|--------|-------|
+| 3.1 | Run-level strategy context persistence | `server.py`, `handoff.py` | TODO | Track build direction |
+| 3.2 | Card pick recommendation tool | `server.py` | ✅ DONE | `evaluate_card_rewards` tool |
+| 3.3 | Boss preparation check tool | `server.py` | TODO | Deck capability analysis |
+| 3.4 | Economy management rules | `SKILL.md` | ✅ DONE | Gold priority, saving rules, skip rules |
+
+## Phase 4: Polish (Priority: Low)
+
+| # | Task | File(s) | Status | Notes |
+|---|------|---------|--------|-------|
+| 4.1 | Cross-run knowledge learning | `knowledge.py` | TODO | What works vs what Boss |
+| 4.2 | Elite fight risk assessment | `server.py` | TODO | HP threshold heuristics |
+| 4.3 | Potion timing optimization | `SKILL.md` | ✅ DONE | Boss/elite/lethal timing rules |
+| 4.4 | Full character coverage | `SKILL.md`, `docs/` | TODO | Silent, Regent, etc. |
+
+---
+
+## Progress Log
+
+### 2026-03-20
+- Created feature branch `feature/agent-combat-intelligence`
+- Completed analysis: identified 5-layer bottleneck model
+- Critical finding: agent cannot see computed damage/block values (template strings only)
+- Starting Phase 1.1: expose computed card values in C# mod
+- **Phase 1.3 DONE**: Added `get_combat_analysis` MCP tool in `server.py`
+  - Helper functions: `_get_power_amount`, `_compute_card_damage`, `_compute_card_block`
+  - Main function: `_compute_combat_analysis` — cross-references live state with static card data
+  - Computes per-card `computed_damage`, `computed_block`, `damage_per_energy`
+  - Tactical summary: max damage/block, per-enemy lethal check, incoming damage analysis
+  - Accounts for Strength, Dexterity, Weak, Frail, Vulnerable modifiers
+  - Note: needs live testing when game is available
+- **Phase 1.2 DONE**: Draw/discard/exhaust piles already exposed via `BuildAgentCombatPayload` in C#
+- **Phase 2.2 DONE**: Added `ironclad-strategy.md` — deck archetypes, card tiers, Act 1 priorities
+- **Phase 2.3 DONE**: Route planning heuristics added to SKILL.md — HP thresholds, elite/shop/rest rules
+- **Phase 2.4 DONE**: Added `act1-boss-guide.md` — Queen, Lagavulin Matriarch, MechaKnight, OwlMagistrate strategies
+- Updated SKILL.md combat heuristics — integrated `get_combat_analysis` tool into turn workflow
+- **Phase 3.2 DONE**: Added `evaluate_card_rewards` MCP tool + `_score_card_for_deck` scoring function
+  - Scores cards by deck composition balance, efficiency, draw, AoE gap-filling
+- **Phase 3.4 DONE**: Economy management rules added to SKILL.md
+  - Gold spending priority, saving rules, skip reward heuristics

--- a/docs/api.md
+++ b/docs/api.md
@@ -988,7 +988,7 @@
 - **参数**：无
 - **行为**：
   1. 逐个领取可领取的奖励（跳过无空位的药水）
-  2. 遇到卡牌选择时**自动选择第一张**
+  2. 遇到卡牌选择时优先关闭当前卡牌奖励覆盖层，不再默认选择第一张
   3. 点击继续按钮
 - **超时**：20 秒
 - **注意**：适合无人值守推进。如需精确控制构筑决策，请用 `claim_reward` + `choose_reward_card` / `skip_reward_cards` 组合
@@ -1301,6 +1301,17 @@
 | 游戏结束 | `game_over` / `return_to_main_menu` | 已实现，待实机验证 |
 
 新增字段与动作的详细说明见 [phase-5-full-chain.md](../docs/phase-5-full-chain.md)。
+
+### 只读启发式工具
+
+以下 MCP 工具不执行动作，只返回结构化评估结果，适合给 planner / guided agent 在 Act 2 及以后阶段直接调用：
+
+- `evaluate_card_rewards`：结合当前 deck、血量、能量曲线与 reward 卡，给每张卡打分并返回推荐顺位。
+- `assess_elite_risk`：结合当前血线、药水、deck 缺口与地图路线，评估当前是否适合走精英。
+- `check_boss_readiness`：按血量、deck size、输出、防御、成长、过牌、易伤与药水做 Boss 战 readiness 检查。
+- `evaluate_shop_options`：统一评估商店里的删牌、卡、relic、potion，并返回当前最值得花钱的动作。
+- `assess_rest_site`：结合血量、升级目标、精英风险与 Boss readiness，对营火选项做优先级排序。
+- `evaluate_potions`：评估当前药水腰带和商店药水，支持给出购买 / 替换建议。
 
 ### Debug 动作
 

--- a/docs/game-knowledge/act1-boss-guide.md
+++ b/docs/game-knowledge/act1-boss-guide.md
@@ -1,0 +1,63 @@
+# Act 1 Boss Guide (Agent Reference)
+
+## Preparing for the Boss
+
+Before the boss fight, your deck should have:
+- **15-18 cards** (too few = inconsistent, too many = diluted)
+- **At least one source of Vulnerable** (Bash counts)
+- **At least 2 block cards beyond starting Defends**
+- **Total damage output of 40+ per turn** (with Vulnerable active)
+
+If missing these, prioritize rest sites for upgrades (upgrade Bash first) and take strong card rewards.
+
+## Known Act 1 Bosses
+
+### Queen
+- **Moves:** `PUPPET_STRINGS` (adds curse cards), `YOUR_MINE` (debuff), `OFF_WITH_YOUR_HEAD` (multi-attack ×5), `EXECUTION` (single heavy attack)
+- **Strategy:**
+  - Kill quickly — Puppet Strings adds junk to your deck each turn
+  - Block heavily on `OFF_WITH_YOUR_HEAD` turns (5-hit multi-attack)
+  - Prioritize damage over block on debuff turns
+  - Use potions early — long fights favor the Queen
+
+### Lagavulin Matriarch
+- **Moves:** `SLEEP` → `SLASH` (single attack), `DISEMBOWEL` (multi-attack)
+- **Passive:** Starts with Plating (block) and Asleep power
+- **Strategy:**
+  - She starts asleep with block — you get free setup turns
+  - Stack Strength/buffs while she sleeps
+  - Once awake, she hits HARD — need strong block
+  - Burst damage is key: deal as much as possible before she debuffs you
+  - She may apply Strength reduction — end the fight fast
+
+### MechaKnight
+- **Moves:** `CHARGE` (single heavy attack), `FLAMETHROWER` (adds 4 status cards), `HEAVY_CLEAVE` (single heavy attack)
+- **Passive:** Starts with Artifact (blocks first debuff)
+- **Strategy:**
+  - Artifact blocks your first Vulnerable — either burn it with a weak debuff or accept one Bash is wasted
+  - Block heavily on CHARGE and HEAVY_CLEAVE turns
+  - FLAMETHROWER adds Burns — play/exhaust them quickly
+  - Consistent damage wins; don't over-invest in one big turn
+
+### OwlMagistrate
+- **Moves:** `SCRUTINY` (single attack), `PECK_ASSAULT` (multi-attack ×6!), `JUDICIAL_FLIGHT` (buff)
+- **Strategy:**
+  - PECK_ASSAULT is 6 hits — extremely dangerous, block as much as possible
+  - On JUDICIAL_FLIGHT turns, go all-out offense
+  - Strength scaling is very effective here (each hit from you matters)
+  - Bring a potion for the first PECK_ASSAULT if your block is weak
+
+## General Boss Combat Rules
+
+1. **Use potions** — don't save them for later, the boss IS the later.
+2. **Bash on turn 1** if boss HP is high and no Artifact — 50% more damage for 3 turns pays off.
+3. **Track Vulnerable duration** — reapply when it expires.
+4. **Block on multi-attack turns** — multi-attacks deal way more than single attacks.
+5. **If boss is buffing** — that's your free damage turn, don't waste it on block.
+6. **Lethal check every turn** — if you can kill the boss, DO IT. Don't play it safe.
+
+## HP Thresholds
+
+- **Enter boss with 60+ HP** (Ironclad) — allows taking a few hits while setting up.
+- **If below 40 HP** — rest at the last rest site before boss, even if upgrade would help.
+- **Burning Blood heals 6** after the fight — factor this into route planning.

--- a/docs/game-knowledge/ironclad-strategy.md
+++ b/docs/game-knowledge/ironclad-strategy.md
@@ -1,0 +1,77 @@
+# Ironclad Strategy Guide (Agent Reference)
+
+## Starting Deck
+
+5× Strike (6 damage), 4× Defend (5 block), 1× Bash (8 damage + 2 Vulnerable)
+
+**Starting Relic:** Burning Blood — heal 6 HP at end of each combat.
+
+## Energy Economy
+
+- Base: 3 energy/turn
+- Most cards cost 1 energy. Bash costs 2.
+- Goal: spend all energy every turn. Leftover energy = wasted value.
+
+## Core Deck-Building Archetypes
+
+### 1. Strength Build (Recommended for beginners)
+- **Key cards:** Inflame (+2 Strength), Spot Weakness (+3 Strength if enemy attacking), Heavy Blade (scales with Strength ×3), Limit Break (double Strength)
+- **Strategy:** Stack Strength, then every attack card hits harder. Heavy Blade becomes a finisher.
+- **Card priority:** Inflame > Spot Weakness > Heavy Blade > Sword Boomerang
+
+### 2. Block/Exhaust Build
+- **Key cards:** Shrug It Off (8 block + draw), Impervious (30 block), Sentinel (5 block, exhaust for energy), Feel No Pain (block on exhaust)
+- **Strategy:** Outlast enemies with high block, thin deck via exhaust.
+- **Card priority:** Shrug It Off > Feel No Pain > Impervious > Sentinel
+
+### 3. Aggressive/Thin Deck
+- **Key cards:** Pommel Strike (9 damage + draw), Anger (6 damage, adds copy to discard), Rampage (grows each play)
+- **Strategy:** Remove Strikes/Defends, keep deck small for consistent draws.
+
+## Act 1 Priorities
+
+1. **Remove a Strike** at first shop/rest opportunity — thins deck.
+2. **Add AoE** if offered — Cleave, Whirlwind, or Immolate handle multi-enemy fights.
+3. **Add draw** — Shrug It Off, Pommel Strike, Battle Trance keep your hand full.
+4. **Bash is your best card early** — Vulnerable means 50% more damage for 3 turns. Always Bash first when possible.
+
+## Combat Decision Framework
+
+### Turn Priority (in order)
+1. **Can I kill an enemy this turn?** → Focus damage to remove a threat.
+2. **Is the enemy attacking for high damage?** → Block enough to survive.
+3. **Can I apply Vulnerable?** → Bash a high-HP target for future damage bonus.
+4. **Spend remaining energy** → Prefer damage over block when safe; prefer draw/setup if available.
+
+### Bash Timing
+- Bash costs 2 energy — use it when:
+  - Enemy has 3+ turns to live (full Vulnerable value)
+  - You have at least 1 energy left for a Strike after
+  - Enemy is NOT about to die (don't waste 2 energy on a nearly dead enemy)
+
+### Block Threshold
+- If enemy intent damage > 0: block at least enough to prevent lethal.
+- If enemy intent damage > player HP × 0.3: prioritize blocking.
+- If enemy is debuffing/buffing: ignore block, deal damage.
+
+## Card Evaluation (Reward Picks)
+
+### Always Take (Act 1)
+- Shrug It Off, Inflame, Pommel Strike, Carnage, Clothesline
+
+### Usually Take
+- Cleave (if seeing multi-enemy fights), Spot Weakness, Anger, Headbutt
+
+### Usually Skip
+- Flex (temporary Strength), True Grit (unless exhaust build), Warcry (weak draw)
+
+### Always Skip (Act 1)
+- Searing Blow (too slow), Bludgeon (3 energy too expensive early), Heavy Blade (no Strength yet)
+
+## Route Planning (Act 1)
+
+- **Prefer fights early** — card rewards improve deck faster than resting.
+- **Rest if HP < 40%** — dying loses the run.
+- **Visit shop with 75+ gold** — card removal (75g) or strong relic purchase.
+- **Avoid elites if HP < 50%** or deck has < 12 cards — too risky.
+- **Take elites if HP > 70%** and deck has AoE + good damage — relic rewards are powerful.

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -152,6 +152,12 @@ Modal：
 - `STS2_AGENT_KNOWLEDGE_DIR`
   - 默认：仓库根目录下的 `agent_knowledge/`
   - 作用：保存 combat / event 的运行时知识文件
+- `STS2_ENABLE_RUN_LOGS`
+  - 默认：`1`
+  - 作用：自动记录每回合状态、动作和奖励变更到 JSONL 对局日志
+- `STS2_AGENT_RUN_LOG_DIR`
+  - 默认：`<STS2_AGENT_KNOWLEDGE_DIR>/logs/runs/`
+  - 作用：覆盖自动对局日志的输出目录
 - `STS2_API_TIMEOUT_SECONDS`
   - 默认：`10`
 - `STS2_ENABLE_DEBUG_ACTIONS`
@@ -174,6 +180,9 @@ agent_knowledge/
   events/
     global/
       cleric.md
+  logs/
+    runs/
+      JHH9GQ9FR0.jsonl
 ```
 
 约束：
@@ -182,6 +191,21 @@ agent_knowledge/
 - 事件文件按 `event_id` 命名
 - 当前还没有 chapter 字段时，目录先落在 `global/`
 - 追加内容时会自动带上 `run_id`、`floor`、`screen`、UTC 时间戳
+
+## 自动对局日志
+
+默认会自动把 run 过程写到：
+
+```text
+agent_knowledge/logs/runs/<run_id>.jsonl
+```
+
+日志特点：
+
+- 按 `run_id` 一局一个文件
+- 自动记录 `run_started`、`state`、`action`
+- `state` 会做去重，只在回合变化、屏幕变化、奖励变化、地图选项变化等情况下新增
+- `action` 会记录参数、动作结果，以及动作前后的状态摘要
 
 ## 主 / 副 Agent 交接
 

--- a/mcp_server/src/sts2_mcp/knowledge.py
+++ b/mcp_server/src/sts2_mcp/knowledge.py
@@ -339,6 +339,9 @@ class Sts2KnowledgeBase:
             },
         }
 
+    def build_route_options(self, state: dict[str, Any]) -> list[dict[str, Any]]:
+        return self._build_route_options(state)
+
     def build_combat_context(
         self,
         state: dict[str, Any],

--- a/mcp_server/src/sts2_mcp/run_logger.py
+++ b/mcp_server/src/sts2_mcp/run_logger.py
@@ -1,0 +1,475 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    value = os.getenv(name, "")
+    if not value:
+        return default
+
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _normalize_run_id(value: str | None) -> str | None:
+    if not value:
+        return None
+
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "_", value).strip("._-")
+    return cleaned or None
+
+
+def _safe_int(value: Any) -> int | None:
+    return value if isinstance(value, int) else None
+
+
+def _string_list(values: Any) -> list[str]:
+    if not isinstance(values, list):
+        return []
+    return [str(value) for value in values if isinstance(value, (str, int, float))]
+
+
+def _compact_power(power: Any) -> dict[str, Any] | None:
+    if not isinstance(power, dict):
+        return None
+
+    return {
+        "power_id": power.get("power_id"),
+        "name": power.get("name"),
+        "amount": power.get("amount"),
+        "is_debuff": bool(power.get("is_debuff", False)),
+    }
+
+
+def _compact_card(card: Any) -> dict[str, Any] | None:
+    if not isinstance(card, dict):
+        return None
+
+    compact = {
+        "index": _safe_int(card.get("index")),
+        "card_id": card.get("card_id"),
+        "name": card.get("name"),
+        "energy_cost": card.get("energy_cost"),
+        "star_cost": card.get("star_cost"),
+        "playable": card.get("playable"),
+        "requires_target": bool(card.get("requires_target", False)),
+        "target_index_space": card.get("target_index_space"),
+        "valid_target_indices": card.get("valid_target_indices"),
+        "unplayable_reason": card.get("unplayable_reason"),
+    }
+    return {key: value for key, value in compact.items() if value is not None}
+
+
+def _compact_enemy(enemy: Any) -> dict[str, Any] | None:
+    if not isinstance(enemy, dict):
+        return None
+
+    intents = enemy.get("intents") if isinstance(enemy.get("intents"), list) else []
+    compact_intents: list[dict[str, Any]] = []
+    for intent in intents:
+        if not isinstance(intent, dict):
+            continue
+        compact_intent = {
+            "intent_type": intent.get("intent_type"),
+            "label": intent.get("label"),
+            "damage": intent.get("damage"),
+            "hits": intent.get("hits"),
+            "total_damage": intent.get("total_damage"),
+        }
+        compact_intents.append({key: value for key, value in compact_intent.items() if value is not None})
+
+    powers = enemy.get("powers") if isinstance(enemy.get("powers"), list) else []
+    return {
+        "index": _safe_int(enemy.get("index")),
+        "enemy_id": enemy.get("enemy_id"),
+        "name": enemy.get("name"),
+        "current_hp": enemy.get("current_hp"),
+        "max_hp": enemy.get("max_hp"),
+        "block": enemy.get("block"),
+        "intent": enemy.get("intent"),
+        "move_id": enemy.get("move_id"),
+        "powers": [power for power in (_compact_power(power) for power in powers) if power is not None],
+        "intents": compact_intents,
+    }
+
+
+def _compact_reward_item(item: Any) -> dict[str, Any] | None:
+    if not isinstance(item, dict):
+        return None
+
+    compact = {
+        "index": _safe_int(item.get("index")) or _safe_int(item.get("i")),
+        "reward_type": item.get("reward_type"),
+        "card_id": item.get("card_id"),
+        "relic_id": item.get("relic_id"),
+        "potion_id": item.get("potion_id"),
+        "name": item.get("name"),
+        "label": item.get("label"),
+        "description": item.get("description"),
+        "rules_text": item.get("rules_text"),
+        "claimable": item.get("claimable"),
+        "upgraded": item.get("upgraded"),
+    }
+    return {key: value for key, value in compact.items() if value is not None}
+
+
+def _compact_map_node(node: Any) -> dict[str, Any] | None:
+    if not isinstance(node, dict):
+        return None
+
+    compact = {
+        "index": _safe_int(node.get("index")),
+        "row": _safe_int(node.get("row")),
+        "col": _safe_int(node.get("col")),
+        "node_type": node.get("node_type"),
+        "state": node.get("state"),
+    }
+    return {key: value for key, value in compact.items() if value is not None}
+
+
+def _compact_event_option(option: Any) -> dict[str, Any] | None:
+    if not isinstance(option, dict):
+        return None
+
+    compact = {
+        "index": _safe_int(option.get("index")) or _safe_int(option.get("i")),
+        "option_id": option.get("option_id"),
+        "label": option.get("label"),
+        "description": option.get("description"),
+        "line": option.get("line"),
+        "disabled": option.get("disabled"),
+    }
+    return {key: value for key, value in compact.items() if value is not None}
+
+
+class Sts2RunLogger:
+    def __init__(
+        self,
+        knowledge_root: str | Path | None = None,
+        *,
+        log_root: str | Path | None = None,
+        enabled: bool | None = None,
+    ) -> None:
+        if log_root is None:
+            configured = os.getenv("STS2_AGENT_RUN_LOG_DIR", "").strip()
+            if configured:
+                log_root = Path(configured).expanduser().resolve()
+            else:
+                base_root = Path(knowledge_root).expanduser().resolve() if knowledge_root is not None else Path.cwd()
+                log_root = base_root / "logs" / "runs"
+
+        self._root_dir = Path(log_root).expanduser().resolve()
+        self._enabled = _env_flag("STS2_ENABLE_RUN_LOGS", default=True) if enabled is None else enabled
+        self._lock = threading.RLock()
+        self._last_signatures: dict[str, str] = {}
+        self._last_summaries: dict[str, dict[str, Any]] = {}
+        self._started_runs: set[str] = set()
+        self._current_run_id: str | None = None
+
+    @property
+    def root_dir(self) -> Path:
+        return self._root_dir
+
+    def record_state(
+        self,
+        state: dict[str, Any],
+        *,
+        reason: str,
+        event: dict[str, Any] | None = None,
+    ) -> bool:
+        if not self._enabled or not isinstance(state, dict):
+            return False
+
+        run_id = self._resolve_run_id(state)
+        if run_id is None:
+            return False
+
+        summary = self._summarize_state(state)
+        signature = json.dumps(summary, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+        with self._lock:
+            self._current_run_id = run_id
+            self._ensure_run_started_locked(run_id, summary)
+            if self._last_signatures.get(run_id) == signature:
+                return False
+
+            entry = {
+                "timestamp_utc": _utc_timestamp(),
+                "type": "state",
+                "category": self._state_category(summary),
+                "reason": reason,
+                "summary": summary,
+            }
+            compact_event = self._compact_event(event)
+            if compact_event is not None:
+                entry["trigger_event"] = compact_event
+
+            self._append_locked(run_id, entry)
+            self._last_signatures[run_id] = signature
+            self._last_summaries[run_id] = summary
+            return True
+
+    def record_action(
+        self,
+        *,
+        action: str,
+        params: dict[str, Any] | None = None,
+        response: dict[str, Any] | None = None,
+        client_context: dict[str, Any] | None = None,
+        error: Exception | None = None,
+    ) -> bool:
+        if not self._enabled:
+            return False
+
+        post_state = response.get("state") if isinstance(response, dict) and isinstance(response.get("state"), dict) else None
+        run_id = self._resolve_run_id(post_state or {})
+        if run_id is None:
+            return False
+
+        after_summary = self._summarize_state(post_state) if post_state is not None else None
+
+        with self._lock:
+            self._current_run_id = run_id
+            if after_summary is not None:
+                self._ensure_run_started_locked(run_id, after_summary)
+
+            entry = {
+                "timestamp_utc": _utc_timestamp(),
+                "type": "action",
+                "action": action,
+                "params": {key: value for key, value in (params or {}).items() if value is not None},
+            }
+            if client_context:
+                entry["client_context"] = client_context
+
+            before_summary = self._last_summaries.get(run_id)
+            if before_summary is not None:
+                entry["before_state"] = before_summary
+            if after_summary is not None:
+                entry["after_state"] = after_summary
+
+            if error is not None:
+                entry["status"] = "error"
+                entry["error"] = {
+                    "type": type(error).__name__,
+                    "message": str(error),
+                }
+            elif isinstance(response, dict):
+                entry["status"] = response.get("status") or "completed"
+                if "stable" in response:
+                    entry["stable"] = bool(response.get("stable"))
+                if response.get("message"):
+                    entry["message"] = response.get("message")
+            else:
+                entry["status"] = "completed"
+
+            self._append_locked(run_id, entry)
+            return True
+
+    def record_action_state(
+        self,
+        action: str,
+        state: dict[str, Any] | None,
+    ) -> bool:
+        if not isinstance(state, dict):
+            return False
+
+        return self.record_state(state, reason=f"action:{action}")
+
+    def _resolve_run_id(self, state: dict[str, Any]) -> str | None:
+        run_id = _normalize_run_id(str(state.get("run_id", "")).strip()) if isinstance(state, dict) else None
+        if run_id is not None:
+            return run_id
+
+        return self._current_run_id
+
+    def _ensure_run_started_locked(self, run_id: str, summary: dict[str, Any]) -> None:
+        if run_id in self._started_runs:
+            return
+
+        entry = {
+            "timestamp_utc": _utc_timestamp(),
+            "type": "run_started",
+            "summary": {
+                "screen": summary.get("screen"),
+                "run": summary.get("run"),
+            },
+        }
+        self._append_locked(run_id, entry)
+        self._started_runs.add(run_id)
+
+    def _append_locked(self, run_id: str, entry: dict[str, Any]) -> None:
+        path = self._root_dir / f"{run_id}.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(entry, ensure_ascii=False, sort_keys=True))
+            handle.write("\n")
+
+    @staticmethod
+    def _state_category(summary: dict[str, Any]) -> str:
+        if summary.get("reward") is not None:
+            return "reward"
+
+        screen = str(summary.get("screen", "")).upper()
+        if screen == "COMBAT":
+            return "combat_turn"
+        if screen == "MAP":
+            return "map"
+        if screen in {"EVENT", "EVENT_ROOM"}:
+            return "event"
+        if "SHOP" in screen:
+            return "shop"
+        if "REST" in screen:
+            return "rest"
+        return "state"
+
+    @staticmethod
+    def _compact_event(event: dict[str, Any] | None) -> dict[str, Any] | None:
+        if not isinstance(event, dict):
+            return None
+
+        payload = {
+            "id": event.get("id"),
+            "event": event.get("event"),
+        }
+        data = event.get("data")
+        if isinstance(data, dict):
+            payload["data_type"] = data.get("type") or data.get("event")
+
+        return {key: value for key, value in payload.items() if value is not None}
+
+    def _summarize_state(self, state: dict[str, Any]) -> dict[str, Any]:
+        summary: dict[str, Any] = {
+            "state_version": _safe_int(state.get("state_version")),
+            "screen": state.get("screen"),
+            "turn": _safe_int(state.get("turn")),
+            "available_actions": _string_list(state.get("available_actions") or state.get("actions")),
+        }
+
+        session = state.get("session")
+        if isinstance(session, dict):
+            summary["session"] = {
+                "mode": session.get("mode"),
+                "phase": session.get("phase"),
+                "control_scope": session.get("control_scope"),
+            }
+
+        run = state.get("run")
+        if isinstance(run, dict):
+            deck = run.get("deck") if isinstance(run.get("deck"), list) else []
+            relics = run.get("relics") if isinstance(run.get("relics"), list) else []
+            potions = run.get("potions") if isinstance(run.get("potions"), list) else []
+            summary["run"] = {
+                "run_id": state.get("run_id"),
+                "character_id": run.get("character_id"),
+                "character_name": run.get("character_name"),
+                "floor": run.get("floor"),
+                "current_hp": run.get("current_hp"),
+                "max_hp": run.get("max_hp"),
+                "gold": run.get("gold"),
+                "max_energy": run.get("max_energy"),
+                "deck_size": len(deck),
+                "relic_count": len(relics),
+                "occupied_potion_slots": sum(1 for potion in potions if isinstance(potion, dict) and potion.get("occupied")),
+            }
+
+        combat = state.get("combat")
+        if isinstance(combat, dict) and (
+            isinstance(combat.get("hand"), list)
+            or isinstance(combat.get("enemies"), list)
+            or state.get("screen") == "COMBAT"
+        ):
+            player = combat.get("player") if isinstance(combat.get("player"), dict) else {}
+            hand = combat.get("hand") if isinstance(combat.get("hand"), list) else []
+            enemies = combat.get("enemies") if isinstance(combat.get("enemies"), list) else []
+            draw = combat.get("draw") if isinstance(combat.get("draw"), list) else []
+            discard = combat.get("discard") if isinstance(combat.get("discard"), list) else []
+            exhaust = combat.get("exhaust") if isinstance(combat.get("exhaust"), list) else []
+            powers = player.get("powers") if isinstance(player.get("powers"), list) else []
+            summary["combat"] = {
+                "player": {
+                    "current_hp": player.get("current_hp"),
+                    "max_hp": player.get("max_hp"),
+                    "block": player.get("block"),
+                    "energy": player.get("energy"),
+                    "stars": player.get("stars"),
+                    "focus": player.get("focus"),
+                    "powers": [power for power in (_compact_power(power) for power in powers) if power is not None],
+                },
+                "hand": [card for card in (_compact_card(card) for card in hand) if card is not None],
+                "draw_count": len(draw),
+                "discard_count": len(discard),
+                "exhaust_count": len(exhaust),
+                "enemies": [enemy for enemy in (_compact_enemy(enemy) for enemy in enemies) if enemy is not None],
+            }
+
+        reward = state.get("reward")
+        if isinstance(reward, dict) and reward:
+            rewards = reward.get("rewards") if isinstance(reward.get("rewards"), list) else []
+            card_options = reward.get("card_options") if isinstance(reward.get("card_options"), list) else []
+            alternatives = reward.get("alternatives") if isinstance(reward.get("alternatives"), list) else []
+            summary["reward"] = {
+                "pending_card_choice": bool(reward.get("pending_card_choice", False)),
+                "can_proceed": bool(reward.get("can_proceed", False)),
+                "rewards": [item for item in (_compact_reward_item(item) for item in rewards) if item is not None],
+                "card_options": [item for item in (_compact_reward_item(item) for item in card_options) if item is not None],
+                "alternatives": [item for item in (_compact_reward_item(item) for item in alternatives) if item is not None],
+            }
+
+        map_payload = state.get("map")
+        if isinstance(map_payload, dict) and map_payload:
+            current_node = map_payload.get("current_node") if isinstance(map_payload.get("current_node"), dict) else None
+            available_nodes = map_payload.get("available_nodes") if isinstance(map_payload.get("available_nodes"), list) else []
+            summary["map"] = {
+                "current_node": _compact_map_node(current_node) if current_node is not None else None,
+                "available_nodes": [node for node in (_compact_map_node(node) for node in available_nodes) if node is not None],
+            }
+
+        event = state.get("event")
+        if isinstance(event, dict) and event:
+            options = event.get("options") if isinstance(event.get("options"), list) else []
+            summary["event"] = {
+                "event_id": event.get("event_id"),
+                "title": event.get("title"),
+                "options": [option for option in (_compact_event_option(option) for option in options) if option is not None],
+            }
+
+        shop = state.get("shop")
+        if isinstance(shop, dict) and shop:
+            cards = shop.get("cards") if isinstance(shop.get("cards"), list) else []
+            relics = shop.get("relics") if isinstance(shop.get("relics"), list) else []
+            potions = shop.get("potions") if isinstance(shop.get("potions"), list) else []
+            summary["shop"] = {
+                "purge_cost": shop.get("purge_cost"),
+                "cards": [item for item in (_compact_reward_item(item) for item in cards) if item is not None],
+                "relics": [item for item in (_compact_reward_item(item) for item in relics) if item is not None],
+                "potions": [item for item in (_compact_reward_item(item) for item in potions) if item is not None],
+            }
+
+        rest = state.get("rest")
+        if isinstance(rest, dict) and rest:
+            options = rest.get("options") if isinstance(rest.get("options"), list) else []
+            summary["rest"] = {
+                "options": [option for option in (_compact_event_option(option) for option in options) if option is not None],
+            }
+
+        selection = state.get("selection")
+        if isinstance(selection, dict) and selection:
+            cards = selection.get("cards") if isinstance(selection.get("cards"), list) else []
+            summary["selection"] = {
+                "kind": selection.get("kind"),
+                "prompt": selection.get("prompt"),
+                "cards": [item for item in (_compact_reward_item(item) for item in cards) if item is not None],
+            }
+
+        return summary

--- a/mcp_server/src/sts2_mcp/server.py
+++ b/mcp_server/src/sts2_mcp/server.py
@@ -583,6 +583,194 @@ def _compute_combat_analysis(state: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _assess_elite_risk(state: dict[str, Any]) -> dict[str, Any]:
+    """Assess whether the player should take an elite fight or avoid it."""
+    agent_view = state.get("agent_view", state)
+    deck_cards = agent_view.get("deck", [])
+    deck_size = len(deck_cards)
+
+    player = agent_view.get("player", {})
+    current_hp = player.get("current_hp", 0)
+    max_hp = player.get("max_hp", 80)
+    potions = agent_view.get("potions", [])
+    potion_count = len([p for p in potions if p.get("potion_id")])
+
+    hp_ratio = current_hp / max(1, max_hp)
+
+    risk_factors: list[str] = []
+    reward_factors: list[str] = []
+
+    # HP assessment
+    if hp_ratio < 0.4:
+        risk_factors.append(f"HP critically low ({current_hp}/{max_hp})")
+    elif hp_ratio < 0.55:
+        risk_factors.append(f"HP below comfort zone ({current_hp}/{max_hp})")
+    else:
+        reward_factors.append(f"HP healthy ({current_hp}/{max_hp})")
+
+    # Deck readiness
+    if deck_size < 12:
+        risk_factors.append(f"Deck too thin ({deck_size} cards) — less margin for error")
+    elif deck_size > 20:
+        risk_factors.append(f"Deck bloated ({deck_size} cards) — inconsistent draws")
+    else:
+        reward_factors.append(f"Good deck size ({deck_size} cards)")
+
+    # Potions
+    if potion_count >= 2:
+        reward_factors.append(f"{potion_count} potions available for emergency")
+    elif potion_count == 1:
+        reward_factors.append("1 potion as safety net")
+    else:
+        risk_factors.append("No potions — no safety net")
+
+    # Reward value: elites give relics
+    reward_factors.append("Elite rewards: relic + higher gold + better card rewards")
+
+    # Decision
+    risk_score = len(risk_factors)
+    reward_score = len(reward_factors)
+    recommendation = "TAKE" if risk_score <= 1 and hp_ratio >= 0.5 else "AVOID"
+
+    return {
+        "recommendation": recommendation,
+        "risk_factors": risk_factors,
+        "reward_factors": reward_factors,
+        "hp_ratio": round(hp_ratio, 2),
+        "summary": f"{'Take the elite — rewards outweigh risk.' if recommendation == 'TAKE' else 'Avoid — too risky with current state. Heal or improve deck first.'}",
+    }
+
+
+def _check_boss_readiness(state: dict[str, Any]) -> dict[str, Any]:
+    """Evaluate whether the current deck and HP are ready for the Act 1 boss."""
+    agent_view = state.get("agent_view", state)
+    deck_cards = agent_view.get("deck", [])
+    deck_size = len(deck_cards)
+
+    player = agent_view.get("player", {})
+    current_hp = player.get("current_hp", 0)
+    max_hp = player.get("max_hp", 80)
+    potions = agent_view.get("potions", [])
+
+    card_data_index = _ensure_game_data_index("cards")
+
+    # Analyze deck composition
+    attack_count = 0
+    block_count = 0
+    draw_count = 0
+    aoe_count = 0
+    vulnerable_sources = 0
+    strength_sources = 0
+    total_base_damage = 0
+    total_base_block = 0
+
+    for card in deck_cards:
+        cid = card.get("card_id", "")
+        static = _lookup_game_data_item(index=card_data_index, item_id=cid)
+        if not isinstance(static, dict):
+            continue
+
+        dmg = static.get("damage", 0)
+        blk = static.get("block", 0)
+        desc = str(static.get("description", "")).upper()
+
+        if dmg:
+            attack_count += 1
+            total_base_damage += dmg
+        if blk:
+            block_count += 1
+            total_base_block += blk
+        if "DRAW" in desc:
+            draw_count += 1
+        if "ALL ENEM" in desc:
+            aoe_count += 1
+        if "VULNERABLE" in desc:
+            vulnerable_sources += 1
+        if "STRENGTH" in desc:
+            strength_sources += 1
+
+    # Generate readiness checks
+    checks: list[dict[str, Any]] = []
+
+    # HP check
+    hp_ok = current_hp >= max_hp * 0.6
+    checks.append({
+        "check": "hp",
+        "pass": hp_ok,
+        "detail": f"{current_hp}/{max_hp} HP" + (" — consider resting" if not hp_ok else " — healthy"),
+    })
+
+    # Deck size check
+    size_ok = 12 <= deck_size <= 20
+    checks.append({
+        "check": "deck_size",
+        "pass": size_ok,
+        "detail": f"{deck_size} cards" + (" — too thin" if deck_size < 12 else " — too bloated" if deck_size > 20 else " — good range"),
+    })
+
+    # Damage output
+    avg_damage_per_draw = total_base_damage / max(1, deck_size) * 5  # ~5 card hand
+    dmg_ok = avg_damage_per_draw >= 25
+    checks.append({
+        "check": "damage_output",
+        "pass": dmg_ok,
+        "detail": f"~{avg_damage_per_draw:.0f} base damage/turn" + (" — need more damage cards" if not dmg_ok else " — sufficient"),
+    })
+
+    # Block coverage
+    avg_block_per_draw = total_base_block / max(1, deck_size) * 5
+    blk_ok = avg_block_per_draw >= 15
+    checks.append({
+        "check": "block_output",
+        "pass": blk_ok,
+        "detail": f"~{avg_block_per_draw:.0f} base block/turn" + (" — need more block cards" if not blk_ok else " — sufficient"),
+    })
+
+    # Vulnerable source
+    vuln_ok = vulnerable_sources >= 1
+    checks.append({
+        "check": "vulnerable_source",
+        "pass": vuln_ok,
+        "detail": f"{vulnerable_sources} source(s)" + (" — Bash alone may not be enough" if vulnerable_sources < 2 else ""),
+    })
+
+    # Draw cards
+    draw_ok = draw_count >= 1
+    checks.append({
+        "check": "draw_cards",
+        "pass": draw_ok,
+        "detail": f"{draw_count} draw card(s)" + (" — deck cycling will be slow" if not draw_ok else ""),
+    })
+
+    # Potions
+    potion_count = len([p for p in potions if p.get("potion_id")])
+    checks.append({
+        "check": "potions",
+        "pass": potion_count >= 1,
+        "detail": f"{potion_count} potion(s) — {'save for boss' if potion_count >= 1 else 'try to acquire one before boss'}",
+    })
+
+    passed = sum(1 for c in checks if c["pass"])
+    total = len(checks)
+    ready = passed >= total - 1  # allow 1 failed check
+
+    return {
+        "ready": ready,
+        "score": f"{passed}/{total}",
+        "checks": checks,
+        "summary": "Deck is boss-ready." if ready else "Deck has gaps — prioritize fixing failed checks before boss.",
+        "deck_stats": {
+            "size": deck_size,
+            "attacks": attack_count,
+            "blocks": block_count,
+            "draw": draw_count,
+            "aoe": aoe_count,
+            "vulnerable_sources": vulnerable_sources,
+            "strength_sources": strength_sources,
+        },
+    }
+
+
 def _score_card_for_deck(
     card_id: str,
     card_data: dict[str, Any],
@@ -1087,6 +1275,27 @@ def create_server(client: Sts2Client | None = None, tool_profile: str | None = N
             "recommendations": results,
             "advice": "Pick the highest-scored card, or skip all if no card scores above 60.",
         }
+
+    @mcp.tool
+    def check_boss_readiness() -> dict[str, Any]:
+        """Check if your current deck, HP, and potions are ready for the boss fight.
+
+        Call this before entering a boss node on the map.
+        Returns pass/fail checks for HP, deck size, damage output, block coverage,
+        vulnerable sources, draw cards, and potions.
+        """
+        state = sts2.get_state()
+        return _check_boss_readiness(state)
+
+    @mcp.tool
+    def assess_elite_risk() -> dict[str, Any]:
+        """Assess whether to take an elite fight based on current HP, deck, and potions.
+
+        Call this when choosing a map path that includes an elite node.
+        Returns TAKE or AVOID recommendation with risk/reward factors.
+        """
+        state = sts2.get_state()
+        return _assess_elite_risk(state)
 
     if _debug_tools_enabled():
         @mcp.tool

--- a/mcp_server/src/sts2_mcp/server.py
+++ b/mcp_server/src/sts2_mcp/server.py
@@ -401,7 +401,7 @@ def _detect_scene_from_screen(screen: str) -> str:
 
 
 def _get_power_amount(powers: list[dict[str, Any]], power_id: str) -> int:
-    """Get stacked amount for a power by id (case-insensitive partial match)."""
+    """Get stacked amount for a power by id (case-insensitive exact match)."""
     needle = power_id.upper()
     for p in powers:
         pid = (p.get("power_id") or "").upper()
@@ -426,6 +426,115 @@ def _compute_card_block(base_block: int, dexterity: int, is_frail: bool) -> int:
     if is_frail:
         value = int(value * 0.75)
     return max(0, value)
+
+
+def _coerce_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _extract_agent_view(state: dict[str, Any]) -> dict[str, Any]:
+    agent_view = state.get("agent_view")
+    return agent_view if isinstance(agent_view, dict) else {}
+
+
+def _extract_run_payload(state: dict[str, Any]) -> dict[str, Any]:
+    run = state.get("run")
+    if isinstance(run, dict):
+        return run
+
+    run = _extract_agent_view(state).get("run")
+    return run if isinstance(run, dict) else {}
+
+
+def _extract_reward_payload(state: dict[str, Any]) -> dict[str, Any]:
+    reward = state.get("reward")
+    if isinstance(reward, dict):
+        return reward
+
+    reward = _extract_agent_view(state).get("reward")
+    return reward if isinstance(reward, dict) else {}
+
+
+def _extract_run_deck(state: dict[str, Any]) -> list[dict[str, Any]]:
+    deck = _extract_run_payload(state).get("deck")
+    if not isinstance(deck, list):
+        return []
+    return [card for card in deck if isinstance(card, dict)]
+
+
+def _extract_run_potions(state: dict[str, Any]) -> list[dict[str, Any]]:
+    potions = _extract_run_payload(state).get("potions")
+    if not isinstance(potions, list):
+        return []
+    return [potion for potion in potions if isinstance(potion, dict)]
+
+
+def _extract_reward_card_options(state: dict[str, Any]) -> list[dict[str, Any]]:
+    reward = _extract_reward_payload(state)
+    raw_options = reward.get("card_options")
+    if isinstance(raw_options, list):
+        return [card for card in raw_options if isinstance(card, dict)]
+
+    compact_options = reward.get("cards")
+    if isinstance(compact_options, list):
+        return [
+            card for card in compact_options
+            if isinstance(card, dict) and card.get("card_id")
+        ]
+
+    return []
+
+
+def _extract_run_hp(state: dict[str, Any]) -> tuple[int, int]:
+    run = _extract_run_payload(state)
+    if run:
+        current_hp = run.get("current_hp")
+        max_hp = run.get("max_hp")
+        if current_hp is not None or max_hp is not None:
+            return _coerce_int(current_hp), _coerce_int(max_hp)
+
+        hp_value = run.get("hp")
+        if isinstance(hp_value, str):
+            current_text, sep, max_text = hp_value.partition("/")
+            if sep:
+                return _coerce_int(current_text.strip()), _coerce_int(max_text.strip())
+
+    return 0, 0
+
+
+def _count_occupied_potions(potions: list[dict[str, Any]]) -> int:
+    count = 0
+    for potion in potions:
+        if potion.get("occupied") is True or potion.get("potion_id") or potion.get("name"):
+            count += 1
+            continue
+
+        line = potion.get("line")
+        if isinstance(line, str):
+            normalized = line.strip()
+            if normalized and not normalized.startswith("空"):
+                count += 1
+
+    return count
+
+
+def _get_card_type_name(card: dict[str, Any]) -> str:
+    return str(card.get("card_type") or card.get("type") or "").upper()
+
+
+def _get_card_text(card: dict[str, Any]) -> str:
+    return str(card.get("rules_text") or card.get("description") or card.get("line") or "")
+
+
+def _get_energy_cost(card_data: dict[str, Any], default: int = 1) -> int:
+    for key in ("energy_cost", "cost"):
+        value = card_data.get(key)
+        if value is not None:
+            return _coerce_int(value, default)
+    return default
 
 
 def _compute_combat_analysis(state: dict[str, Any]) -> dict[str, Any]:
@@ -548,7 +657,8 @@ def _compute_combat_analysis(state: dict[str, Any]) -> dict[str, Any]:
     remaining_energy = energy
     max_damage = 0
     for c in attacks:
-        cost = c.get("energy_cost", 1) or 1
+        cost = c.get("energy_cost")
+        cost = 1 if cost is None else _coerce_int(cost, 1)
         if cost <= remaining_energy:
             max_damage += c["computed_damage"]
             remaining_energy -= cost
@@ -556,7 +666,8 @@ def _compute_combat_analysis(state: dict[str, Any]) -> dict[str, Any]:
     remaining_energy_for_block = energy
     max_block = 0
     for c in blocks:
-        cost = c.get("energy_cost", 1) or 1
+        cost = c.get("energy_cost")
+        cost = 1 if cost is None else _coerce_int(cost, 1)
         if cost <= remaining_energy_for_block:
             max_block += c["computed_block"]
             remaining_energy_for_block -= cost
@@ -598,15 +709,11 @@ def _compute_combat_analysis(state: dict[str, Any]) -> dict[str, Any]:
 
 def _assess_elite_risk(state: dict[str, Any]) -> dict[str, Any]:
     """Assess whether the player should take an elite fight or avoid it."""
-    agent_view = state.get("agent_view", state)
-    deck_cards = agent_view.get("deck", [])
+    deck_cards = _extract_run_deck(state)
     deck_size = len(deck_cards)
-
-    player = agent_view.get("player", {})
-    current_hp = player.get("current_hp", 0)
-    max_hp = player.get("max_hp", 80)
-    potions = agent_view.get("potions", [])
-    potion_count = len([p for p in potions if p.get("potion_id")])
+    current_hp, max_hp = _extract_run_hp(state)
+    potions = _extract_run_potions(state)
+    potion_count = _count_occupied_potions(potions)
 
     hp_ratio = current_hp / max(1, max_hp)
 
@@ -656,14 +763,10 @@ def _assess_elite_risk(state: dict[str, Any]) -> dict[str, Any]:
 
 def _check_boss_readiness(state: dict[str, Any]) -> dict[str, Any]:
     """Evaluate whether the current deck and HP are ready for the Act 1 boss."""
-    agent_view = state.get("agent_view", state)
-    deck_cards = agent_view.get("deck", [])
+    deck_cards = _extract_run_deck(state)
     deck_size = len(deck_cards)
-
-    player = agent_view.get("player", {})
-    current_hp = player.get("current_hp", 0)
-    max_hp = player.get("max_hp", 80)
-    potions = agent_view.get("potions", [])
+    current_hp, max_hp = _extract_run_hp(state)
+    potions = _extract_run_potions(state)
 
     card_data_index = _ensure_game_data_index("cards")
 
@@ -756,7 +859,7 @@ def _check_boss_readiness(state: dict[str, Any]) -> dict[str, Any]:
     })
 
     # Potions
-    potion_count = len([p for p in potions if p.get("potion_id")])
+    potion_count = _count_occupied_potions(potions)
     checks.append({
         "check": "potions",
         "pass": potion_count >= 1,
@@ -795,14 +898,14 @@ def _score_card_for_deck(
     reasons: list[str] = []
 
     # Count deck composition
-    attack_count = sum(1 for c in current_deck if c.get("type") == "ATTACK" or c.get("damage"))
-    skill_count = sum(1 for c in current_deck if c.get("type") == "SKILL" or (c.get("block") and not c.get("damage")))
-    power_count = sum(1 for c in current_deck if c.get("type") == "POWER")
+    attack_count = sum(1 for c in current_deck if _get_card_type_name(c) == "ATTACK")
+    skill_count = sum(1 for c in current_deck if _get_card_type_name(c) == "SKILL")
+    power_count = sum(1 for c in current_deck if _get_card_type_name(c) == "POWER")
 
-    card_type = card_data.get("type", "")
-    base_dmg = card_data.get("damage", 0)
-    base_blk = card_data.get("block", 0)
-    energy_cost = card_data.get("energy_cost", 1)
+    card_type = str(card_data.get("type", "")).upper()
+    base_dmg = _coerce_int(card_data.get("damage"))
+    base_blk = _coerce_int(card_data.get("block"))
+    energy_cost = _get_energy_cost(card_data)
     has_draw = "draw" in str(card_data.get("powers_applied", "")).lower() or "draw" in str(card_data.get("description", "")).lower()
 
     # Deck size penalty — bigger decks need stronger cards to justify adding
@@ -848,7 +951,7 @@ def _score_card_for_deck(
     # AoE bonus — check for multi-target or "ALL" in description
     desc = str(card_data.get("description", "")).upper()
     if "ALL ENEM" in desc or "AOE" in desc:
-        aoe_count = sum(1 for c in current_deck if "ALL ENEM" in str(c.get("description", "")).upper())
+        aoe_count = sum(1 for c in current_deck if "ALL ENEM" in _get_card_text(c).upper())
         if aoe_count == 0:
             score += 15
             reasons.append("deck has no AoE — this fills a critical gap")
@@ -1250,23 +1353,9 @@ def create_server(client: Sts2Client | None = None, tool_profile: str | None = N
         Higher score = better fit for your current deck.
         """
         state = sts2.get_state()
-        agent_view = state.get("agent_view", state)
-
-        # Get current deck
-        deck_cards = agent_view.get("deck", [])
+        deck_cards = _extract_run_deck(state)
         deck_size = len(deck_cards)
-
-        # Get reward card options from available actions or state
-        reward = agent_view.get("reward", {})
-        card_rewards = reward.get("card_rewards", [])
-
-        if not card_rewards:
-            # Try to find cards in available actions
-            actions = agent_view.get("available_actions", [])
-            for action in actions:
-                if action.get("action_name") in ("select_reward_card", "choose_reward_card"):
-                    card_rewards = action.get("options", [])
-                    break
+        card_rewards = _extract_reward_card_options(state)
 
         if not card_rewards:
             return {"error": "no_card_rewards", "message": "No card rewards currently available."}

--- a/mcp_server/src/sts2_mcp/server.py
+++ b/mcp_server/src/sts2_mcp/server.py
@@ -400,6 +400,270 @@ def _detect_scene_from_screen(screen: str) -> str:
     return SCENE_MENU
 
 
+def _get_power_amount(powers: list[dict[str, Any]], power_id: str) -> int:
+    """Get stacked amount for a power by id (case-insensitive partial match)."""
+    needle = power_id.upper()
+    for p in powers:
+        pid = (p.get("power_id") or "").upper()
+        if pid == needle or pid == f"{needle}_POWER":
+            return int(p.get("amount", 0))
+    return 0
+
+
+def _compute_card_damage(base_damage: int, strength: int, is_weak: bool, target_vulnerable: bool, hits: int = 1) -> int:
+    """Compute actual damage for a single card play."""
+    per_hit = base_damage + strength
+    if is_weak:
+        per_hit = int(per_hit * 0.75)
+    if target_vulnerable:
+        per_hit = int(per_hit * 1.5)
+    return max(0, per_hit) * max(1, hits)
+
+
+def _compute_card_block(base_block: int, dexterity: int, is_frail: bool) -> int:
+    """Compute actual block for a single card play."""
+    value = base_block + dexterity
+    if is_frail:
+        value = int(value * 0.75)
+    return max(0, value)
+
+
+def _compute_combat_analysis(state: dict[str, Any]) -> dict[str, Any]:
+    """Analyze current combat: compute effective card values and tactical summary."""
+    combat = state.get("combat")
+    if not combat:
+        return {"error": "not_in_combat", "message": "Combat analysis is only available during combat."}
+
+    # --- Extract player info ---
+    player = combat.get("player", {})
+    energy = player.get("energy", 0)
+    player_block = player.get("block", 0)
+    player_powers = player.get("powers", [])
+    strength = _get_power_amount(player_powers, "STRENGTH")
+    dexterity = _get_power_amount(player_powers, "DEXTERITY")
+    is_weak = _get_power_amount(player_powers, "WEAK") > 0
+    is_frail = _get_power_amount(player_powers, "FRAIL") > 0
+
+    # --- Extract enemy info ---
+    enemies_raw = combat.get("enemies", [])
+    enemies = []
+    total_incoming = 0
+    for e in enemies_raw:
+        if not e.get("is_alive", True):
+            continue
+        hp = e.get("current_hp", 0)
+        block = e.get("block", 0)
+        e_powers = e.get("powers", [])
+        vulnerable = _get_power_amount(e_powers, "VULNERABLE") > 0
+        intents = e.get("intents", [])
+        intent_damage = 0
+        for intent in intents:
+            if intent.get("intent_type") == "Attack":
+                intent_damage += intent.get("total_damage") or intent.get("damage", 0)
+        total_incoming += intent_damage
+        enemies.append({
+            "index": e.get("index"),
+            "name": e.get("name"),
+            "hp": hp,
+            "block": block,
+            "vulnerable": vulnerable,
+            "intent_damage": intent_damage,
+        })
+
+    # --- Build card index from static data ---
+    card_data_index = _ensure_game_data_index("cards")
+
+    # --- Analyze hand ---
+    hand = combat.get("hand", [])
+    analyzed_cards: list[dict[str, Any]] = []
+    for card in hand:
+        card_id = card.get("card_id", "")
+        static = _lookup_game_data_item(index=card_data_index, item_id=card_id)
+        base_dmg = (static or {}).get("damage") if isinstance(static, dict) else None
+        base_blk = (static or {}).get("block") if isinstance(static, dict) else None
+        hit_count = (static or {}).get("hit_count") if isinstance(static, dict) else None
+        card_cost = card.get("energy_cost", 0)
+        is_playable = card.get("playable", False)
+
+        computed_damage = None
+        computed_block = None
+        damage_per_energy = None
+
+        if base_dmg is not None:
+            # For targeted cards, compute vs first alive vulnerable enemy; otherwise use non-vulnerable
+            any_vulnerable = any(e["vulnerable"] for e in enemies)
+            computed_damage = _compute_card_damage(
+                base_dmg, strength, is_weak,
+                target_vulnerable=any_vulnerable,
+                hits=hit_count or 1,
+            )
+            if card_cost and card_cost > 0:
+                damage_per_energy = round(computed_damage / card_cost, 1)
+
+        if base_blk is not None:
+            computed_block = _compute_card_block(base_blk, dexterity, is_frail)
+
+        entry: dict[str, Any] = {
+            "index": card.get("index"),
+            "card_id": card_id,
+            "name": card.get("name", ""),
+            "energy_cost": card_cost,
+            "playable": is_playable,
+        }
+        if computed_damage is not None:
+            entry["computed_damage"] = computed_damage
+            if damage_per_energy is not None:
+                entry["damage_per_energy"] = damage_per_energy
+        if computed_block is not None:
+            entry["computed_block"] = computed_block
+
+        analyzed_cards.append(entry)
+
+    # --- Compute tactical summary ---
+    # Greedy: play cards by damage_per_energy descending until energy exhausted
+    attacks = sorted(
+        [c for c in analyzed_cards if c.get("computed_damage") and c.get("playable")],
+        key=lambda c: c.get("damage_per_energy", 0),
+        reverse=True,
+    )
+    blocks = sorted(
+        [c for c in analyzed_cards if c.get("computed_block") and c.get("playable")],
+        key=lambda c: c.get("computed_block", 0),
+        reverse=True,
+    )
+
+    remaining_energy = energy
+    max_damage = 0
+    for c in attacks:
+        cost = c.get("energy_cost", 1) or 1
+        if cost <= remaining_energy:
+            max_damage += c["computed_damage"]
+            remaining_energy -= cost
+
+    remaining_energy_for_block = energy
+    max_block = 0
+    for c in blocks:
+        cost = c.get("energy_cost", 1) or 1
+        if cost <= remaining_energy_for_block:
+            max_block += c["computed_block"]
+            remaining_energy_for_block -= cost
+
+    # Per-enemy lethal check
+    enemy_analysis = []
+    for e in enemies:
+        effective_hp = e["hp"] + e["block"]
+        enemy_analysis.append({
+            "index": e["index"],
+            "name": e["name"],
+            "effective_hp": effective_hp,
+            "lethal": max_damage >= effective_hp,
+            "intent_damage": e["intent_damage"],
+            "vulnerable": e["vulnerable"],
+        })
+
+    net_damage_taken = max(0, total_incoming - player_block - max_block)
+
+    return {
+        "hand": analyzed_cards,
+        "energy": energy,
+        "player_powers": {
+            "strength": strength,
+            "dexterity": dexterity,
+            "weak": is_weak,
+            "frail": is_frail,
+        },
+        "summary": {
+            "max_damage_all_attacks": max_damage,
+            "max_block_all_defense": max_block,
+            "total_incoming_damage": total_incoming,
+            "current_block": player_block,
+            "net_damage_if_all_block": net_damage_taken,
+        },
+        "enemies": enemy_analysis,
+    }
+
+
+def _score_card_for_deck(
+    card_id: str,
+    card_data: dict[str, Any],
+    current_deck: list[dict[str, Any]],
+    deck_size: int,
+) -> dict[str, Any]:
+    """Score a card reward option against the current deck composition."""
+    score = 50  # baseline
+    reasons: list[str] = []
+
+    # Count deck composition
+    attack_count = sum(1 for c in current_deck if c.get("type") == "ATTACK" or c.get("damage"))
+    skill_count = sum(1 for c in current_deck if c.get("type") == "SKILL" or (c.get("block") and not c.get("damage")))
+    power_count = sum(1 for c in current_deck if c.get("type") == "POWER")
+
+    card_type = card_data.get("type", "")
+    base_dmg = card_data.get("damage", 0)
+    base_blk = card_data.get("block", 0)
+    energy_cost = card_data.get("energy_cost", 1)
+    has_draw = "draw" in str(card_data.get("powers_applied", "")).lower() or "draw" in str(card_data.get("description", "")).lower()
+
+    # Deck size penalty — bigger decks need stronger cards to justify adding
+    if deck_size > 18:
+        score -= 10
+        reasons.append("deck already large (>18)")
+    elif deck_size < 12:
+        score += 5
+        reasons.append("deck is small, card adds consistency")
+
+    # Value damage cards if deck is defense-heavy
+    if attack_count < skill_count and base_dmg > 0:
+        score += 10
+        reasons.append("deck needs more damage")
+
+    # Value block cards if deck is attack-heavy
+    if skill_count < attack_count and base_blk > 0:
+        score += 10
+        reasons.append("deck needs more block")
+
+    # Powers are generally valuable (one-time play, permanent effect)
+    if card_type == "POWER":
+        score += 15
+        reasons.append("powers provide lasting value")
+
+    # Draw is always valuable
+    if has_draw:
+        score += 12
+        reasons.append("draw improves deck cycling")
+
+    # Efficiency: damage/energy or block/energy
+    if base_dmg and energy_cost:
+        eff = base_dmg / max(1, energy_cost)
+        if eff >= 8:
+            score += 10
+            reasons.append(f"high damage efficiency ({eff:.0f}/energy)")
+    if base_blk and energy_cost:
+        eff = base_blk / max(1, energy_cost)
+        if eff >= 6:
+            score += 8
+            reasons.append(f"high block efficiency ({eff:.0f}/energy)")
+
+    # AoE bonus — check for multi-target or "ALL" in description
+    desc = str(card_data.get("description", "")).upper()
+    if "ALL ENEM" in desc or "AOE" in desc:
+        aoe_count = sum(1 for c in current_deck if "ALL ENEM" in str(c.get("description", "")).upper())
+        if aoe_count == 0:
+            score += 15
+            reasons.append("deck has no AoE — this fills a critical gap")
+
+    # 0-cost cards are almost always good
+    if energy_cost == 0:
+        score += 10
+        reasons.append("0-cost = free value")
+
+    return {
+        "card_id": card_id,
+        "score": min(100, max(0, score)),
+        "reasons": reasons,
+    }
+
+
 def create_server(client: Sts2Client | None = None, tool_profile: str | None = None) -> FastMCP:
     sts2 = client or Sts2Client()
     knowledge = Sts2KnowledgeBase()
@@ -760,6 +1024,69 @@ def create_server(client: Sts2Client | None = None, tool_profile: str | None = N
 
     if profile == "full":
         _register_legacy_action_tools(mcp, sts2)
+
+    @mcp.tool
+    def get_combat_analysis() -> dict[str, Any]:
+        """Compute effective damage/block values for every card in hand, considering all active powers.
+
+        Returns per-card computed values and a tactical summary including:
+        - Each hand card with `computed_damage`, `computed_block`, and `damage_per_energy`
+        - Total available damage/block this turn (energy-limited)
+        - Per-enemy lethal check (can this enemy be killed this turn?)
+        - Incoming damage (total enemy intent damage vs available block)
+
+        Call this at the start of each combat turn for informed decision-making.
+        """
+        state = sts2.get_state()
+        return _compute_combat_analysis(state)
+
+    @mcp.tool
+    def evaluate_card_rewards() -> dict[str, Any]:
+        """Score card reward options against your current deck composition.
+
+        Call this when presented with card rewards after combat.
+        Returns each reward card with a score (0-100) and reasons for/against picking it.
+        Higher score = better fit for your current deck.
+        """
+        state = sts2.get_state()
+        agent_view = state.get("agent_view", state)
+
+        # Get current deck
+        deck_cards = agent_view.get("deck", [])
+        deck_size = len(deck_cards)
+
+        # Get reward card options from available actions or state
+        reward = agent_view.get("reward", {})
+        card_rewards = reward.get("card_rewards", [])
+
+        if not card_rewards:
+            # Try to find cards in available actions
+            actions = agent_view.get("available_actions", [])
+            for action in actions:
+                if action.get("action_name") in ("select_reward_card", "choose_reward_card"):
+                    card_rewards = action.get("options", [])
+                    break
+
+        if not card_rewards:
+            return {"error": "no_card_rewards", "message": "No card rewards currently available."}
+
+        card_data_index = _ensure_game_data_index("cards")
+        results = []
+        for card in card_rewards:
+            cid = card.get("card_id", "")
+            static = _lookup_game_data_item(index=card_data_index, item_id=cid)
+            if not isinstance(static, dict):
+                static = {}
+            scored = _score_card_for_deck(cid, static, deck_cards, deck_size)
+            scored["name"] = card.get("name", cid)
+            results.append(scored)
+
+        results.sort(key=lambda x: x["score"], reverse=True)
+        return {
+            "deck_size": deck_size,
+            "recommendations": results,
+            "advice": "Pick the highest-scored card, or skip all if no card scores above 60.",
+        }
 
     if _debug_tools_enabled():
         @mcp.tool

--- a/mcp_server/src/sts2_mcp/server.py
+++ b/mcp_server/src/sts2_mcp/server.py
@@ -4,6 +4,7 @@ import json
 import os
 import threading
 import time
+from collections import Counter
 from dataclasses import dataclass
 from typing import Any, Callable
 
@@ -31,6 +32,21 @@ COMBAT_SCREEN_NAMES = {"combat_reward", "combat_victory"}
 SHOP_SCREEN_KEYWORDS = ("shop", "merchant")
 EVENT_SCREEN_KEYWORDS = ("event",)
 EVENT_SCREEN_NAMES = {"event_room", "ancient_event"}
+_AGENT_VIEW_BACKFILL_KEYS = (
+    "run",
+    "combat",
+    "reward",
+    "map",
+    "shop",
+    "rest",
+    "event",
+    "selection",
+    "character_select",
+    "timeline",
+    "chest",
+    "modal",
+    "game_over",
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -400,6 +416,1475 @@ def _detect_scene_from_screen(screen: str) -> str:
     return SCENE_MENU
 
 
+def _build_agent_state_payload(state: dict[str, Any], knowledge: Sts2KnowledgeBase) -> dict[str, Any]:
+    agent_view = state.get("agent_view")
+    if not isinstance(agent_view, dict):
+        return state
+
+    enriched = dict(agent_view)
+    for key in _AGENT_VIEW_BACKFILL_KEYS:
+        if key in enriched:
+            continue
+        raw_value = state.get(key)
+        if isinstance(raw_value, (dict, list)):
+            enriched[key] = raw_value
+
+    if "available_actions" not in enriched and isinstance(enriched.get("actions"), list):
+        enriched["available_actions"] = enriched["actions"]
+    if "available_actions" not in enriched and isinstance(state.get("available_actions"), list):
+        enriched["available_actions"] = state["available_actions"]
+
+    raw_map = state.get("map")
+    compact_map = enriched.get("map")
+    if isinstance(raw_map, dict) and isinstance(compact_map, dict) and "route_options" not in compact_map:
+        enriched_map = dict(compact_map)
+        enriched_map["route_options"] = knowledge.build_route_options(state)
+        enriched["map"] = enriched_map
+
+    return enriched
+
+
+_AOE_TARGETS = {"allenemies"}
+_SCALING_POWER_IDS = {
+    "accuracy",
+    "afterimage",
+    "buffer",
+    "dexterity",
+    "focus",
+    "intangible",
+    "mantra",
+    "plating",
+    "poison",
+    "strength",
+    "thorns",
+    "vigor",
+}
+_SCALING_HINTS = (
+    "at the start of your turn",
+    "for the rest of combat",
+    "whenever",
+    "each turn",
+)
+_REST_NODE_TYPES = {"rest", "campfire"}
+_SHOP_NODE_TYPES = {"shop", "merchant"}
+_ELITE_NODE_TYPES = {"elite"}
+_MONSTER_NODE_TYPES = {"monster", "enemy"}
+
+
+def _safe_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _normalize_token(value: Any) -> str:
+    if value is None:
+        return ""
+    return "".join(ch for ch in str(value).lower() if ch.isalnum())
+
+
+def _safe_ratio(current: int | None, maximum: int | None) -> float:
+    if current is None or maximum is None or maximum <= 0:
+        return 0.0
+    return round(current / maximum, 3)
+
+
+def _clamp(value: int, minimum: int, maximum: int) -> int:
+    return max(minimum, min(maximum, value))
+
+
+def _dedupe_reasons(reasons: list[str], limit: int = 5) -> list[str]:
+    ordered = list(dict.fromkeys(reason for reason in reasons if reason))
+    return ordered[:limit]
+
+
+def _safe_collection_index(collection: str) -> dict[str, Any]:
+    try:
+        return _ensure_game_data_index(collection)
+    except (KeyError, RuntimeError, TypeError):
+        return {}
+
+
+def _lookup_item_meta(index: dict[str, Any], item_id: str | None) -> dict[str, Any]:
+    if not item_id or not index:
+        return {}
+
+    item = _lookup_game_data_item(index=index, item_id=item_id)
+    return item if isinstance(item, dict) else {}
+
+
+def _run_payload(state: dict[str, Any]) -> dict[str, Any]:
+    run = state.get("run")
+    return run if isinstance(run, dict) else {}
+
+
+def _reward_payload(state: dict[str, Any]) -> dict[str, Any]:
+    reward = state.get("reward")
+    return reward if isinstance(reward, dict) else {}
+
+
+def _map_payload(state: dict[str, Any]) -> dict[str, Any]:
+    map_data = state.get("map")
+    return map_data if isinstance(map_data, dict) else {}
+
+
+def _extract_card_entries(entries: Any) -> list[dict[str, Any]]:
+    if not isinstance(entries, list):
+        return []
+
+    result: list[dict[str, Any]] = []
+    for position, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            continue
+
+        count = _safe_int(entry.get("count")) or 1
+        card_id = entry.get("card_id") or entry.get("id")
+        result.append(
+            {
+                "index": _safe_int(entry.get("i")) or _safe_int(entry.get("index")) or position,
+                "card_id": str(card_id) if card_id is not None else None,
+                "name": entry.get("name"),
+                "count": max(1, count),
+                "energy_cost": _safe_int(entry.get("energy_cost")) if "energy_cost" in entry else _safe_int(entry.get("cost")),
+                "star_cost": _safe_int(entry.get("star_cost")),
+                "costs_x": bool(entry.get("costs_x") or entry.get("is_x_cost")),
+                "star_costs_x": bool(entry.get("star_costs_x") or entry.get("is_x_star_cost")),
+                "upgraded": bool(entry.get("upgraded")),
+                "rarity": entry.get("rarity"),
+                "type": entry.get("card_type") or entry.get("type"),
+                "rules_text": entry.get("rules_text") or entry.get("description") or entry.get("line"),
+            }
+        )
+
+    return result
+
+
+def _extract_potion_count(entries: Any) -> int:
+    if not isinstance(entries, list):
+        return 0
+
+    count = 0
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+
+        occupied = entry.get("occupied")
+        if isinstance(occupied, bool):
+            if occupied:
+                count += 1
+            continue
+
+        if entry.get("potion_id") or entry.get("name"):
+            count += 1
+
+    return count
+
+
+def _extract_hp_values(run: dict[str, Any]) -> tuple[int | None, int | None]:
+    current_hp = _safe_int(run.get("current_hp"))
+    max_hp = _safe_int(run.get("max_hp"))
+    if current_hp is not None and max_hp is not None:
+        return current_hp, max_hp
+
+    hp_summary = run.get("hp")
+    if not isinstance(hp_summary, str) or "/" not in hp_summary:
+        return current_hp, max_hp
+
+    current_part, max_part = hp_summary.split("/", 1)
+    try:
+        parsed_current = int(current_part.strip())
+        parsed_max = int(max_part.strip())
+    except ValueError:
+        return current_hp, max_hp
+
+    return current_hp if current_hp is not None else parsed_current, max_hp if max_hp is not None else parsed_max
+
+
+def _card_profile(card: dict[str, Any], meta: dict[str, Any]) -> dict[str, Any]:
+    cost = _safe_int(card.get("energy_cost"))
+    if cost is None:
+        cost = _safe_int(meta.get("cost"))
+
+    damage = _safe_int(meta.get("damage")) or 0
+    block = _safe_int(meta.get("block")) or 0
+    hit_count = _safe_int(meta.get("hit_count")) or (1 if damage > 0 else 0)
+    total_damage = damage * hit_count if damage > 0 else 0
+    draw_count = _safe_int(meta.get("cards_draw")) or 0
+    energy_gain = _safe_int(meta.get("energy_gain")) or 0
+    hp_loss = _safe_int(meta.get("hp_loss")) or 0
+    target = _normalize_token(card.get("target") or meta.get("target"))
+    card_type = str(card.get("type") or meta.get("type") or "").strip()
+    rarity = str(card.get("rarity") or meta.get("rarity") or "").strip()
+
+    description_parts = [
+        part
+        for part in (
+            card.get("rules_text"),
+            meta.get("description"),
+            meta.get("description_raw"),
+        )
+        if isinstance(part, str) and part.strip()
+    ]
+    description = "\n".join(description_parts).lower()
+
+    powers = meta.get("powers_applied") if isinstance(meta.get("powers_applied"), list) else []
+    power_ids = {
+        _normalize_token(power.get("power"))
+        for power in powers
+        if isinstance(power, dict) and power.get("power")
+    }
+
+    aoe = target in _AOE_TARGETS or "all enemies" in description
+    frontload = aoe or total_damage >= 8 or (target in {"anyenemy", "randomenemy"} and damage >= 7)
+    block_card = block > 0 or ("gain" in description and "block" in description)
+    weak = "weak" in description or "weak" in power_ids
+    vulnerable = "vulnerable" in description or "vulnerable" in power_ids
+    poison = "poison" in description or "poison" in power_ids
+    scaling = (
+        _normalize_token(card_type) == "power"
+        or bool(power_ids & _SCALING_POWER_IDS)
+        or poison
+        or any(phrase in description for phrase in _SCALING_HINTS)
+    )
+
+    return {
+        "card_id": card.get("card_id"),
+        "name": card.get("name") or meta.get("name") or "Unknown Card",
+        "type": card_type or None,
+        "rarity": rarity or None,
+        "cost": cost,
+        "x_cost": bool(card.get("costs_x") or meta.get("is_x_cost")),
+        "high_cost": cost is not None and cost >= 2 and not bool(card.get("costs_x") or meta.get("is_x_cost")),
+        "damage": damage,
+        "total_damage": total_damage,
+        "block": block,
+        "draw_count": draw_count,
+        "energy_gain": energy_gain,
+        "hp_loss": hp_loss,
+        "aoe": aoe,
+        "frontload": frontload,
+        "block_card": block_card,
+        "scaling": scaling,
+        "weak": weak,
+        "vulnerable": vulnerable,
+        "poison": poison,
+        "energy": energy_gain > 0,
+    }
+
+
+def _summarize_deck(state: dict[str, Any], cards_index: dict[str, Any]) -> dict[str, Any]:
+    run = _run_payload(state)
+    deck_entries = _extract_card_entries(run.get("deck"))
+    totals: Counter[str] = Counter()
+    type_counts: Counter[str] = Counter()
+    card_id_counts: Counter[str] = Counter()
+
+    for entry in deck_entries:
+        count = max(1, entry.get("count", 1))
+        card_id = entry.get("card_id")
+        if isinstance(card_id, str) and card_id:
+            card_id_counts[card_id] += count
+
+        profile = _card_profile(entry, _lookup_item_meta(cards_index, card_id))
+        type_key = _normalize_token(profile.get("type"))
+        if type_key:
+            type_counts[type_key] += count
+
+        if profile["aoe"]:
+            totals["aoe_cards"] += count
+        if profile["frontload"]:
+            totals["frontload_cards"] += count
+        if profile["block_card"]:
+            totals["block_cards"] += count
+        if profile["scaling"]:
+            totals["scaling_cards"] += count
+        if profile["draw_count"] > 0:
+            totals["draw_cards"] += count
+        if profile["weak"]:
+            totals["weak_sources"] += count
+        if profile["vulnerable"]:
+            totals["vulnerable_sources"] += count
+        if profile["poison"]:
+            totals["poison_sources"] += count
+        if profile["energy"]:
+            totals["energy_cards"] += count
+        if profile["high_cost"]:
+            totals["high_cost_cards"] += count
+        if profile["hp_loss"] > 0:
+            totals["hp_loss_cards"] += count
+
+    current_hp, max_hp = _extract_hp_values(run)
+    relic_items = run.get("relic_items") if isinstance(run.get("relic_items"), list) else None
+    relics = run.get("relics") if isinstance(run.get("relics"), list) else None
+    deck_size = sum(entry["count"] for entry in deck_entries) or _safe_int(run.get("deck_size")) or 0
+
+    return {
+        "floor": _safe_int(run.get("floor")) or 0,
+        "current_hp": current_hp or 0,
+        "max_hp": max_hp or 0,
+        "hp_ratio": _safe_ratio(current_hp, max_hp),
+        "gold": _safe_int(run.get("gold")) or 0,
+        "max_energy": _safe_int(run.get("max_energy")) or 3,
+        "deck_size": deck_size,
+        "relic_count": len(relic_items) if relic_items is not None else len(relics or []),
+        "potion_count": _extract_potion_count(run.get("potions")),
+        "aoe_cards": totals["aoe_cards"],
+        "frontload_cards": totals["frontload_cards"],
+        "block_cards": totals["block_cards"],
+        "scaling_cards": totals["scaling_cards"],
+        "draw_cards": totals["draw_cards"],
+        "weak_sources": totals["weak_sources"],
+        "vulnerable_sources": totals["vulnerable_sources"],
+        "poison_sources": totals["poison_sources"],
+        "energy_cards": totals["energy_cards"],
+        "high_cost_cards": totals["high_cost_cards"],
+        "hp_loss_cards": totals["hp_loss_cards"],
+        "type_counts": dict(type_counts),
+        "card_id_counts": dict(card_id_counts),
+    }
+
+
+def _public_deck_summary(summary: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in summary.items() if key != "card_id_counts"}
+
+
+def _score_reward_card(card: dict[str, Any], deck_summary: dict[str, Any], profile: dict[str, Any]) -> tuple[int, list[str]]:
+    reasons: list[str] = []
+    score = 50
+    floor = deck_summary["floor"]
+    act2_or_later = floor >= 17
+    duplicate_count = deck_summary["card_id_counts"].get(card.get("card_id") or "", 0)
+
+    if profile["aoe"]:
+        bonus = 18 if deck_summary["aoe_cards"] == 0 else 10 if deck_summary["aoe_cards"] == 1 else 4
+        if act2_or_later:
+            bonus += 4
+        score += bonus
+        reasons.append("补强范围伤害")
+    elif act2_or_later and deck_summary["aoe_cards"] == 0:
+        score -= 6
+        reasons.append("当前更缺范围伤害")
+
+    if profile["frontload"]:
+        bonus = 9 if deck_summary["frontload_cards"] < 5 else 3
+        if act2_or_later and deck_summary["frontload_cards"] < 5:
+            bonus += 3
+        score += bonus
+        reasons.append("补强前台输出")
+    elif act2_or_later and profile["type"] == "Power" and deck_summary["frontload_cards"] < 4:
+        score -= 6
+        reasons.append("Act 2 更需要立即影响战局的牌")
+
+    if profile["scaling"]:
+        bonus = 14 if deck_summary["scaling_cards"] == 0 else 8 if deck_summary["scaling_cards"] == 1 else 3
+        score += bonus
+        reasons.append("补强成长与长战能力")
+
+    if profile["block_card"]:
+        if deck_summary["block_cards"] < 4:
+            score += 10
+            reasons.append("补强防御覆盖")
+        elif deck_summary["block_cards"] >= 7:
+            score -= 3
+            reasons.append("牌组已有较多防御")
+
+    if profile["draw_count"] > 0:
+        if deck_summary["draw_cards"] < 2:
+            score += 8
+            reasons.append("补强过牌稳定性")
+        elif deck_summary["draw_cards"] >= 4:
+            score -= 2
+            reasons.append("当前过牌已经不少")
+
+    if profile["weak"] and deck_summary["weak_sources"] == 0:
+        score += 5
+        reasons.append("补弱化来源")
+
+    if profile["vulnerable"] and deck_summary["vulnerable_sources"] == 0:
+        score += 5
+        reasons.append("补易伤来源")
+
+    if profile["energy"] and deck_summary["energy_cards"] == 0:
+        score += 8
+        reasons.append("改善能量回转")
+
+    if profile["x_cost"] and deck_summary["energy_cards"] == 0 and deck_summary["max_energy"] <= 3:
+        score -= 5
+        reasons.append("当前能量曲线不太支持 X 费")
+
+    if profile["high_cost"] and deck_summary["high_cost_cards"] >= 4:
+        score -= 8
+        reasons.append("高费牌已经偏多")
+
+    if profile["hp_loss"] > 0 and deck_summary["hp_ratio"] < 0.55:
+        score -= 12
+        reasons.append("当前血线偏低，不适合继续自伤")
+
+    if duplicate_count >= 2 and _normalize_token(profile.get("type")) == "power":
+        score -= 6
+        reasons.append("同名 Power 已经偏多")
+    elif duplicate_count >= 2:
+        score -= 4
+        reasons.append("同名牌已经偏多")
+
+    rarity_bonus = {"Rare": 7, "Uncommon": 3}.get(profile.get("rarity"), 0)
+    if rarity_bonus > 0:
+        score += rarity_bonus
+        reasons.append(f"{profile['rarity']} 牌上限更高")
+
+    return _clamp(score, 0, 100), _dedupe_reasons(reasons)
+
+
+def _evaluate_card_rewards_for_state(state: dict[str, Any]) -> dict[str, Any]:
+    cards_index = _safe_collection_index("cards")
+    reward = _reward_payload(state)
+    reward_cards = _extract_card_entries(
+        reward.get("cards") or reward.get("card_options") or reward.get("card_rewards")
+    )
+    deck_summary = _summarize_deck(state, cards_index)
+
+    if not reward_cards:
+        return {
+            "best_index": None,
+            "reward_cards": [],
+            "deck_summary": _public_deck_summary(deck_summary),
+            "message": "当前状态没有待选卡牌奖励。",
+        }
+
+    evaluated: list[dict[str, Any]] = []
+    for entry in reward_cards:
+        meta = _lookup_item_meta(cards_index, entry.get("card_id"))
+        profile = _card_profile(entry, meta)
+        score, reasons = _score_reward_card(entry, deck_summary, profile)
+        evaluated.append(
+            {
+                "index": entry["index"],
+                "card_id": entry.get("card_id"),
+                "name": profile["name"],
+                "score": score,
+                "recommendation": "take" if score >= 68 else "consider" if score >= 52 else "skip",
+                "reasons": reasons,
+            }
+        )
+
+    best = max(evaluated, key=lambda item: (item["score"], -(item["index"] or 0)))
+    return {
+        "best_index": best["index"],
+        "reward_cards": evaluated,
+        "deck_summary": _public_deck_summary(deck_summary),
+    }
+
+
+def _node_type_matches(node_type: Any, targets: set[str]) -> bool:
+    normalized = _normalize_token(node_type)
+    if normalized in targets:
+        return True
+
+    return any(target in normalized for target in targets)
+
+
+def _build_elite_route_previews(route_options: Any) -> list[dict[str, Any]]:
+    if not isinstance(route_options, list):
+        return []
+
+    previews: list[dict[str, Any]] = []
+    for option in route_options:
+        if not isinstance(option, dict):
+            continue
+
+        start_node = option.get("start_node") if isinstance(option.get("start_node"), dict) else {}
+        paths = option.get("paths") if isinstance(option.get("paths"), list) else []
+        best_preview: dict[str, Any] | None = None
+
+        for path in paths:
+            if not isinstance(path, dict):
+                continue
+
+            node_types = path.get("node_types") if isinstance(path.get("node_types"), list) else []
+            normalized_types = [_normalize_token(node_type) for node_type in node_types]
+            elite_index = next(
+                (index for index, node_type in enumerate(normalized_types) if _node_type_matches(node_type, _ELITE_NODE_TYPES)),
+                None,
+            )
+            if elite_index is None:
+                continue
+
+            types_before_elite = normalized_types[:elite_index]
+            preview = {
+                "start_index": _safe_int(start_node.get("index")) or _safe_int(start_node.get("i")) or 0,
+                "start_node": {
+                    "row": _safe_int(start_node.get("row")),
+                    "col": _safe_int(start_node.get("col")),
+                    "type": start_node.get("node_type") or start_node.get("type"),
+                },
+                "elite_distance": elite_index + 1,
+                "rest_before_elite": any(_node_type_matches(node_type, _REST_NODE_TYPES) for node_type in types_before_elite),
+                "shop_before_elite": any(_node_type_matches(node_type, _SHOP_NODE_TYPES) for node_type in types_before_elite),
+                "monster_before_elite": sum(
+                    1 for node_type in types_before_elite if _node_type_matches(node_type, _MONSTER_NODE_TYPES)
+                ),
+                "elite_count": sum(
+                    1 for node_type in normalized_types if _node_type_matches(node_type, _ELITE_NODE_TYPES)
+                ),
+                "path_types": node_types,
+            }
+            preview["threat_score"] = (
+                preview["elite_distance"]
+                + 2 * preview["elite_count"]
+                - (2 if preview["rest_before_elite"] else 0)
+                - (1 if preview["shop_before_elite"] else 0)
+            )
+
+            if best_preview is None or preview["threat_score"] < best_preview["threat_score"]:
+                best_preview = preview
+
+        if best_preview is not None:
+            previews.append(best_preview)
+
+    previews.sort(key=lambda preview: (preview["threat_score"], preview["elite_distance"], preview["start_index"]))
+    return previews
+
+
+def _assess_elite_risk_for_state(state: dict[str, Any]) -> dict[str, Any]:
+    cards_index = _safe_collection_index("cards")
+    deck_summary = _summarize_deck(state, cards_index)
+    route_previews = _build_elite_route_previews(_map_payload(state).get("route_options"))
+    best_route = route_previews[0] if route_previews else None
+
+    risk_score = 50
+    positive: list[str] = []
+    negative: list[str] = []
+    hp_ratio = deck_summary["hp_ratio"]
+    act2_or_later = deck_summary["floor"] >= 17
+
+    if hp_ratio < 0.35:
+        risk_score += 28
+        negative.append("当前血量过低")
+    elif hp_ratio < 0.5:
+        risk_score += 18
+        negative.append("当前血线偏低")
+    elif hp_ratio >= 0.75:
+        risk_score -= 8
+        positive.append("血量缓冲充足")
+    elif hp_ratio >= 0.6:
+        risk_score -= 4
+        positive.append("血量尚可")
+
+    if deck_summary["potion_count"] == 0:
+        risk_score += 8
+        negative.append("没有药水缓冲")
+    elif deck_summary["potion_count"] >= 2:
+        risk_score -= 8
+        positive.append("药水储备充足")
+    else:
+        risk_score -= 3
+        positive.append("有药水可应急")
+
+    if deck_summary["aoe_cards"] == 0:
+        risk_score += 12 if act2_or_later else 8
+        negative.append("缺范围伤害")
+    else:
+        risk_score -= 5
+        positive.append("有范围伤害处理多目标")
+
+    if deck_summary["frontload_cards"] < 5:
+        risk_score += 10
+        negative.append("前台输出不足")
+    elif deck_summary["frontload_cards"] >= 7:
+        risk_score -= 6
+        positive.append("前台输出足够")
+
+    if deck_summary["block_cards"] < 4 and deck_summary["weak_sources"] == 0:
+        risk_score += 10
+        negative.append("防御覆盖偏弱")
+    else:
+        risk_score -= 5
+        positive.append("有一定防御与减伤")
+
+    if deck_summary["scaling_cards"] == 0:
+        risk_score += 6
+        negative.append("缺持续成长")
+    else:
+        risk_score -= 3
+        positive.append("有成长手段")
+
+    if deck_summary["draw_cards"] < 2:
+        risk_score += 4
+        negative.append("过牌偏少")
+    elif deck_summary["draw_cards"] >= 3:
+        risk_score -= 2
+        positive.append("过牌稳定性尚可")
+
+    if deck_summary["max_energy"] >= 4:
+        risk_score -= 3
+        positive.append("能量上限较高")
+
+    if best_route is None:
+        risk_score += 4
+        negative.append("当前路线缺少精英前缓冲信息")
+    else:
+        if best_route["rest_before_elite"]:
+            risk_score -= 10
+            positive.append("存在精英前营火")
+        if best_route["shop_before_elite"] and deck_summary["gold"] >= 150:
+            risk_score -= 6
+            positive.append("可先商店补强再打精英")
+        if best_route["elite_distance"] <= 2 and not best_route["rest_before_elite"]:
+            risk_score += 8
+            negative.append("精英过近，缺少缓冲节点")
+        if best_route["elite_count"] > 1:
+            risk_score += 4
+            negative.append("该分支后续精英密度偏高")
+
+    risk_score = _clamp(risk_score, 0, 100)
+    recommendation = "TAKE" if risk_score <= 40 else "CAUTION" if risk_score <= 65 else "AVOID"
+
+    return {
+        "recommendation": recommendation,
+        "risk_score": risk_score,
+        "hp_ratio": deck_summary["hp_ratio"],
+        "deck_summary": _public_deck_summary(deck_summary),
+        "best_elite_route": best_route,
+        "route_preview": route_previews[:3],
+        "factors": {
+            "positive": _dedupe_reasons(positive),
+            "negative": _dedupe_reasons(negative),
+        },
+    }
+
+
+def _build_check(status: str, value: Any, target: str, reason: str) -> dict[str, Any]:
+    return {
+        "status": status,
+        "value": value,
+        "target": target,
+        "reason": reason,
+    }
+
+
+def _check_boss_readiness_for_state(state: dict[str, Any]) -> dict[str, Any]:
+    cards_index = _safe_collection_index("cards")
+    deck_summary = _summarize_deck(state, cards_index)
+    hp_ratio = deck_summary["hp_ratio"]
+    current_hp = deck_summary["current_hp"]
+    deck_size = deck_summary["deck_size"]
+    checks = {
+        "hp": _build_check(
+            "pass" if hp_ratio >= 0.6 or current_hp >= 45 else "borderline" if hp_ratio >= 0.45 or current_hp >= 30 else "fail",
+            current_hp,
+            ">= 45 HP or >= 60% HP",
+            "血线越高，Boss 战容错越高。",
+        ),
+        "deck_size": _build_check(
+            "pass" if 10 <= deck_size <= 30 else "borderline" if 8 <= deck_size <= 34 else "fail",
+            deck_size,
+            "10-30 张左右",
+            "过小容易缺关键功能，过大则抽不到核心牌。",
+        ),
+        "damage": _build_check(
+            "pass"
+            if deck_summary["frontload_cards"] + deck_summary["vulnerable_sources"] + deck_summary["energy_cards"] >= 6
+            else "borderline"
+            if deck_summary["frontload_cards"] + deck_summary["vulnerable_sources"] + deck_summary["energy_cards"] >= 4
+            else "fail",
+            {
+                "frontload_cards": deck_summary["frontload_cards"],
+                "vulnerable_sources": deck_summary["vulnerable_sources"],
+                "energy_cards": deck_summary["energy_cards"],
+            },
+            "至少 6 点综合输出指标",
+            "需要足够的单体输出把 Boss 战拖回可控节奏。",
+        ),
+        "block": _build_check(
+            "pass"
+            if deck_summary["block_cards"] + deck_summary["weak_sources"] >= 5
+            else "borderline"
+            if deck_summary["block_cards"] + deck_summary["weak_sources"] >= 3
+            else "fail",
+            {
+                "block_cards": deck_summary["block_cards"],
+                "weak_sources": deck_summary["weak_sources"],
+            },
+            "至少 5 点综合防御指标",
+            "Boss 战要求稳定防御，不只是偶尔一手好牌。",
+        ),
+        "scaling": _build_check(
+            "pass"
+            if deck_summary["scaling_cards"] + deck_summary["poison_sources"] + deck_summary["energy_cards"] >= 2
+            else "borderline"
+            if deck_summary["scaling_cards"] + deck_summary["poison_sources"] + deck_summary["energy_cards"] >= 1
+            else "fail",
+            {
+                "scaling_cards": deck_summary["scaling_cards"],
+                "poison_sources": deck_summary["poison_sources"],
+                "energy_cards": deck_summary["energy_cards"],
+            },
+            "至少 2 点成长指标",
+            "没有成长手段时，Boss 往往会在中后段把你压死。",
+        ),
+        "draw": _build_check(
+            "pass" if deck_summary["draw_cards"] >= 2 else "borderline" if deck_summary["draw_cards"] >= 1 else "fail",
+            deck_summary["draw_cards"],
+            "至少 2 张稳定过牌",
+            "过牌保证关键回合能摸到防御和核心输出。",
+        ),
+        "vulnerable": _build_check(
+            "pass"
+            if deck_summary["vulnerable_sources"] >= 1
+            else "borderline"
+            if deck_summary["frontload_cards"] >= 7
+            else "fail",
+            deck_summary["vulnerable_sources"],
+            "至少 1 个易伤来源或很强的前台输出",
+            "易伤能明显抬高 Boss 战的伤害效率。",
+        ),
+        "potions": _build_check(
+            "pass" if deck_summary["potion_count"] >= 2 else "borderline" if deck_summary["potion_count"] >= 1 else "fail",
+            deck_summary["potion_count"],
+            "至少 2 瓶可用药水",
+            "药水是 Boss 战最稳定的临时补强。",
+        ),
+    }
+
+    status_counts = Counter(check["status"] for check in checks.values())
+    if status_counts["fail"] >= 3 or (
+        checks["hp"]["status"] == "fail"
+        and (checks["damage"]["status"] == "fail" or checks["block"]["status"] == "fail")
+    ):
+        recommendation = "NOT_READY"
+    elif status_counts["fail"] == 0 and status_counts["borderline"] <= 2:
+        recommendation = "READY"
+    else:
+        recommendation = "BORDERLINE"
+
+    return {
+        "recommendation": recommendation,
+        "deck_summary": _public_deck_summary(deck_summary),
+        "checks": checks,
+        "passed_checks": status_counts["pass"],
+        "borderline_checks": status_counts["borderline"],
+        "failed_checks": status_counts["fail"],
+    }
+
+
+def _shop_payload(state: dict[str, Any]) -> dict[str, Any]:
+    shop = state.get("shop")
+    return shop if isinstance(shop, dict) else {}
+
+
+def _rest_payload(state: dict[str, Any]) -> dict[str, Any]:
+    rest = state.get("rest")
+    return rest if isinstance(rest, dict) else {}
+
+
+def _extract_shop_cards(entries: Any) -> list[dict[str, Any]]:
+    cards = _extract_card_entries(entries)
+    if not isinstance(entries, list):
+        return cards
+
+    for card, raw_entry in zip(cards, entries):
+        if not isinstance(raw_entry, dict):
+            continue
+        card["price"] = _safe_int(raw_entry.get("price")) or 0
+        card["affordable"] = bool(raw_entry.get("affordable"))
+        card["stocked"] = raw_entry.get("stocked") is not False
+
+    return cards
+
+
+def _is_basic_strike_or_defend(card: dict[str, Any], meta: dict[str, Any]) -> bool:
+    name = str(card.get("name") or meta.get("name") or "").strip().lower()
+    return name in {"strike", "defend"}
+
+
+def _find_removal_candidates(
+    state: dict[str, Any],
+    cards_index: dict[str, Any],
+    deck_summary: dict[str, Any],
+) -> list[dict[str, Any]]:
+    run = _run_payload(state)
+    candidates: list[dict[str, Any]] = []
+    for entry in _extract_card_entries(run.get("deck")):
+        meta = _lookup_item_meta(cards_index, entry.get("card_id"))
+        profile = _card_profile(entry, meta)
+        rarity_key = _normalize_token(meta.get("rarity") or entry.get("rarity"))
+        type_key = _normalize_token(meta.get("type") or entry.get("type"))
+        duplicate_count = deck_summary["card_id_counts"].get(entry.get("card_id") or "", 0)
+        score = 0
+        reasons: list[str] = []
+
+        if type_key == "curse":
+            score += 40
+            reasons.append("诅咒是最高优先级删牌目标")
+        elif rarity_key == "basic":
+            score += 14
+            reasons.append("基础牌在 Act 2 往往边际收益偏低")
+
+        if _is_basic_strike_or_defend(entry, meta):
+            score += 10
+            reasons.append("Strike/Defend 常是最稳的删牌对象")
+
+        if duplicate_count >= 3:
+            score += 6
+            reasons.append("同名牌数量偏多")
+
+        if profile["aoe"] or profile["scaling"] or profile["draw_count"] > 0 or profile["weak"] or profile["vulnerable"]:
+            score -= 10
+            reasons.append("这张牌承担了功能位，不适合优先删除")
+
+        if score <= 0:
+            continue
+
+        candidates.append(
+            {
+                "card_id": entry.get("card_id"),
+                "name": profile["name"],
+                "remove_score": score,
+                "reasons": _dedupe_reasons(reasons, limit=3),
+            }
+        )
+
+    candidates.sort(key=lambda item: (-item["remove_score"], item["name"]))
+    return candidates[:5]
+
+
+def _evaluate_shop_removal(
+    state: dict[str, Any],
+    deck_summary: dict[str, Any],
+    cards_index: dict[str, Any],
+) -> dict[str, Any] | None:
+    shop = _shop_payload(state)
+    removal = shop.get("remove")
+    if not isinstance(removal, dict):
+        return None
+
+    available = bool(removal.get("available"))
+    used = bool(removal.get("used"))
+    affordable = bool(removal.get("affordable"))
+    price = _safe_int(removal.get("price")) or 0
+    candidates = _find_removal_candidates(state, cards_index, deck_summary)
+    score = 45
+    reasons: list[str] = []
+
+    if not available or used:
+        score = 0
+        reasons.append("删牌当前不可用")
+    else:
+        if affordable:
+            score += 6
+            reasons.append("当前金币足够删牌")
+        else:
+            score -= 30
+            reasons.append("当前金币不足以删牌")
+
+        if deck_summary["deck_size"] >= 18:
+            score += 8
+            reasons.append("牌组偏厚，删牌收益更高")
+
+        if candidates:
+            score += min(20, candidates[0]["remove_score"])
+            reasons.append(f"当前有明显低价值目标：{candidates[0]['name']}")
+        else:
+            score -= 8
+            reasons.append("当前牌组里没有特别差的删牌目标")
+
+        if price >= 100:
+            score -= 4
+            reasons.append("删牌价格偏高")
+
+    score = _clamp(score, 0, 100)
+    return {
+        "price": price,
+        "available": available,
+        "affordable": affordable,
+        "score": score,
+        "recommendation": "take" if score >= 68 else "consider" if score >= 55 else "skip",
+        "candidate_cards": candidates[:3],
+        "reasons": _dedupe_reasons(reasons),
+    }
+
+
+def _relic_profile(relic: dict[str, Any], meta: dict[str, Any]) -> dict[str, Any]:
+    description = str(meta.get("description") or relic.get("description") or "").lower()
+    rarity = str(meta.get("rarity") or relic.get("rarity") or "").strip()
+    return {
+        "name": relic.get("name") or meta.get("name") or "Unknown Relic",
+        "rarity": rarity or None,
+        "draw": "draw" in description,
+        "block": "block" in description or "dexterity" in description,
+        "frontload": "strength" in description or "vigor" in description or "damage" in description,
+        "scaling": "strength" in description or "dexterity" in description or "focus" in description or "poison" in description,
+        "potion": "potion" in description,
+        "gold": "gold" in description,
+        "combat_setup": "start each combat" in description or "at the start of each combat" in description,
+        "description": description,
+    }
+
+
+def _score_shop_relic(relic: dict[str, Any], deck_summary: dict[str, Any], profile: dict[str, Any]) -> tuple[int, list[str]]:
+    score = 58
+    reasons: list[str] = []
+    rarity_bonus = {
+        "commonrelic": 4,
+        "uncommonrelic": 8,
+        "rarerelic": 14,
+        "ancientrelic": 16,
+    }.get(_normalize_token(profile.get("rarity")), 6)
+    score += rarity_bonus
+
+    if profile["draw"] and deck_summary["draw_cards"] < 2:
+        score += 10
+        reasons.append("补强开局与过牌稳定性")
+    if profile["block"] and deck_summary["block_cards"] < 5:
+        score += 10
+        reasons.append("补强防御覆盖")
+    if profile["frontload"] and deck_summary["frontload_cards"] < 5:
+        score += 9
+        reasons.append("补强前台输出")
+    if profile["scaling"] and deck_summary["scaling_cards"] < 2:
+        score += 8
+        reasons.append("补强成长能力")
+    if profile["potion"] and deck_summary["potion_count"] < 2:
+        score += 6
+        reasons.append("提升药水上限或药水收益")
+    if profile["gold"] and deck_summary["floor"] < 30:
+        score += 4
+        reasons.append("仍有楼层可把经济收益转成强度")
+    if profile["combat_setup"]:
+        score += 4
+        reasons.append("稳定的每战即时收益")
+
+    return _clamp(score, 0, 100), _dedupe_reasons(reasons)
+
+
+def _find_upgrade_targets(state: dict[str, Any], cards_index: dict[str, Any]) -> list[dict[str, Any]]:
+    run = _run_payload(state)
+    targets: list[dict[str, Any]] = []
+    for entry in _extract_card_entries(run.get("deck")):
+        if entry.get("upgraded"):
+            continue
+
+        meta = _lookup_item_meta(cards_index, entry.get("card_id"))
+        upgrade = meta.get("upgrade")
+        if not isinstance(upgrade, dict) or not upgrade:
+            continue
+
+        profile = _card_profile(entry, meta)
+        score = 50
+        reasons: list[str] = []
+        rarity_key = _normalize_token(meta.get("rarity"))
+
+        if profile["aoe"]:
+            score += 14
+            reasons.append("升级后能明显改善群战")
+        if profile["scaling"]:
+            score += 12
+            reasons.append("升级能放大成长价值")
+        if profile["frontload"]:
+            score += 10
+            reasons.append("升级后能更快影响战局")
+        if profile["draw_count"] > 0 or profile["energy"]:
+            score += 6
+            reasons.append("升级会改善节奏或手感")
+        if rarity_key == "rare":
+            score += 6
+            reasons.append("高稀有度牌升级收益通常更高")
+        if rarity_key == "basic" and not (profile["weak"] or profile["vulnerable"]):
+            score -= 10
+            reasons.append("基础牌升级优先级偏低")
+
+        targets.append(
+            {
+                "card_id": entry.get("card_id"),
+                "name": profile["name"],
+                "upgrade_score": _clamp(score, 0, 100),
+                "reasons": _dedupe_reasons(reasons, limit=3),
+            }
+        )
+
+    targets.sort(key=lambda item: (-item["upgrade_score"], item["name"]))
+    return targets[:5]
+
+
+def _rest_option_kind(option: dict[str, Any]) -> str:
+    token = _normalize_token(f"{option.get('option_id', '')} {option.get('line', '')}")
+    if "rest" in token or "heal" in token or "sleep" in token:
+        return "rest"
+    if "smith" in token or "upgrade" in token:
+        return "smith"
+    if "dig" in token:
+        return "dig"
+    if "lift" in token:
+        return "lift"
+    if "recall" in token:
+        return "recall"
+    return "other"
+
+
+def _potion_profile(potion: dict[str, Any], meta: dict[str, Any]) -> dict[str, Any]:
+    description = str(
+        meta.get("description")
+        or potion.get("usage")
+        or potion.get("description")
+        or potion.get("line")
+        or ""
+    ).lower()
+    rarity = str(meta.get("rarity") or potion.get("rarity") or "").strip()
+    has_strength_down = "lose" in description and "strength" in description
+    return {
+        "name": potion.get("name") or meta.get("name") or "Unknown Potion",
+        "rarity": rarity or None,
+        "aoe": "all enemies" in description,
+        "block": "block" in description,
+        "draw": "draw" in description,
+        "strength": "strength" in description and not has_strength_down,
+        "dexterity": "dexterity" in description,
+        "weak": "weak" in description or has_strength_down,
+        "vulnerable": "vulnerable" in description,
+        "poison": "poison" in description,
+        "energy": "gain [energy" in description or "[energy:1]" in description,
+        "damage": "deal " in description,
+    }
+
+
+def _score_potion_value(profile: dict[str, Any], deck_summary: dict[str, Any]) -> tuple[int, list[str]]:
+    score = 50
+    reasons: list[str] = []
+    rarity_bonus = {
+        "common": 0,
+        "uncommon": 6,
+        "rare": 12,
+        "event": 4,
+    }.get(_normalize_token(profile.get("rarity")), 3)
+    score += rarity_bonus
+
+    if profile["aoe"] and deck_summary["aoe_cards"] == 0:
+        score += 16
+        reasons.append("补足当前缺的范围处理")
+    if profile["block"] and deck_summary["hp_ratio"] < 0.55:
+        score += 12
+        reasons.append("低血线时防御药水价值更高")
+    if profile["draw"] and deck_summary["draw_cards"] < 2:
+        score += 8
+        reasons.append("补强过牌稳定性")
+    if profile["strength"] and deck_summary["frontload_cards"] < 5:
+        score += 8
+        reasons.append("补强爆发输出")
+    if profile["dexterity"] and deck_summary["block_cards"] < 5:
+        score += 8
+        reasons.append("补强防御强度")
+    if profile["weak"] and deck_summary["weak_sources"] == 0:
+        score += 7
+        reasons.append("补减伤来源")
+    if profile["vulnerable"] and deck_summary["vulnerable_sources"] == 0:
+        score += 7
+        reasons.append("补易伤来源")
+    if profile["poison"] and deck_summary["scaling_cards"] < 2:
+        score += 6
+        reasons.append("补成长伤害")
+    if profile["energy"]:
+        score += 12
+        reasons.append("能量药水在关键战斗很值钱")
+    if profile["damage"] and deck_summary["frontload_cards"] < 5:
+        score += 6
+        reasons.append("补即时伤害")
+
+    return _clamp(score, 0, 100), _dedupe_reasons(reasons)
+
+
+def _evaluate_potions_for_state(state: dict[str, Any]) -> dict[str, Any]:
+    potions_index = _safe_collection_index("potions")
+    cards_index = _safe_collection_index("cards")
+    deck_summary = _summarize_deck(state, cards_index)
+    run = _run_payload(state)
+    shop = _shop_payload(state)
+    belt_entries = run.get("potions") if isinstance(run.get("potions"), list) else []
+    occupied_belt = [
+        entry
+        for entry in belt_entries
+        if isinstance(entry, dict) and (entry.get("occupied") is not False) and (entry.get("potion_id") or entry.get("name"))
+    ]
+    total_slots = len(belt_entries)
+    empty_slots = max(0, total_slots - len(occupied_belt))
+
+    current_potions: list[dict[str, Any]] = []
+    for entry in occupied_belt:
+        meta = _lookup_item_meta(potions_index, entry.get("potion_id"))
+        profile = _potion_profile(entry, meta)
+        keep_score, reasons = _score_potion_value(profile, deck_summary)
+        current_potions.append(
+            {
+                "index": _safe_int(entry.get("i")) or _safe_int(entry.get("index")) or 0,
+                "potion_id": entry.get("potion_id"),
+                "name": profile["name"],
+                "keep_score": keep_score,
+                "reasons": reasons,
+            }
+        )
+
+    current_potions.sort(key=lambda item: (item["keep_score"], item["index"]))
+    weakest_potion = current_potions[0] if current_potions else None
+
+    shop_potions: list[dict[str, Any]] = []
+    raw_shop_potions = shop.get("potions") if isinstance(shop.get("potions"), list) else []
+    for entry in raw_shop_potions:
+        if not isinstance(entry, dict):
+            continue
+
+        meta = _lookup_item_meta(potions_index, entry.get("potion_id"))
+        profile = _potion_profile(entry, meta)
+        buy_score, reasons = _score_potion_value(profile, deck_summary)
+        price = _safe_int(entry.get("price")) or 0
+        affordable = bool(entry.get("affordable"))
+        if not affordable:
+            buy_score -= 35
+            reasons.append("当前金币不足")
+        elif price <= 45:
+            buy_score += 3
+            reasons.append("价格较低")
+        elif price >= 70:
+            buy_score -= 6
+            reasons.append("价格偏高")
+
+        if empty_slots == 0:
+            buy_score -= 6
+            reasons.append("药水槽已满，需要替换现有药水")
+
+        shop_potions.append(
+            {
+                "option_index": _safe_int(entry.get("i")) or _safe_int(entry.get("index")) or 0,
+                "potion_id": entry.get("potion_id"),
+                "name": profile["name"],
+                "price": price,
+                "affordable": affordable,
+                "buy_score": _clamp(buy_score, 0, 100),
+                "recommendation": "buy" if buy_score >= 64 else "consider" if buy_score >= 54 else "skip",
+                "reasons": _dedupe_reasons(reasons),
+            }
+        )
+
+    shop_potions.sort(key=lambda item: (-item["buy_score"], item["price"], item["option_index"]))
+    best_shop_potion = next((item for item in shop_potions if item["affordable"]), None)
+    recommended_purchase: dict[str, Any] | None = None
+    if best_shop_potion is not None:
+        if empty_slots > 0 and best_shop_potion["buy_score"] >= 56:
+            recommended_purchase = {
+                "option_index": best_shop_potion["option_index"],
+                "potion_id": best_shop_potion["potion_id"],
+                "name": best_shop_potion["name"],
+                "replace_index": None,
+            }
+        elif weakest_potion is not None and best_shop_potion["buy_score"] >= weakest_potion["keep_score"] + 8:
+            recommended_purchase = {
+                "option_index": best_shop_potion["option_index"],
+                "potion_id": best_shop_potion["potion_id"],
+                "name": best_shop_potion["name"],
+                "replace_index": weakest_potion["index"],
+            }
+
+    return {
+        "deck_summary": _public_deck_summary(deck_summary),
+        "belt": {
+            "occupied_slots": len(occupied_belt),
+            "total_slots": total_slots,
+            "empty_slots": empty_slots,
+            "potions": current_potions,
+        },
+        "shop_potions": shop_potions,
+        "recommended_purchase": recommended_purchase,
+    }
+
+
+def _evaluate_shop_options_for_state(state: dict[str, Any]) -> dict[str, Any]:
+    shop = _shop_payload(state)
+    if not shop:
+        return {
+            "recommended_action": None,
+            "message": "当前状态没有商店库存可评估。",
+        }
+
+    cards_index = _safe_collection_index("cards")
+    relics_index = _safe_collection_index("relics")
+    deck_summary = _summarize_deck(state, cards_index)
+    removal = _evaluate_shop_removal(state, deck_summary, cards_index)
+    potion_analysis = _evaluate_potions_for_state(state)
+
+    evaluated_cards: list[dict[str, Any]] = []
+    for card in _extract_shop_cards(shop.get("cards")):
+        meta = _lookup_item_meta(cards_index, card.get("card_id"))
+        profile = _card_profile(card, meta)
+        score, reasons = _score_reward_card(card, deck_summary, profile)
+        price = _safe_int(card.get("price")) or 0
+        affordable = bool(card.get("affordable"))
+        stocked = card.get("stocked") is not False
+
+        if not stocked:
+            score -= 30
+            reasons.append("当前已售出")
+        elif not affordable:
+            score -= 35
+            reasons.append("当前金币不足")
+        else:
+            if price <= 60:
+                score += 4
+                reasons.append("价格较低")
+            elif price >= 130:
+                score -= 8
+                reasons.append("价格偏高")
+            elif price >= 100:
+                score -= 4
+                reasons.append("价格不低")
+
+            if removal and removal["affordable"] and removal["score"] >= 70 and price + removal["price"] > deck_summary["gold"]:
+                score -= 6
+                reasons.append("可能更该把金币留给删牌")
+
+        score = _clamp(score, 0, 100)
+        evaluated_cards.append(
+            {
+                "option_index": card["index"],
+                "card_id": card.get("card_id"),
+                "name": profile["name"],
+                "price": price,
+                "affordable": affordable,
+                "score": score,
+                "recommendation": "buy" if score >= 70 else "consider" if score >= 56 else "skip",
+                "reasons": _dedupe_reasons(reasons),
+            }
+        )
+
+    evaluated_relics: list[dict[str, Any]] = []
+    raw_relics = shop.get("relics") if isinstance(shop.get("relics"), list) else []
+    for relic in raw_relics:
+        if not isinstance(relic, dict):
+            continue
+
+        meta = _lookup_item_meta(relics_index, relic.get("relic_id"))
+        profile = _relic_profile(relic, meta)
+        score, reasons = _score_shop_relic(relic, deck_summary, profile)
+        price = _safe_int(relic.get("price")) or 0
+        affordable = bool(relic.get("affordable"))
+        stocked = relic.get("stocked") is not False
+
+        if not stocked:
+            score -= 30
+            reasons.append("当前已售出")
+        elif not affordable:
+            score -= 40
+            reasons.append("当前金币不足")
+        else:
+            if price <= 180:
+                score += 2
+                reasons.append("价格还算合理")
+            elif price >= 260:
+                score -= 6
+                reasons.append("价格偏高")
+
+        evaluated_relics.append(
+            {
+                "option_index": _safe_int(relic.get("i")) or _safe_int(relic.get("index")) or 0,
+                "relic_id": relic.get("relic_id"),
+                "name": profile["name"],
+                "price": price,
+                "affordable": affordable,
+                "score": _clamp(score, 0, 100),
+                "recommendation": "buy" if score >= 72 else "consider" if score >= 60 else "skip",
+                "reasons": _dedupe_reasons(reasons),
+            }
+        )
+
+    action_candidates: list[tuple[int, int, dict[str, Any]]] = []
+    if removal and removal["affordable"]:
+        action_candidates.append(
+            (
+                removal["score"],
+                3,
+                {
+                    "kind": "remove_card_at_shop",
+                    "score": removal["score"],
+                    "candidate_card": removal["candidate_cards"][0] if removal["candidate_cards"] else None,
+                },
+            )
+        )
+
+    for relic in evaluated_relics:
+        if relic["affordable"]:
+            action_candidates.append(
+                (
+                    relic["score"],
+                    4,
+                    {
+                        "kind": "buy_relic",
+                        "option_index": relic["option_index"],
+                        "item_id": relic["relic_id"],
+                        "name": relic["name"],
+                        "score": relic["score"],
+                    },
+                )
+            )
+
+    for card in evaluated_cards:
+        if card["affordable"]:
+            action_candidates.append(
+                (
+                    card["score"],
+                    2,
+                    {
+                        "kind": "buy_card",
+                        "option_index": card["option_index"],
+                        "item_id": card["card_id"],
+                        "name": card["name"],
+                        "score": card["score"],
+                    },
+                )
+            )
+
+    for potion in potion_analysis["shop_potions"]:
+        if potion["affordable"]:
+            action_candidates.append(
+                (
+                    potion["buy_score"],
+                    1,
+                    {
+                        "kind": "buy_potion",
+                        "option_index": potion["option_index"],
+                        "item_id": potion["potion_id"],
+                        "name": potion["name"],
+                        "score": potion["buy_score"],
+                    },
+                )
+            )
+
+    action_candidates.sort(key=lambda item: (-item[0], -item[1]))
+    recommended_action = action_candidates[0][2] if action_candidates and action_candidates[0][0] >= 56 else None
+
+    return {
+        "recommended_action": recommended_action,
+        "deck_summary": _public_deck_summary(deck_summary),
+        "remove": removal,
+        "cards": evaluated_cards,
+        "relics": evaluated_relics,
+        "potions": potion_analysis["shop_potions"],
+    }
+
+
+def _assess_rest_site_for_state(state: dict[str, Any]) -> dict[str, Any]:
+    rest = _rest_payload(state)
+    options = rest.get("options") if isinstance(rest.get("options"), list) else []
+    if not options:
+        return {
+            "best_index": None,
+            "options": [],
+            "message": "当前状态没有可评估的营火选项。",
+        }
+
+    cards_index = _safe_collection_index("cards")
+    deck_summary = _summarize_deck(state, cards_index)
+    elite_risk = _assess_elite_risk_for_state(state)
+    boss_readiness = _check_boss_readiness_for_state(state)
+    upgrade_targets = _find_upgrade_targets(state, cards_index)
+    evaluated_options: list[dict[str, Any]] = []
+
+    for option in options:
+        if not isinstance(option, dict):
+            continue
+
+        enabled = option.get("enabled") is not False
+        kind = _rest_option_kind(option)
+        score = 50
+        reasons: list[str] = []
+
+        if not enabled:
+            score = 0
+            reasons.append("当前不可选")
+        elif kind == "rest":
+            if deck_summary["hp_ratio"] < 0.45 or deck_summary["current_hp"] < 30:
+                score += 25
+                reasons.append("当前血线偏低，优先补血")
+            elif deck_summary["hp_ratio"] < 0.6:
+                score += 12
+                reasons.append("血量不算安全")
+            else:
+                score -= 4
+                reasons.append("血量尚可，补血收益下降")
+
+            if boss_readiness["checks"]["hp"]["status"] == "fail":
+                score += 12
+                reasons.append("Boss readiness 的血量检查未过")
+            if elite_risk["recommendation"] != "TAKE" and deck_summary["hp_ratio"] < 0.6:
+                score += 8
+                reasons.append("近期精英风险偏高")
+
+        elif kind == "smith":
+            if deck_summary["hp_ratio"] >= 0.65:
+                score += 10
+                reasons.append("血量足够支持贪升级")
+            elif deck_summary["hp_ratio"] < 0.5:
+                score -= 18
+                reasons.append("血量太低，不适合继续贪升级")
+
+            if upgrade_targets:
+                score += 8 + min(8, len(upgrade_targets) * 2)
+                reasons.append(f"当前有高价值升级目标：{upgrade_targets[0]['name']}")
+            else:
+                score -= 10
+                reasons.append("当前缺少特别值钱的升级目标")
+
+            if boss_readiness["recommendation"] == "READY":
+                score += 6
+                reasons.append("整体 readiness 尚可，可以换更强上限")
+
+        elif kind == "dig":
+            if deck_summary["hp_ratio"] >= 0.65:
+                score += 8
+                reasons.append("血量允许拿长期收益")
+            else:
+                score -= 8
+                reasons.append("当前血量不适合贪 relic")
+
+        elif kind == "lift":
+            if deck_summary["hp_ratio"] >= 0.65:
+                score += 7
+                reasons.append("血量允许拿长期强度")
+            else:
+                score -= 7
+                reasons.append("当前血量不适合贪力量")
+            if deck_summary["frontload_cards"] < 5:
+                score += 5
+                reasons.append("当前牌组仍缺前台输出")
+
+        elif kind == "recall":
+            if deck_summary["hp_ratio"] >= 0.55:
+                score += 4
+                reasons.append("血量尚可，可以承担 key 成本")
+            else:
+                score -= 10
+                reasons.append("当前血量不适合回忆拿 key")
+
+        evaluated_options.append(
+            {
+                "index": _safe_int(option.get("i")) or _safe_int(option.get("index")) or 0,
+                "option_id": option.get("option_id"),
+                "kind": kind,
+                "line": option.get("line"),
+                "score": _clamp(score, 0, 100),
+                "recommendation": "take" if score >= 68 else "consider" if score >= 56 else "skip",
+                "reasons": _dedupe_reasons(reasons),
+            }
+        )
+
+    best_option = max(evaluated_options, key=lambda item: (item["score"], -(item["index"] or 0)))
+    return {
+        "best_index": best_option["index"],
+        "best_option_id": best_option.get("option_id"),
+        "deck_summary": _public_deck_summary(deck_summary),
+        "upgrade_targets": upgrade_targets[:3],
+        "options": evaluated_options,
+    }
+
+
 def create_server(client: Sts2Client | None = None, tool_profile: str | None = None) -> FastMCP:
     sts2 = client or Sts2Client()
     knowledge = Sts2KnowledgeBase()
@@ -409,15 +1894,7 @@ def create_server(client: Sts2Client | None = None, tool_profile: str | None = N
 
     def _agent_state() -> dict[str, Any]:
         state = sts2.get_state()
-        agent_view = state.get("agent_view")
-        if isinstance(agent_view, dict):
-            if "available_actions" not in agent_view and isinstance(agent_view.get("actions"), list):
-                return {
-                    **agent_view,
-                    "available_actions": agent_view["actions"],
-                }
-            return agent_view
-        return state
+        return _build_agent_state_payload(state, knowledge)
 
     def _is_actionable_state(state: dict[str, Any]) -> bool:
         actions = state.get("available_actions")
@@ -670,6 +2147,40 @@ def create_server(client: Sts2Client | None = None, tool_profile: str | None = N
             )
         except (KeyError, RuntimeError, TypeError) as exc:
             return _build_game_data_tool_error(collection=collection, exc=exc)
+
+    @mcp.tool
+    def evaluate_card_rewards() -> dict[str, Any]:
+        """Score card reward options against your current deck composition.
+
+        Returns each reward card with a score (0-100) and reasons for/against picking it.
+        Higher score = better fit for the current deck.
+        """
+        return _evaluate_card_rewards_for_state(_build_agent_state_payload(sts2.get_state(), knowledge))
+
+    @mcp.tool
+    def assess_elite_risk() -> dict[str, Any]:
+        """Assess whether to take an elite fight based on current HP, deck, and potions."""
+        return _assess_elite_risk_for_state(_build_agent_state_payload(sts2.get_state(), knowledge))
+
+    @mcp.tool
+    def check_boss_readiness() -> dict[str, Any]:
+        """Check whether the current deck, HP, and potions are ready for the next boss fight."""
+        return _check_boss_readiness_for_state(_build_agent_state_payload(sts2.get_state(), knowledge))
+
+    @mcp.tool
+    def evaluate_shop_options() -> dict[str, Any]:
+        """Score shop cards, relics, potions, and card removal against the current run state."""
+        return _evaluate_shop_options_for_state(_build_agent_state_payload(sts2.get_state(), knowledge))
+
+    @mcp.tool
+    def assess_rest_site() -> dict[str, Any]:
+        """Score rest-site options using HP, upgrade targets, and upcoming risk signals."""
+        return _assess_rest_site_for_state(_build_agent_state_payload(sts2.get_state(), knowledge))
+
+    @mcp.tool
+    def evaluate_potions() -> dict[str, Any]:
+        """Evaluate current belt potions and any visible shop potions, including replacement suggestions."""
+        return _evaluate_potions_for_state(_build_agent_state_payload(sts2.get_state(), knowledge))
 
     @mcp.tool
     def wait_for_event(event_names: str = "", timeout_seconds: float = 20.0) -> dict[str, Any]:

--- a/mcp_server/src/sts2_mcp/server.py
+++ b/mcp_server/src/sts2_mcp/server.py
@@ -13,6 +13,7 @@ from fastmcp import FastMCP
 from .client import Sts2Client
 from .handoff import Sts2HandoffService
 from .knowledge import Sts2KnowledgeBase
+from .run_logger import Sts2RunLogger
 
 ToolHandler = Callable[..., dict[str, Any]]
 
@@ -383,23 +384,53 @@ def _register_option_target_tool(mcp: FastMCP, name: str, description: str, hand
     mcp.tool(name=name, description=description)(tool)
 
 
-def _register_legacy_action_tools(mcp: FastMCP, sts2: Sts2Client) -> None:
+def _register_legacy_action_tools(
+    mcp: FastMCP,
+    action_runner: Callable[..., dict[str, Any]],
+) -> None:
     for spec in _LEGACY_ACTION_TOOLS:
-        handler = getattr(sts2, spec.name)
         if spec.kind == "no_args":
-            _register_no_arg_tool(mcp, spec.name, spec.description, handler)
+            _register_no_arg_tool(
+                mcp,
+                spec.name,
+                spec.description,
+                lambda spec_name=spec.name: action_runner(spec_name),
+            )
             continue
 
         if spec.kind == "option_index":
-            _register_option_index_tool(mcp, spec.name, spec.description, handler)
+            _register_option_index_tool(
+                mcp,
+                spec.name,
+                spec.description,
+                lambda option_index, spec_name=spec.name: action_runner(spec_name, option_index=option_index),
+            )
             continue
 
         if spec.kind == "card_target":
-            _register_card_target_tool(mcp, spec.name, spec.description, handler)
+            _register_card_target_tool(
+                mcp,
+                spec.name,
+                spec.description,
+                lambda card_index, target_index=None, spec_name=spec.name: action_runner(
+                    spec_name,
+                    card_index=card_index,
+                    target_index=target_index,
+                ),
+            )
             continue
 
         if spec.kind == "option_target":
-            _register_option_target_tool(mcp, spec.name, spec.description, handler)
+            _register_option_target_tool(
+                mcp,
+                spec.name,
+                spec.description,
+                lambda option_index, target_index=None, spec_name=spec.name: action_runner(
+                    spec_name,
+                    option_index=option_index,
+                    target_index=target_index,
+                ),
+            )
             continue
 
         raise RuntimeError(f"Unsupported action tool kind: {spec.kind}")
@@ -1889,12 +1920,71 @@ def create_server(client: Sts2Client | None = None, tool_profile: str | None = N
     sts2 = client or Sts2Client()
     knowledge = Sts2KnowledgeBase()
     handoff = Sts2HandoffService(knowledge)
+    run_logger = Sts2RunLogger(knowledge.root_dir)
     profile = _normalize_tool_profile(tool_profile)
     mcp = FastMCP("STS2 AI Agent")
 
-    def _agent_state() -> dict[str, Any]:
+    def _record_state(
+        state: dict[str, Any],
+        *,
+        reason: str,
+        event: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        run_logger.record_state(state, reason=reason, event=event)
+        return state
+
+    def _raw_state(reason: str) -> dict[str, Any]:
         state = sts2.get_state()
+        return _record_state(state, reason=reason)
+
+    def _agent_state(reason: str = "get_game_state") -> dict[str, Any]:
+        state = _raw_state(reason)
         return _build_agent_state_payload(state, knowledge)
+
+    def _execute_logged_action(
+        action: str,
+        *,
+        card_index: int | None = None,
+        target_index: int | None = None,
+        option_index: int | None = None,
+        command: str | None = None,
+        client_context: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        params = {
+            "card_index": card_index,
+            "target_index": target_index,
+            "option_index": option_index,
+            "command": command,
+        }
+        try:
+            response = sts2.execute_action(
+                action,
+                card_index=card_index,
+                target_index=target_index,
+                option_index=option_index,
+                command=command,
+                client_context=client_context,
+            )
+        except Exception as exc:
+            run_logger.record_action(
+                action=action,
+                params=params,
+                client_context=client_context,
+                error=exc,
+            )
+            raise
+
+        run_logger.record_action(
+            action=action,
+            params=params,
+            response=response,
+            client_context=client_context,
+        )
+        post_state = response.get("state")
+        if isinstance(post_state, dict):
+            run_logger.record_action_state(action, post_state)
+
+        return response
 
     def _is_actionable_state(state: dict[str, Any]) -> bool:
         actions = state.get("available_actions")
@@ -1919,6 +2009,7 @@ def create_server(client: Sts2Client | None = None, tool_profile: str | None = N
 
         state = sts2.get_state()
         if _is_actionable_state(state):
+            _record_state(state, reason="wait_until_actionable")
             return {
                 "matched": False,
                 "event": None,
@@ -1957,6 +2048,8 @@ def create_server(client: Sts2Client | None = None, tool_profile: str | None = N
                 if signature != baseline_signature:
                     break
 
+        _record_state(state, reason="wait_until_actionable", event=event)
+
         return {
             "matched": event is not None,
             "event": event,
@@ -1974,12 +2067,12 @@ def create_server(client: Sts2Client | None = None, tool_profile: str | None = N
     @mcp.tool
     def get_game_state() -> dict[str, Any]:
         """Read the compact agent-facing game state snapshot."""
-        return _agent_state()
+        return _agent_state("get_game_state")
 
     @mcp.tool
     def get_raw_game_state() -> dict[str, Any]:
         """Read the full raw `/state` snapshot for debugging or schema inspection."""
-        return sts2.get_state()
+        return _raw_state("get_raw_game_state")
 
     @mcp.tool
     def get_available_actions() -> list[dict[str, Any]]:
@@ -1990,7 +2083,7 @@ def create_server(client: Sts2Client | None = None, tool_profile: str | None = N
         @mcp.tool
         def get_planner_context(planner_note: str | None = None) -> dict[str, Any]:
             """Build a planner-focused snapshot with route branches and linked event knowledge."""
-            return knowledge.build_planner_context(sts2.get_state(), planner_note=planner_note)
+            return knowledge.build_planner_context(_raw_state("get_planner_context"), planner_note=planner_note)
 
         @mcp.tool
         def create_planner_handoff(
@@ -1999,7 +2092,7 @@ def create_server(client: Sts2Client | None = None, tool_profile: str | None = N
         ) -> dict[str, Any]:
             """Build a clean planner-agent packet for route, reward, event, and shop decisions."""
             return handoff.create_planner_handoff(
-                sts2.get_state(),
+                _raw_state("create_planner_handoff"),
                 planning_focus=planning_focus,
                 previous_combat_summary=previous_combat_summary,
             )
@@ -2011,7 +2104,7 @@ def create_server(client: Sts2Client | None = None, tool_profile: str | None = N
         ) -> dict[str, Any]:
             """Build a combat-focused snapshot and link it to the canonical combat knowledge entry."""
             return knowledge.build_combat_context(
-                sts2.get_state(),
+                _raw_state("get_combat_context"),
                 planner_note=planner_note,
                 include_knowledge=include_knowledge,
             )
@@ -2023,7 +2116,7 @@ def create_server(client: Sts2Client | None = None, tool_profile: str | None = N
         ) -> dict[str, Any]:
             """Build a clean combat-agent packet with linked combat knowledge and planner guidance."""
             return handoff.create_combat_handoff(
-                sts2.get_state(),
+                _raw_state("create_combat_handoff"),
                 planner_message=planner_message,
                 combat_objective=combat_objective,
             )
@@ -2051,7 +2144,7 @@ def create_server(client: Sts2Client | None = None, tool_profile: str | None = N
         def append_combat_knowledge(note: str, section: str = "observations") -> dict[str, Any]:
             """Append a note to the active combat knowledge file."""
             return knowledge.append_combat_note(
-                sts2.get_state(),
+                _raw_state("append_combat_knowledge"),
                 note=note,
                 section=section,
             )
@@ -2064,7 +2157,7 @@ def create_server(client: Sts2Client | None = None, tool_profile: str | None = N
         ) -> dict[str, Any]:
             """Append a note to the active event knowledge file."""
             return knowledge.append_event_note(
-                sts2.get_state(),
+                _raw_state("append_event_knowledge"),
                 note=note,
                 section=section,
                 option_index=option_index,
@@ -2131,7 +2224,7 @@ def create_server(client: Sts2Client | None = None, tool_profile: str | None = N
         Recommended for most queries to save tokens and reduce uncertainty.
         """
         # Auto-detect current scene from game state
-        state = sts2.get_state()
+        state = _raw_state("get_relevant_game_data")
         screen = state.get("screen", "")
         scene = _detect_scene_from_screen(screen)
         try:
@@ -2155,32 +2248,32 @@ def create_server(client: Sts2Client | None = None, tool_profile: str | None = N
         Returns each reward card with a score (0-100) and reasons for/against picking it.
         Higher score = better fit for the current deck.
         """
-        return _evaluate_card_rewards_for_state(_build_agent_state_payload(sts2.get_state(), knowledge))
+        return _evaluate_card_rewards_for_state(_build_agent_state_payload(_raw_state("evaluate_card_rewards"), knowledge))
 
     @mcp.tool
     def assess_elite_risk() -> dict[str, Any]:
         """Assess whether to take an elite fight based on current HP, deck, and potions."""
-        return _assess_elite_risk_for_state(_build_agent_state_payload(sts2.get_state(), knowledge))
+        return _assess_elite_risk_for_state(_build_agent_state_payload(_raw_state("assess_elite_risk"), knowledge))
 
     @mcp.tool
     def check_boss_readiness() -> dict[str, Any]:
         """Check whether the current deck, HP, and potions are ready for the next boss fight."""
-        return _check_boss_readiness_for_state(_build_agent_state_payload(sts2.get_state(), knowledge))
+        return _check_boss_readiness_for_state(_build_agent_state_payload(_raw_state("check_boss_readiness"), knowledge))
 
     @mcp.tool
     def evaluate_shop_options() -> dict[str, Any]:
         """Score shop cards, relics, potions, and card removal against the current run state."""
-        return _evaluate_shop_options_for_state(_build_agent_state_payload(sts2.get_state(), knowledge))
+        return _evaluate_shop_options_for_state(_build_agent_state_payload(_raw_state("evaluate_shop_options"), knowledge))
 
     @mcp.tool
     def assess_rest_site() -> dict[str, Any]:
         """Score rest-site options using HP, upgrade targets, and upcoming risk signals."""
-        return _assess_rest_site_for_state(_build_agent_state_payload(sts2.get_state(), knowledge))
+        return _assess_rest_site_for_state(_build_agent_state_payload(_raw_state("assess_rest_site"), knowledge))
 
     @mcp.tool
     def evaluate_potions() -> dict[str, Any]:
         """Evaluate current belt potions and any visible shop potions, including replacement suggestions."""
-        return _evaluate_potions_for_state(_build_agent_state_payload(sts2.get_state(), knowledge))
+        return _evaluate_potions_for_state(_build_agent_state_payload(_raw_state("evaluate_potions"), knowledge))
 
     @mcp.tool
     def wait_for_event(event_names: str = "", timeout_seconds: float = 20.0) -> dict[str, Any]:
@@ -2257,7 +2350,7 @@ def create_server(client: Sts2Client | None = None, tool_profile: str | None = N
         if normalized == "run_console_command":
             raise RuntimeError("run_console_command is gated separately and must use its own tool when enabled.")
 
-        return sts2.execute_action(
+        return _execute_logged_action(
             normalized,
             card_index=card_index,
             target_index=target_index,
@@ -2270,13 +2363,32 @@ def create_server(client: Sts2Client | None = None, tool_profile: str | None = N
         )
 
     if profile == "full":
-        _register_legacy_action_tools(mcp, sts2)
+        _register_legacy_action_tools(
+            mcp,
+            lambda action_name, **params: _execute_logged_action(
+                action_name,
+                **params,
+                client_context={
+                    "source": "mcp",
+                    "tool_name": action_name,
+                    "tool_profile": profile,
+                },
+            ),
+        )
 
     if _debug_tools_enabled():
         @mcp.tool
         def run_console_command(command: str) -> dict[str, Any]:
             """Run a game dev-console command for local validation or debugging."""
-            return sts2.run_console_command(command=command)
+            return _execute_logged_action(
+                "run_console_command",
+                command=command,
+                client_context={
+                    "source": "mcp",
+                    "tool_name": "run_console_command",
+                    "tool_profile": profile,
+                },
+            )
 
     return mcp
 

--- a/mcp_server/src/sts2_mcp/server.py
+++ b/mcp_server/src/sts2_mcp/server.py
@@ -479,9 +479,15 @@ def _compute_combat_analysis(state: dict[str, Any]) -> dict[str, Any]:
     for card in hand:
         card_id = card.get("card_id", "")
         static = _lookup_game_data_item(index=card_data_index, item_id=card_id)
+
+        # Prefer C#-computed values (from mod) over static data + Python calculation
+        cs_dmg = card.get("dmg") or card.get("computed_damage")
+        cs_blk = card.get("blk") or card.get("computed_block")
+        cs_hits = card.get("hits") or card.get("hit_count")
+
         base_dmg = (static or {}).get("damage") if isinstance(static, dict) else None
         base_blk = (static or {}).get("block") if isinstance(static, dict) else None
-        hit_count = (static or {}).get("hit_count") if isinstance(static, dict) else None
+        hit_count = cs_hits or ((static or {}).get("hit_count") if isinstance(static, dict) else None)
         card_cost = card.get("energy_cost", 0)
         is_playable = card.get("playable", False)
 
@@ -489,18 +495,25 @@ def _compute_combat_analysis(state: dict[str, Any]) -> dict[str, Any]:
         computed_block = None
         damage_per_energy = None
 
-        if base_dmg is not None:
-            # For targeted cards, compute vs first alive vulnerable enemy; otherwise use non-vulnerable
+        if cs_dmg is not None:
+            # Use C#-computed value directly (already accounts for powers)
+            computed_damage = int(cs_dmg) * max(1, int(hit_count or 1))
+            if card_cost and card_cost > 0:
+                damage_per_energy = round(computed_damage / card_cost, 1)
+        elif base_dmg is not None:
+            # Fallback: compute from static data + Python power calculation
             any_vulnerable = any(e["vulnerable"] for e in enemies)
             computed_damage = _compute_card_damage(
                 base_dmg, strength, is_weak,
                 target_vulnerable=any_vulnerable,
-                hits=hit_count or 1,
+                hits=int(hit_count or 1),
             )
             if card_cost and card_cost > 0:
                 damage_per_energy = round(computed_damage / card_cost, 1)
 
-        if base_blk is not None:
+        if cs_blk is not None:
+            computed_block = int(cs_blk)
+        elif base_blk is not None:
             computed_block = _compute_card_block(base_blk, dexterity, is_frail)
 
         entry: dict[str, Any] = {

--- a/mcp_server/tests/test_game_data_tools.py
+++ b/mcp_server/tests/test_game_data_tools.py
@@ -5,17 +5,27 @@ import unittest
 from unittest.mock import patch
 
 import sts2_mcp.server as server_module
-from sts2_mcp.server import _SCENE_FIELD_SETS, create_server, get_game_data_items_fields
+from sts2_mcp.knowledge import Sts2KnowledgeBase
+from sts2_mcp.server import (
+    _SCENE_FIELD_SETS,
+    _build_agent_state_payload,
+    _card_profile,
+    create_server,
+    get_game_data_items_fields,
+)
 
 
 class DummyClient:
-    def __init__(self, screen: str = "MAIN_MENU") -> None:
+    def __init__(self, screen: str = "MAIN_MENU", state: dict | None = None) -> None:
         self._screen = screen
+        self._state = state
 
     def get_health(self) -> dict:
         return {"ok": True}
 
     def get_state(self) -> dict:
+        if self._state is not None:
+            return self._state
         return {"screen": self._screen, "available_actions": []}
 
     def get_available_actions(self) -> list[dict]:
@@ -213,6 +223,468 @@ class GameDataToolsTests(unittest.TestCase):
             },
         )
         self.assertNotIn("title", result["MYSTERY"])
+
+    def test_build_agent_state_payload_adds_route_options_to_compact_map(self) -> None:
+        state = {
+            "screen": "MAP",
+            "available_actions": ["choose_map_node"],
+            "map": {
+                "nodes": [
+                    {
+                        "row": 0,
+                        "col": 0,
+                        "node_type": "Start",
+                        "children": [{"row": 1, "col": 0}],
+                    },
+                    {
+                        "row": 1,
+                        "col": 0,
+                        "node_type": "Elite",
+                        "children": [{"row": 2, "col": 0}],
+                    },
+                    {
+                        "row": 2,
+                        "col": 0,
+                        "node_type": "Rest",
+                        "children": [],
+                    },
+                ],
+                "available_nodes": [
+                    {"index": 0, "row": 0, "col": 0, "node_type": "Start", "state": "Travelable"},
+                ],
+            },
+            "agent_view": {
+                "screen": "MAP",
+                "actions": ["choose_map_node"],
+                "map": {
+                    "current": None,
+                    "options": [{"i": 0, "line": "Start (0,0)"}],
+                },
+            },
+        }
+
+        result = _build_agent_state_payload(state, Sts2KnowledgeBase())
+
+        self.assertEqual(result["available_actions"], ["choose_map_node"])
+        self.assertIn("route_options", result["map"])
+        self.assertEqual(len(result["map"]["route_options"]), 1)
+        self.assertEqual(
+            result["map"]["route_options"][0]["paths"][0]["node_types"],
+            ["Start", "Elite", "Rest"],
+        )
+
+    def test_build_agent_state_payload_keeps_existing_route_options(self) -> None:
+        state = {
+            "screen": "MAP",
+            "map": {
+                "nodes": [],
+                "available_nodes": [],
+            },
+            "agent_view": {
+                "screen": "MAP",
+                "available_actions": ["choose_map_node"],
+                "map": {
+                    "route_options": [{"start_node": {"row": 1, "col": 1}, "path_count": 1, "paths": []}],
+                },
+            },
+        }
+
+        result = _build_agent_state_payload(state, Sts2KnowledgeBase())
+
+        self.assertEqual(
+            result["map"]["route_options"],
+            [{"start_node": {"row": 1, "col": 1}, "path_count": 1, "paths": []}],
+        )
+
+    def test_build_agent_state_payload_backfills_missing_sections_from_raw_state(self) -> None:
+        state = {
+            "screen": "COMBAT_REWARD",
+            "available_actions": ["choose_reward_card"],
+            "run": {
+                "floor": 9,
+                "current_hp": 38,
+                "max_hp": 70,
+            },
+            "reward": {
+                "cards": [{"i": 0, "card_id": "BACKFLIP", "name": "Backflip"}],
+            },
+            "agent_view": {
+                "screen": "COMBAT_REWARD",
+                "actions": ["choose_reward_card"],
+            },
+        }
+
+        result = _build_agent_state_payload(state, Sts2KnowledgeBase())
+
+        self.assertEqual(result["available_actions"], ["choose_reward_card"])
+        self.assertEqual(result["run"]["current_hp"], 38)
+        self.assertEqual(result["reward"]["cards"][0]["card_id"], "BACKFLIP")
+
+    def test_evaluate_card_rewards_prioritizes_missing_aoe_in_act2(self) -> None:
+        state = {
+            "screen": "COMBAT_REWARD",
+            "agent_view": {
+                "screen": "COMBAT_REWARD",
+                "run": {
+                    "floor": 22,
+                    "current_hp": 42,
+                    "max_hp": 70,
+                    "gold": 142,
+                    "max_energy": 3,
+                    "deck": [
+                        {"card_id": "STRIKE_SILENT", "name": "Strike", "count": 5, "energy_cost": 1, "rules_text": "Deal 6 damage."},
+                        {"card_id": "DEFEND_SILENT", "name": "Defend", "count": 5, "energy_cost": 1, "rules_text": "Gain 5 Block."},
+                        {"card_id": "BACKFLIP", "name": "Backflip", "count": 2, "energy_cost": 1, "rules_text": "Gain 5 Block.\nDraw 2 cards."},
+                        {"card_id": "FOOTWORK", "name": "Footwork", "count": 2, "energy_cost": 1, "rules_text": "Gain 2 Dexterity."},
+                        {"card_id": "PREDATOR", "name": "Predator", "count": 1, "energy_cost": 2, "rules_text": "Deal 15 damage. Draw 2 cards next turn."},
+                    ],
+                    "potions": [
+                        {"i": 0, "potion_id": "ASHWATER", "name": "Ashwater", "occupied": True},
+                    ],
+                    "relic_items": [{"i": 0, "relic_id": "AKABEKO", "name": "Akabeko"}],
+                },
+                "reward": {
+                    "pending_card_choice": True,
+                    "cards": [
+                        {"i": 0, "card_id": "BACKFLIP", "name": "Backflip", "energy_cost": 1, "rules_text": "Gain 5 Block.\nDraw 2 cards."},
+                        {"i": 1, "card_id": "DAGGER_SPRAY", "name": "Dagger Spray", "energy_cost": 1, "rules_text": "Deal 4 damage to ALL enemies twice."},
+                        {"i": 2, "card_id": "FOOTWORK", "name": "Footwork", "energy_cost": 1, "rules_text": "Gain 2 Dexterity."},
+                    ],
+                },
+            },
+        }
+        client = DummyClient(state=state)
+        server = create_server(client=client)
+        tool = asyncio.run(server.get_tool("evaluate_card_rewards"))
+
+        result = tool.fn()
+
+        self.assertEqual(result["best_index"], 1)
+        self.assertEqual(result["reward_cards"][1]["card_id"], "DAGGER_SPRAY")
+        self.assertEqual(result["reward_cards"][1]["recommendation"], "take")
+        self.assertGreater(result["reward_cards"][1]["score"], result["reward_cards"][0]["score"])
+
+    def test_evaluate_card_rewards_backfills_raw_run_and_reward_sections(self) -> None:
+        state = {
+            "screen": "COMBAT_REWARD",
+            "available_actions": ["choose_reward_card"],
+            "run": {
+                "floor": 20,
+                "current_hp": 41,
+                "max_hp": 70,
+                "gold": 120,
+                "max_energy": 3,
+                "deck": [
+                    {"card_id": "STRIKE_SILENT", "name": "Strike", "count": 5, "energy_cost": 1},
+                    {"card_id": "DEFEND_SILENT", "name": "Defend", "count": 5, "energy_cost": 1},
+                ],
+                "potions": [],
+            },
+            "reward": {
+                "cards": [
+                    {"i": 0, "card_id": "BACKFLIP", "name": "Backflip"},
+                    {"i": 1, "card_id": "DAGGER_SPRAY", "name": "Dagger Spray"},
+                ],
+            },
+            "agent_view": {
+                "screen": "COMBAT_REWARD",
+                "actions": ["choose_reward_card"],
+            },
+        }
+        client = DummyClient(state=state)
+        server = create_server(client=client)
+        tool = asyncio.run(server.get_tool("evaluate_card_rewards"))
+
+        result = tool.fn()
+
+        self.assertEqual(result["best_index"], 1)
+        self.assertEqual(result["reward_cards"][1]["card_id"], "DAGGER_SPRAY")
+
+    def test_assess_elite_risk_flags_low_hp_weak_deck_as_avoid(self) -> None:
+        state = {
+            "screen": "MAP",
+            "map": {
+                "nodes": [
+                    {"row": 1, "col": 0, "node_type": "Monster", "children": [{"row": 2, "col": 0}]},
+                    {"row": 2, "col": 0, "node_type": "Elite", "children": [{"row": 3, "col": 0}]},
+                    {"row": 3, "col": 0, "node_type": "Rest", "children": []},
+                ],
+                "available_nodes": [
+                    {"index": 0, "row": 1, "col": 0, "node_type": "Monster", "state": "Travelable"},
+                ],
+            },
+            "agent_view": {
+                "screen": "MAP",
+                "run": {
+                    "floor": 21,
+                    "current_hp": 18,
+                    "max_hp": 70,
+                    "gold": 96,
+                    "max_energy": 3,
+                    "deck": [
+                        {"card_id": "STRIKE_SILENT", "name": "Strike", "count": 5, "energy_cost": 1, "rules_text": "Deal 6 damage."},
+                        {"card_id": "DEFEND_SILENT", "name": "Defend", "count": 5, "energy_cost": 1, "rules_text": "Gain 5 Block."},
+                        {"card_id": "SURVIVOR", "name": "Survivor", "count": 1, "energy_cost": 1, "rules_text": "Gain 8 Block. Discard 1 card."},
+                        {"card_id": "NEUTRALIZE", "name": "Neutralize", "count": 1, "energy_cost": 0, "rules_text": "Deal 3 damage. Apply 1 Weak."},
+                    ],
+                    "potions": [],
+                    "relic_items": [],
+                },
+                "map": {
+                    "current": None,
+                    "options": [{"i": 0, "row": 1, "col": 0, "type": "Monster", "line": "Monster (1,0)"}],
+                },
+            },
+        }
+        client = DummyClient(state=state)
+        server = create_server(client=client)
+        tool = asyncio.run(server.get_tool("assess_elite_risk"))
+
+        result = tool.fn()
+
+        self.assertEqual(result["recommendation"], "AVOID")
+        self.assertGreaterEqual(result["risk_score"], 66)
+        self.assertIn("当前血量过低", result["factors"]["negative"])
+
+    def test_assess_elite_risk_parses_hp_summary_when_numeric_hp_missing(self) -> None:
+        state = {
+            "screen": "MAP",
+            "agent_view": {
+                "screen": "MAP",
+                "run": {
+                    "floor": 21,
+                    "hp": "18/72",
+                    "gold": 90,
+                    "max_energy": 3,
+                    "deck": [
+                        {"card_id": "STRIKE_SILENT", "name": "Strike", "count": 5},
+                        {"card_id": "DEFEND_SILENT", "name": "Defend", "count": 5},
+                    ],
+                    "potions": [],
+                },
+                "map": {
+                    "route_options": [
+                        {
+                            "start_node": {"index": 0, "row": 1, "col": 0, "node_type": "Monster"},
+                            "path_count": 1,
+                            "paths": [{"node_types": ["Monster", "Elite", "Rest"]}],
+                        },
+                    ],
+                },
+            },
+        }
+        client = DummyClient(state=state)
+        server = create_server(client=client)
+        tool = asyncio.run(server.get_tool("assess_elite_risk"))
+
+        result = tool.fn()
+
+        self.assertAlmostEqual(result["hp_ratio"], 0.25, places=2)
+        self.assertEqual(result["deck_summary"]["current_hp"], 18)
+
+    def test_check_boss_readiness_reports_missing_core_checks(self) -> None:
+        state = {
+            "screen": "MAP",
+            "agent_view": {
+                "screen": "MAP",
+                "run": {
+                    "floor": 16,
+                    "current_hp": 24,
+                    "max_hp": 72,
+                    "gold": 88,
+                    "max_energy": 3,
+                    "deck": [
+                        {"card_id": "STRIKE_SILENT", "name": "Strike", "count": 5, "energy_cost": 1, "rules_text": "Deal 6 damage."},
+                        {"card_id": "DEFEND_SILENT", "name": "Defend", "count": 5, "energy_cost": 1, "rules_text": "Gain 5 Block."},
+                        {"card_id": "SURVIVOR", "name": "Survivor", "count": 1, "energy_cost": 1, "rules_text": "Gain 8 Block. Discard 1 card."},
+                        {"card_id": "NEUTRALIZE", "name": "Neutralize", "count": 1, "energy_cost": 0, "rules_text": "Deal 3 damage. Apply 1 Weak."},
+                    ],
+                    "potions": [],
+                    "relic_items": [],
+                },
+            },
+        }
+        client = DummyClient(state=state)
+        server = create_server(client=client)
+        tool = asyncio.run(server.get_tool("check_boss_readiness"))
+
+        result = tool.fn()
+
+        self.assertEqual(result["recommendation"], "NOT_READY")
+        self.assertEqual(result["checks"]["hp"]["status"], "fail")
+        self.assertEqual(result["checks"]["scaling"]["status"], "fail")
+        self.assertEqual(result["checks"]["potions"]["status"], "fail")
+
+    def test_card_profile_falls_back_to_metadata_cost(self) -> None:
+        profile = _card_profile(
+            {"card_id": "WHIRLWIND", "name": "Whirlwind"},
+            {
+                "id": "WHIRLWIND",
+                "name": "Whirlwind",
+                "cost": 0,
+                "is_x_cost": False,
+                "type": "Attack",
+                "target": "AllEnemies",
+                "damage": 5,
+                "hit_count": None,
+            },
+        )
+
+        self.assertEqual(profile["cost"], 0)
+        self.assertFalse(profile["high_cost"])
+
+    def test_evaluate_shop_options_prefers_card_removal_for_bloated_deck(self) -> None:
+        state = {
+            "screen": "SHOP",
+            "agent_view": {
+                "screen": "SHOP",
+                "run": {
+                    "floor": 23,
+                    "current_hp": 44,
+                    "max_hp": 70,
+                    "gold": 95,
+                    "max_energy": 3,
+                    "deck": [
+                        {"card_id": "STRIKE_SILENT", "name": "Strike", "count": 5, "energy_cost": 1, "rules_text": "Deal 6 damage."},
+                        {"card_id": "DEFEND_SILENT", "name": "Defend", "count": 5, "energy_cost": 1, "rules_text": "Gain 5 Block."},
+                        {"card_id": "SURVIVOR", "name": "Survivor", "count": 1, "energy_cost": 1, "rules_text": "Gain 8 Block. Discard 1 card."},
+                        {"card_id": "NEUTRALIZE", "name": "Neutralize", "count": 1, "energy_cost": 0, "rules_text": "Deal 3 damage. Apply 1 Weak."},
+                    ],
+                    "potions": [],
+                    "relic_items": [],
+                },
+                "shop": {
+                    "open": True,
+                    "cards": [
+                        {
+                            "i": 0,
+                            "card_id": "BACKFLIP",
+                            "name": "Backflip",
+                            "rarity": "Common",
+                            "energy_cost": 1,
+                            "price": 82,
+                            "affordable": True,
+                            "stocked": True,
+                            "rules_text": "Gain 5 Block.\nDraw 2 cards.",
+                        },
+                    ],
+                    "relics": [],
+                    "potions": [
+                        {
+                            "i": 0,
+                            "potion_id": "BLOCK_POTION",
+                            "name": "Block Potion",
+                            "rarity": "Common",
+                            "usage": "Gain 12 Block.",
+                            "price": 45,
+                            "affordable": True,
+                            "stocked": True,
+                        },
+                    ],
+                    "remove": {
+                        "price": 75,
+                        "affordable": True,
+                        "available": True,
+                        "used": False,
+                    },
+                },
+            },
+        }
+        client = DummyClient(state=state)
+        server = create_server(client=client)
+        tool = asyncio.run(server.get_tool("evaluate_shop_options"))
+
+        result = tool.fn()
+
+        self.assertEqual(result["recommended_action"]["kind"], "remove_card_at_shop")
+        self.assertIn(result["remove"]["candidate_cards"][0]["name"], {"Strike", "Defend"})
+        self.assertGreaterEqual(result["remove"]["score"], 68)
+
+    def test_assess_rest_site_prefers_rest_on_low_hp(self) -> None:
+        state = {
+            "screen": "REST",
+            "agent_view": {
+                "screen": "REST",
+                "run": {
+                    "floor": 24,
+                    "current_hp": 19,
+                    "max_hp": 72,
+                    "gold": 120,
+                    "max_energy": 3,
+                    "deck": [
+                        {"card_id": "STRIKE_SILENT", "name": "Strike", "count": 5, "energy_cost": 1, "rules_text": "Deal 6 damage."},
+                        {"card_id": "DEFEND_SILENT", "name": "Defend", "count": 5, "energy_cost": 1, "rules_text": "Gain 5 Block."},
+                        {"card_id": "DAGGER_SPRAY", "name": "Dagger Spray", "count": 1, "energy_cost": 1, "rules_text": "Deal 4 damage to ALL enemies twice."},
+                        {"card_id": "FOOTWORK", "name": "Footwork", "count": 1, "energy_cost": 1, "rules_text": "Gain 2 Dexterity."},
+                    ],
+                    "potions": [],
+                    "relic_items": [],
+                },
+                "rest": {
+                    "options": [
+                        {"i": 0, "option_id": "REST", "line": "Rest: Recover HP", "enabled": True},
+                        {"i": 1, "option_id": "SMITH", "line": "Smith: Upgrade a card", "enabled": True},
+                    ],
+                },
+            },
+        }
+        client = DummyClient(state=state)
+        server = create_server(client=client)
+        tool = asyncio.run(server.get_tool("assess_rest_site"))
+
+        result = tool.fn()
+
+        self.assertEqual(result["best_index"], 0)
+        self.assertEqual(result["options"][0]["kind"], "rest")
+        self.assertEqual(result["options"][0]["recommendation"], "take")
+
+    def test_evaluate_potions_recommends_buying_aoe_when_slot_open(self) -> None:
+        state = {
+            "screen": "SHOP",
+            "agent_view": {
+                "screen": "SHOP",
+                "run": {
+                    "floor": 22,
+                    "current_hp": 28,
+                    "max_hp": 70,
+                    "gold": 80,
+                    "max_energy": 3,
+                    "deck": [
+                        {"card_id": "STRIKE_SILENT", "name": "Strike", "count": 5, "energy_cost": 1, "rules_text": "Deal 6 damage."},
+                        {"card_id": "DEFEND_SILENT", "name": "Defend", "count": 5, "energy_cost": 1, "rules_text": "Gain 5 Block."},
+                        {"card_id": "SURVIVOR", "name": "Survivor", "count": 1, "energy_cost": 1, "rules_text": "Gain 8 Block. Discard 1 card."},
+                    ],
+                    "potions": [
+                        {"i": 0, "potion_id": "BLOCK_POTION", "name": "Block Potion", "occupied": True, "rarity": "Common"},
+                        {"i": 1, "occupied": False},
+                    ],
+                    "relic_items": [],
+                },
+                "shop": {
+                    "potions": [
+                        {
+                            "i": 0,
+                            "potion_id": "EXPLOSIVE_AMPOULE",
+                            "name": "Explosive Ampoule",
+                            "rarity": "Common",
+                            "usage": "Deal 10 damage to ALL enemies.",
+                            "price": 42,
+                            "affordable": True,
+                            "stocked": True,
+                        },
+                    ],
+                },
+            },
+        }
+        client = DummyClient(state=state)
+        server = create_server(client=client)
+        tool = asyncio.run(server.get_tool("evaluate_potions"))
+
+        result = tool.fn()
+
+        self.assertEqual(result["recommended_purchase"]["option_index"], 0)
+        self.assertEqual(result["recommended_purchase"]["potion_id"], "EXPLOSIVE_AMPOULE")
+        self.assertIsNone(result["recommended_purchase"]["replace_index"])
 
     def test_get_game_data_items_fields_filters_fields(self) -> None:
         with patch(

--- a/mcp_server/tests/test_game_data_tools.py
+++ b/mcp_server/tests/test_game_data_tools.py
@@ -28,6 +28,15 @@ class DummyClient:
         return {"ok": True}
 
 
+class StateClient(DummyClient):
+    def __init__(self, state: dict[str, object]) -> None:
+        super().__init__()
+        self._state = state
+
+    def get_state(self) -> dict:
+        return self._state
+
+
 class GameDataToolsTests(unittest.TestCase):
     def test_get_game_data_item_returns_none_for_empty_item_id(self) -> None:
         client = DummyClient()
@@ -250,6 +259,184 @@ class GameDataToolsTests(unittest.TestCase):
 
         self.assertEqual(result_with_empty_fields["ABRASIVE"], payload["ABRASIVE"])
         self.assertEqual(result_with_none_fields["ABRASIVE"], payload["ABRASIVE"])
+
+    def test_get_combat_analysis_counts_zero_cost_cards_when_energy_is_zero(self) -> None:
+        client = StateClient(
+            {
+                "combat": {
+                    "player": {"energy": 0, "block": 0, "powers": []},
+                    "enemies": [
+                        {
+                            "index": 0,
+                            "name": "Training Dummy",
+                            "current_hp": 4,
+                            "block": 0,
+                            "powers": [],
+                            "intents": [{"intent_type": "Attack", "damage": 0}],
+                            "is_alive": True,
+                        }
+                    ],
+                    "hand": [
+                        {
+                            "index": 0,
+                            "card_id": "FLASH",
+                            "name": "Flash",
+                            "energy_cost": 0,
+                            "playable": True,
+                            "dmg": 4,
+                        }
+                    ],
+                }
+            }
+        )
+        server = create_server(client=client)
+        tool = asyncio.run(server.get_tool("get_combat_analysis"))
+
+        with patch("sts2_mcp.server._ensure_game_data_index", return_value={}):
+            result = tool.fn()
+
+        self.assertEqual(result["summary"]["max_damage_all_attacks"], 4)
+        self.assertTrue(result["enemies"][0]["lethal"])
+
+    def test_evaluate_card_rewards_uses_raw_run_and_reward_payloads(self) -> None:
+        client = StateClient(
+            {
+                "run": {
+                    "deck": [
+                        {"card_id": "STRIKE", "card_type": "ATTACK", "energy_cost": 1, "rules_text": "Deal 6 damage."},
+                        {"card_id": "DEFEND", "card_type": "SKILL", "energy_cost": 1, "rules_text": "Gain 5 Block."},
+                    ],
+                },
+                "reward": {
+                    "card_options": [
+                        {"index": 0, "card_id": "FLASH", "name": "Flash"},
+                    ]
+                },
+                "agent_view": {
+                    "run": {"deck": []},
+                    "reward": {"cards": [{"i": 0, "line": "Flash"}]},
+                    "available_actions": ["choose_reward_card"],
+                },
+            }
+        )
+        server = create_server(client=client)
+        tool = asyncio.run(server.get_tool("evaluate_card_rewards"))
+
+        with patch(
+            "sts2_mcp.server._ensure_game_data_index",
+            return_value={
+                "FLASH": {
+                    "id": "FLASH",
+                    "type": "Skill",
+                    "cost": 0,
+                    "damage": 0,
+                    "block": 0,
+                    "description": "Draw 1 card.",
+                }
+            },
+        ):
+            result = tool.fn()
+
+        self.assertEqual(result["deck_size"], 2)
+        self.assertEqual(result["recommendations"][0]["card_id"], "FLASH")
+        self.assertIn("0-cost = free value", result["recommendations"][0]["reasons"])
+
+    def test_assess_elite_risk_uses_run_payload_instead_of_compact_agent_view(self) -> None:
+        client = StateClient(
+            {
+                "run": {
+                    "current_hp": 56,
+                    "max_hp": 80,
+                    "deck": [{"card_id": f"CARD_{i}"} for i in range(15)],
+                    "potions": [
+                        {"potion_id": "FIRE", "occupied": True},
+                        {"potion_id": "BLOCK", "occupied": True},
+                    ],
+                },
+                "agent_view": {
+                    "run": {
+                        "hp": "0/0",
+                        "deck": [],
+                        "potions": [],
+                    }
+                },
+            }
+        )
+        server = create_server(client=client)
+        tool = asyncio.run(server.get_tool("assess_elite_risk"))
+
+        result = tool.fn()
+
+        self.assertEqual(result["recommendation"], "TAKE")
+        self.assertEqual(result["hp_ratio"], 0.7)
+
+    def test_check_boss_readiness_uses_run_payload_hp_deck_and_potions(self) -> None:
+        deck_cards = [
+            {"card_id": "STRIKE", "card_type": "ATTACK", "rules_text": "Deal 6 damage."},
+            {"card_id": "STRIKE", "card_type": "ATTACK", "rules_text": "Deal 6 damage."},
+            {"card_id": "STRIKE", "card_type": "ATTACK", "rules_text": "Deal 6 damage."},
+            {"card_id": "STRIKE", "card_type": "ATTACK", "rules_text": "Deal 6 damage."},
+            {"card_id": "BASH", "card_type": "ATTACK", "rules_text": "Deal 8 damage. Apply 2 Vulnerable."},
+            {"card_id": "DEFEND", "card_type": "SKILL", "rules_text": "Gain 5 Block."},
+            {"card_id": "DEFEND", "card_type": "SKILL", "rules_text": "Gain 5 Block."},
+            {"card_id": "DEFEND", "card_type": "SKILL", "rules_text": "Gain 5 Block."},
+            {"card_id": "DEFEND", "card_type": "SKILL", "rules_text": "Gain 5 Block."},
+            {"card_id": "SHRUG", "card_type": "SKILL", "rules_text": "Gain 8 Block. Draw 1 card."},
+            {"card_id": "ANGER", "card_type": "ATTACK", "rules_text": "Deal 6 damage."},
+            {"card_id": "POMMEL", "card_type": "ATTACK", "rules_text": "Deal 9 damage. Draw 1 card."},
+        ]
+        client = StateClient(
+            {
+                "run": {
+                    "current_hp": 56,
+                    "max_hp": 80,
+                    "deck": deck_cards,
+                    "potions": [{"potion_id": "FIRE", "occupied": True}],
+                },
+                "agent_view": {
+                    "run": {
+                        "hp": "0/0",
+                        "deck": [],
+                        "potions": [],
+                    }
+                },
+            }
+        )
+        server = create_server(client=client)
+        tool = asyncio.run(server.get_tool("check_boss_readiness"))
+        card_index = {
+            "STRIKE": {"id": "STRIKE", "damage": 6, "block": 0, "description": "Deal 6 damage."},
+            "BASH": {"id": "BASH", "damage": 8, "block": 0, "description": "Deal 8 damage. Apply 2 Vulnerable."},
+            "DEFEND": {"id": "DEFEND", "damage": 0, "block": 5, "description": "Gain 5 Block."},
+            "SHRUG": {"id": "SHRUG", "damage": 0, "block": 8, "description": "Gain 8 Block. Draw 1 card."},
+            "ANGER": {"id": "ANGER", "damage": 6, "block": 0, "description": "Deal 6 damage."},
+            "POMMEL": {"id": "POMMEL", "damage": 9, "block": 0, "description": "Deal 9 damage. Draw 1 card."},
+        }
+
+        with patch("sts2_mcp.server._ensure_game_data_index", return_value=card_index):
+            result = tool.fn()
+
+        self.assertEqual(result["deck_stats"]["size"], 12)
+        self.assertEqual(result["checks"][0]["detail"], "56/80 HP — healthy")
+        self.assertTrue(result["checks"][-1]["pass"])
+
+    def test_score_card_for_deck_uses_cost_field_and_normalizes_card_type(self) -> None:
+        result = server_module._score_card_for_deck(
+            card_id="TEST_POWER",
+            card_data={
+                "id": "TEST_POWER",
+                "type": "Power",
+                "cost": 0,
+                "damage": 0,
+                "block": 0,
+                "description": "Draw 1 card.",
+            },
+            current_deck=[{"card_id": "STRIKE", "card_type": "ATTACK", "rules_text": "Deal 6 damage."}],
+            deck_size=10,
+        )
+
+        self.assertIn("powers provide lasting value", result["reasons"])
+        self.assertIn("0-cost = free value", result["reasons"])
 
     def test_ensure_game_data_index_supports_case_insensitive_lookup_for_dict_collection(self) -> None:
         with patch.object(server_module, "_GAME_DATA_INDEXES", {}):

--- a/mcp_server/tests/test_run_logs.py
+++ b/mcp_server/tests/test_run_logs.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import tempfile
+import unittest
+from copy import deepcopy
+from pathlib import Path
+from unittest.mock import patch
+
+from sts2_mcp.server import create_server
+
+
+def _combat_state(turn: int) -> dict:
+    return {
+        "run_id": "RUN123",
+        "screen": "COMBAT",
+        "turn": turn,
+        "available_actions": ["end_turn", "play_card"],
+        "session": {
+            "mode": "singleplayer",
+            "phase": "run",
+            "control_scope": "local_player",
+        },
+        "run": {
+            "character_id": "SILENT",
+            "character_name": "静默猎手",
+            "floor": 7,
+            "current_hp": 60,
+            "max_hp": 70,
+            "gold": 123,
+            "max_energy": 3,
+            "deck": [{"card_id": "NEUTRALIZE"}],
+            "relics": [{"relic_id": "RING_OF_THE_SNAKE"}],
+            "potions": [],
+        },
+        "combat": {
+            "player": {
+                "current_hp": 60,
+                "max_hp": 70,
+                "block": 0,
+                "energy": 3,
+                "powers": [],
+            },
+            "hand": [
+                {
+                    "index": 0,
+                    "card_id": "NEUTRALIZE",
+                    "name": "中和",
+                    "energy_cost": 0,
+                    "playable": True,
+                    "requires_target": True,
+                    "target_index_space": "enemies",
+                    "valid_target_indices": [0],
+                }
+            ],
+            "draw": [],
+            "discard": [],
+            "exhaust": [],
+            "enemies": [
+                {
+                    "index": 0,
+                    "enemy_id": "CULTIST",
+                    "name": "邪教徒",
+                    "current_hp": 48,
+                    "max_hp": 48,
+                    "block": 0,
+                    "intent": "INCANTATION",
+                    "move_id": "INCANTATION",
+                    "powers": [],
+                    "intents": [{"intent_type": "Buff"}],
+                }
+            ],
+        },
+    }
+
+
+def _reward_state() -> dict:
+    return {
+        "run_id": "RUN123",
+        "screen": "CARD_SELECTION",
+        "turn": 10,
+        "available_actions": ["choose_reward_card", "skip_reward_cards"],
+        "session": {
+            "mode": "singleplayer",
+            "phase": "run",
+            "control_scope": "local_player",
+        },
+        "run": {
+            "character_id": "SILENT",
+            "character_name": "静默猎手",
+            "floor": 28,
+            "current_hp": 52,
+            "max_hp": 75,
+            "gold": 936,
+            "max_energy": 3,
+            "deck": [{"card_id": "NOXIOUS_FUMES"}],
+            "relics": [{"relic_id": "GORGET"}],
+            "potions": [],
+        },
+        "reward": {
+            "pending_card_choice": True,
+            "can_proceed": False,
+            "rewards": [],
+            "card_options": [
+                {
+                    "index": 0,
+                    "card_id": "FOOTWORK",
+                    "name": "灵动步法",
+                    "upgraded": False,
+                    "rules_text": "获得2点敏捷。",
+                }
+            ],
+            "alternatives": [{"index": 0, "label": "跳过"}],
+        },
+    }
+
+
+def _map_state() -> dict:
+    return {
+        "run_id": "RUN123",
+        "screen": "MAP",
+        "turn": 10,
+        "available_actions": ["choose_map_node"],
+        "session": {
+            "mode": "singleplayer",
+            "phase": "run",
+            "control_scope": "local_player",
+        },
+        "run": {
+            "character_id": "SILENT",
+            "character_name": "静默猎手",
+            "floor": 28,
+            "current_hp": 52,
+            "max_hp": 75,
+            "gold": 936,
+            "max_energy": 3,
+            "deck": [{"card_id": "NOXIOUS_FUMES"}, {"card_id": "FOOTWORK"}],
+            "relics": [{"relic_id": "GORGET"}],
+            "potions": [],
+        },
+        "map": {
+            "current_node": {"row": 9, "col": 3, "node_type": "Elite"},
+            "available_nodes": [
+                {"index": 0, "row": 10, "col": 2, "node_type": "RestSite", "state": "Travelable"}
+            ],
+        },
+    }
+
+
+class LoggingDummyClient:
+    def __init__(self, states: list[dict], action_response: dict | None = None) -> None:
+        self._states = [deepcopy(state) for state in states]
+        self._action_response = deepcopy(action_response) if action_response is not None else None
+
+    def get_health(self) -> dict:
+        return {"ok": True}
+
+    def get_state(self) -> dict:
+        if len(self._states) > 1:
+            return self._states.pop(0)
+        return deepcopy(self._states[0])
+
+    def get_available_actions(self) -> list[dict]:
+        return []
+
+    def wait_for_event(self, *, event_names=None, timeout=0.0) -> dict | None:
+        return None
+
+    def execute_action(self, *args, **kwargs) -> dict:
+        if self._action_response is None:
+            return {"status": "completed"}
+        return deepcopy(self._action_response)
+
+
+class RunLogTests(unittest.TestCase):
+    def test_get_game_state_logs_each_new_turn_once(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            client = LoggingDummyClient(
+                states=[
+                    _combat_state(turn=1),
+                    _combat_state(turn=1),
+                    _combat_state(turn=2),
+                ]
+            )
+
+            with patch.dict(os.environ, {"STS2_AGENT_KNOWLEDGE_DIR": tempdir}, clear=False):
+                server = create_server(client=client)
+                tool = asyncio.run(server.get_tool("get_game_state"))
+
+                tool.fn()
+                tool.fn()
+                tool.fn()
+
+            entries = self._read_entries(Path(tempdir) / "logs" / "runs" / "RUN123.jsonl")
+            state_entries = [entry for entry in entries if entry["type"] == "state"]
+
+            self.assertEqual(len(state_entries), 2)
+            self.assertEqual([entry["summary"]["turn"] for entry in state_entries], [1, 2])
+            self.assertTrue(all(entry["category"] == "combat_turn" for entry in state_entries))
+
+    def test_reward_action_logs_reward_state_and_post_action_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            client = LoggingDummyClient(
+                states=[_reward_state()],
+                action_response={
+                    "action": "choose_reward_card",
+                    "status": "completed",
+                    "stable": True,
+                    "message": "Action completed.",
+                    "state": _map_state(),
+                },
+            )
+
+            with patch.dict(os.environ, {"STS2_AGENT_KNOWLEDGE_DIR": tempdir}, clear=False):
+                server = create_server(client=client)
+                state_tool = asyncio.run(server.get_tool("get_game_state"))
+                act_tool = asyncio.run(server.get_tool("act"))
+
+                state_tool.fn()
+                act_tool.fn(action="choose_reward_card", option_index=0)
+
+            entries = self._read_entries(Path(tempdir) / "logs" / "runs" / "RUN123.jsonl")
+            reward_entries = [entry for entry in entries if entry["type"] == "state" and entry["category"] == "reward"]
+            action_entries = [entry for entry in entries if entry["type"] == "action"]
+            map_entries = [
+                entry
+                for entry in entries
+                if entry["type"] == "state" and entry["summary"].get("screen") == "MAP"
+            ]
+
+            self.assertEqual(reward_entries[0]["summary"]["reward"]["card_options"][0]["card_id"], "FOOTWORK")
+            self.assertEqual(len(action_entries), 1)
+            self.assertEqual(action_entries[0]["action"], "choose_reward_card")
+            self.assertEqual(action_entries[0]["params"]["option_index"], 0)
+            self.assertEqual(action_entries[0]["after_state"]["screen"], "MAP")
+            self.assertEqual(len(map_entries), 1)
+
+    @staticmethod
+    def _read_entries(path: Path) -> list[dict]:
+        with path.open("r", encoding="utf-8") as handle:
+            return [json.loads(line) for line in handle if line.strip()]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/sts2-mcp-player/SKILL.md
+++ b/skills/sts2-mcp-player/SKILL.md
@@ -113,9 +113,85 @@ For detailed per-screen sequences and pitfalls, read [references/screen-playbook
 - `shop.is_open = true` means inner inventory, not room completion.
 - Timeline gates can block run start until the overlay is confirmed or the submenu is closed.
 
-## Minimal Decision Heuristics
+## Combat Decision Heuristics
 
-- In combat, spend energy efficiently and avoid ending turn with obvious free value unused.
-- In rewards, take cards only when the upgrade is clear; otherwise skip.
+### Pre-Turn Analysis
+- **Always call `get_combat_analysis` at the start of each combat turn.** This gives you computed damage/block per card (accounting for Strength, Dexterity, Weak, Frail, Vulnerable), max available damage/block, and per-enemy lethal checks.
+- Use the tactical summary to decide: attack vs defend vs setup.
+
+### Turn Priority (in order)
+1. **Lethal check** — if `summary.enemies[].lethal == true`, play attacks to kill that enemy.
+2. **Survive check** — if `summary.net_damage_if_all_block > 0` and HP is low, prioritize block.
+3. **Apply Vulnerable** — Bash a high-HP target for +50% damage over 3 turns.
+4. **Spend remaining energy** — prefer `damage_per_energy` to find efficient cards.
+5. **Never end turn with unspent energy** if playable cards remain.
+
+### Block Decision
+- Block if incoming damage > 30% of current HP.
+- Block if incoming damage is multi-attack (multi-attacks bypass small block).
+- Skip block if enemy is buffing/debuffing (free damage turn).
+
+### Card Reward Decisions
+- Take cards that fill gaps: no AoE → take AoE; no draw → take draw.
+- Skip cards that don't improve your average turn.
+- Refer to `docs/game-knowledge/ironclad-strategy.md` for card tier lists.
+
+### Route Planning
+- Rest if HP < 40%. Upgrade if HP > 60%.
+- Shop with 75+ gold for card removal or relics.
+- Avoid elites if HP < 50% or deck < 12 cards.
+- Take elites if HP > 70% and deck is solid.
+
+### Boss Preparation
+- Refer to `docs/game-knowledge/act1-boss-guide.md` before boss fights.
+- Use potions during boss fights, not before.
+- Enter boss with 60+ HP if possible.
+
+## Card Reward Heuristics
+
+- **Call `evaluate_card_rewards`** when card rewards appear after combat.
+- Pick the highest-scored card; skip all if no card scores above 60.
+- Prefer cards that fill gaps (no AoE → take AoE, no draw → take draw).
+- Never bloat deck past 20 cards unless the card is exceptional.
+
+## Economy Management
+
+### Gold Spending Priority
+1. **Card removal (75g)** — most valuable early buy. Remove Strikes first.
+2. **Strong relics (150-300g)** — permanent power. Check before buying cards.
+3. **Cards from shop** — only if they fill a critical deck gap.
+4. **Potions** — buy before boss fights if you have spare gold.
+
+### Gold Saving Rules
+- **Always keep 75g reserve** for card removal at next shop.
+- Don't buy cards in shop if deck > 18 cards.
+- Don't buy relics if gold < 150 and next shop is 2+ floors away.
+- Spending all gold before boss is fine — gold doesn't help in combat.
+
+### When to Skip Rewards
+- Skip card rewards if deck > 18 cards and no card fills a gap.
+- Skip gold in favor of max HP if HP < 50%.
+- Never skip relics — relics are always valuable.
+
+## Potion Timing
+
+### When to Use Potions
+- **Boss fights** — use offensive potions (Strength, Fire, Explosive) on turn 1-2 for max value.
+- **Elite fights** — use defensive potions if HP < 50% going in.
+- **Lethal prevention** — use Block/Fairy potions to survive a killing blow.
+- **Lethal enable** — use damage potions to secure a kill this turn when close.
+
+### When NOT to Use Potions
+- Normal combat you're winning comfortably — save for harder fights.
+- Turn 1 of normal combat — wait to see if you actually need it.
+- Healing potions outside combat when HP > 70% — save for emergencies.
+
+### Potion Slot Management
+- If all slots full and approaching a fight, use the weakest potion first.
+- Prioritize keeping: Fairy in a Bottle > Strength Potion > Block Potion > other.
+
+## General Decision Heuristics
+
+- In rewards, use `evaluate_card_rewards` to decide.
 - In shops, check relics and removal before committing all gold.
 - In events, prefer unlocked options and re-read state after every branch.


### PR DESCRIPTION
## Summary

- What changed in this PR?
- Why is this change needed?

## Validation

- [ ] `dotnet build "STS2AIAgent/STS2AIAgent.csproj"`
- [ ] `powershell -ExecutionPolicy Bypass -File "scripts/build-mod.ps1"`
- [ ] `powershell -ExecutionPolicy Bypass -File "scripts/test-mod-load.ps1"`
- [ ] `cd "mcp_server"` then `uv run sts2-mcp-server`

List any additional validation you ran:

```text
<commands and results>
```

## Prerequisites

- [ ] No machine-specific paths were added to tracked files
- [ ] Required local tools / env vars are documented
- [ ] User-facing behavior or API changes are documented

## Notes

- Screenshots, logs, compatibility notes, or follow-up work

## Summary by Sourcery

Add Act 2-focused decision support capabilities to the MCP server and agent, enriching game state payloads and exposing new heuristic evaluation tools for downstream planners.

New Features:
- Expose multiple read-only MCP tools that score card rewards, elite routes, boss readiness, shop options, rest-site choices, and potion usage based on the current run state.
- Backfill and normalize agent_view state with raw run/map/reward sections, including computed route options for map navigation decisions.

Enhancements:
- Enrich the agent-view payload from the .NET game agent with detailed combat, run, map, shop, reward, event, potion, and card metadata to support the new heuristic scorers.
- Extend the knowledge base with a helper to build route options, enabling map-based risk assessment logic.
- Adjust the auto-claim reward flow to prefer skipping card rewards instead of defaulting to the first card pick in unattended runs.
- Document the new heuristic MCP tools as read-only decision aids for Act 2+ planners in the API docs.

Tests:
- Add extensive unit tests around agent_view backfilling, card profiling, and each new decision support scorer to validate recommendations and edge cases.