### PR TITLE
Fix use_potion pending forever for AoE/random-target potions (AllEnemies/AllAllies/RandomEnemy)

### DIFF
--- a/STS2AIAgent/Game/GameActionService.cs
+++ b/STS2AIAgent/Game/GameActionService.cs
@@ -3852,6 +3852,12 @@ internal static class GameActionService
             TargetType.AnyEnemy => ResolvePotionEnemyTarget(request, combatState, potion),
             TargetType.AnyPlayer when GameStateService.PotionRequiresTarget(combatState, potion) => ResolvePotionPlayerTarget(request, combatState, potion),
             TargetType.TargetedNoCreature => null,
+            // AoE / random-target potions resolve their targets inside the game.
+            // Passing Owner.Creature here makes the game silently discard the use
+            // (invalid target), so use_potion stays pending forever.
+            TargetType.AllEnemies => null,
+            TargetType.AllAllies => null,
+            TargetType.RandomEnemy => null,
             _ => potion.Owner.Creature
         };
     }


### PR DESCRIPTION
## Summary / 概述

`use_potion` never completes for potions whose `TargetType` is `AllEnemies`, `AllAllies`, or `RandomEnemy` (e.g. `EXPLOSIVE_AMPOULE` / 爆炸药瓶): the action stays `pending` forever and the potion is never consumed.

`use_potion` 对所有 AoE / 随机目标药水（`TargetType` 为 `AllEnemies` / `AllAllies` / `RandomEnemy`，例如爆炸药瓶 `EXPLOSIVE_AMPOULE`）永远卡在 `pending`，药水不会被使用。

## Root cause / 根因

In `GameActionService.ResolvePotionTarget`, the switch has no arm for `AllEnemies` / `AllAllies` / `RandomEnemy`, so they fall into the default arm and return `potion.Owner.Creature`:

`GameActionService.ResolvePotionTarget` 的 switch 没有覆盖这三种 `TargetType`，落入默认分支返回 `potion.Owner.Creature`：

```csharp
TargetType.TargetedNoCreature => null,
_ => potion.Owner.Creature   // <- AllEnemies/AllAllies/RandomEnemy also land here
```

These potion types resolve their targets inside the game (all enemies / all allies / a random enemy). Passing the owner creature as the target is invalid, and the game **silently discards** the use — no error, no state transition, so the API caller waits until timeout and reports `pending`.

这几类药水的目标由游戏内部自行解析（全体敌人/全体友方/随机敌人）。把玩家自己作为目标传入是非法的，游戏会**静默丢弃**这次使用——无报错、无状态迁移，API 调用方只能等到超时并返回 `pending`。

## Fix / 修复

Return `null` for these target types (same as `TargetedNoCreature`), letting the game resolve targets internally:

对这三种目标类型返回 `null`（与 `TargetedNoCreature` 一致），交由游戏内部解析目标：

```csharp
TargetType.TargetedNoCreature => null,
TargetType.AllEnemies => null,
TargetType.AllAllies => null,
TargetType.RandomEnemy => null,
_ => potion.Owner.Creature
```

## Reproduction / 复现

1. Start any run, enter combat, hold an AoE potion such as `EXPLOSIVE_AMPOULE`.
2. `POST /action` with `{"action": "use_potion", "option_index": <i>}` (no `target_index`, as documented for non-`AnyEnemy` potions).
3. Before the fix: response stays `pending`, potion is never used. After the fix: response is `completed`, all enemies take damage.

1. 任意开局进入战斗，持有爆炸药瓶等 AoE 药水。
2. 调用 `use_potion`（按文档无需 `target_index`）。
3. 修复前：响应永远 `pending`，药水未被使用；修复后：返回 `completed`，敌方全体正常扣血。

## Validation / 验证

- Real-game test on Slay the Spire 2 `v0.111.0`: `use_potion` with an AoE potion returns `completed` and every enemy's HP drops.
- `dotnet build STS2AIAgent/STS2AIAgent.csproj -c Release` — 0 warnings / 0 errors.
- `dotnet run --project STS2AIAgent.Tests/STS2AIAgent.Tests.csproj` — all tests pass.

- 已在游戏 `v0.111.0` 真机验证：AoE 药水返回 `completed` 且敌方全体扣血。
- Release 构建 0 警告 0 错误；全部单元测试通过。

## Summary by Sourcery

Bug Fixes:
- Fix `use_potion` actions for AoE and random-target potions so they complete successfully and consume the potion instead of remaining pending indefinitely.