### PR TITLE
feat: support Crystal Sphere divination minigame as CRYSTAL_SPHERE screen

### DIFF
--- a/STS2AIAgent.Tests/AgentLoopTests.cs
+++ b/STS2AIAgent.Tests/AgentLoopTests.cs
@@ -105,6 +105,55 @@ internal static class AgentLoopTests
         Assert.Null(result.Error);
     }
 
+    public static async Task PlayOnce_ForwardsCrystalSphereArguments()
+    {
+        var bridge = new FakeBridge
+        {
+            CompactStateJson =
+                """{"screen":"CRYSTAL_SPHERE","available_actions":["crystal_clear_cell"],"crystal_sphere":{"grid_width":11,"grid_height":11}}""",
+            AvailableActionsJson =
+                """[{"name":"crystal_clear_cell","requires_index":false,"requires_target":false}]""",
+            AvailableActionNames = new[] { "crystal_clear_cell" },
+            Screen = "CRYSTAL_SPHERE"
+        };
+        var factory = new ScriptedClientFactory(new[]
+        {
+            new LlmCompletion
+            {
+                ToolCalls = new[]
+                {
+                    new LlmToolCall
+                    {
+                        Id = "call_act",
+                        Name = "act",
+                        ArgumentsJson =
+                            """{"action":"crystal_clear_cell","x":4,"y":7,"tool":"small"}"""
+                    }
+                }
+            }
+        });
+        var loop = new AgentLoop(bridge, factory, AgentSettings.CreateDefault);
+
+        var result = await loop.PlayOnceAsync(CancellationToken.None);
+
+        Assert.Equal("crystal_clear_cell", result.Acted);
+        Assert.Equal("crystal_clear_cell", bridge.LastAction);
+        Assert.Equal(4, bridge.LastX);
+        Assert.Equal(7, bridge.LastY);
+        Assert.Equal("small", bridge.LastTool);
+        Assert.Null(result.Error);
+    }
+
+    public static void ActToolSchema_IncludesCrystalSphereArguments()
+    {
+        var act = AgentTools.Play.Single(tool => tool.Name == "act");
+        var schema = JsonSerializer.Serialize(act.Parameters);
+
+        Assert.Contains("\"x\"", schema);
+        Assert.Contains("\"y\"", schema);
+        Assert.Contains("\"tool\"", schema);
+    }
+
     public static async Task PlayOnce_SkipsWhenNotActionable()
     {
         var bridge = new FakeBridge { Actionable = false };
@@ -263,6 +312,40 @@ internal static class AgentLoopTests
         Assert.Null(result.Error);
         Assert.Equal(0, bridge.CaptureCalls);
         Assert.Null(factory.LastRequest?.Tools);
+    }
+
+    public static async Task PlayOnce_TextOnlyCrystalJsonForwardsCoordinatesAndNullTool()
+    {
+        var bridge = new FakeBridge
+        {
+            CompactStateJson =
+                """{"screen":"CRYSTAL_SPHERE","available_actions":["crystal_clear_cell"],"crystal_sphere":{"grid_width":11,"grid_height":11}}""",
+            AvailableActionsJson =
+                """[{"name":"crystal_clear_cell","requires_index":false,"requires_target":false}]""",
+            AvailableActionNames = new[] { "crystal_clear_cell" },
+            Screen = "CRYSTAL_SPHERE"
+        };
+        var factory = new ScriptedClientFactory(new[]
+        {
+            new LlmCompletion
+            {
+                Content =
+                    """{"action":"crystal_clear_cell","x":2,"y":9,"tool":null}"""
+            }
+        });
+        var settings = AgentSettings.CreateDefault();
+        settings.Models[0].SupportsVision = false;
+        settings.Models[0].SupportsTools = false;
+        settings.VisionModelId = null;
+        var loop = new AgentLoop(bridge, factory, () => settings);
+
+        var result = await loop.PlayOnceAsync(CancellationToken.None);
+
+        Assert.Equal("crystal_clear_cell", result.Acted);
+        Assert.Equal(2, bridge.LastX);
+        Assert.Equal(9, bridge.LastY);
+        Assert.Null(bridge.LastTool);
+        Assert.Null(result.Error);
     }
 
     public static async Task PlayOnce_WaitUntilActionableTool()
@@ -472,16 +555,34 @@ internal static class AgentLoopTests
 
         public int CaptureCalls { get; private set; }
 
+        public string? LastAction { get; private set; }
+
+        public int? LastX { get; private set; }
+
+        public int? LastY { get; private set; }
+
+        public string? LastTool { get; private set; }
+
         public bool Actionable { get; set; } = true;
 
         public bool HonorCancelOnWait { get; set; } = true;
 
         public string ActResultJson { get; set; } = """{"action":"play_card","status":"completed","stable":true}""";
 
+        public string CompactStateJson { get; set; } =
+            """{"screen":"COMBAT","available_actions":["play_card","end_turn"],"combat":{"hand":[{"i":0,"line":"Strike","targets":[]}],"enemies":[{"i":0}]}}""";
+
+        public string AvailableActionsJson { get; set; } =
+            """[{"name":"play_card","requires_index":true,"requires_target":false}]""";
+
+        public IReadOnlyList<string> AvailableActionNames { get; set; } =
+            new[] { "play_card", "end_turn" };
+
+        public string Screen { get; set; } = "COMBAT";
+
         public Task<string> GetCompactStateJsonAsync(CancellationToken cancellationToken)
         {
-            return Task.FromResult(
-                """{"screen":"COMBAT","available_actions":["play_card","end_turn"],"combat":{"hand":[{"i":0,"line":"Strike","targets":[]}],"enemies":[{"i":0}]}}""");
+            return Task.FromResult(CompactStateJson);
         }
 
         public Task<string> GetRawStateJsonAsync(CancellationToken cancellationToken)
@@ -491,19 +592,31 @@ internal static class AgentLoopTests
 
         public Task<string> GetAvailableActionsJsonAsync(CancellationToken cancellationToken)
         {
-            return Task.FromResult("""[{"name":"play_card","requires_index":true,"requires_target":false}]""");
+            return Task.FromResult(AvailableActionsJson);
         }
 
         public Task<IReadOnlyList<string>> GetAvailableActionNamesAsync(CancellationToken cancellationToken)
         {
-            return Task.FromResult<IReadOnlyList<string>>(new[] { "play_card", "end_turn" });
+            return Task.FromResult(AvailableActionNames);
         }
 
-        public Task<string> GetScreenAsync(CancellationToken cancellationToken) => Task.FromResult("COMBAT");
+        public Task<string> GetScreenAsync(CancellationToken cancellationToken) => Task.FromResult(Screen);
 
-        public Task<string> ActAsync(string action, int? cardIndex, int? targetIndex, int? optionIndex, CancellationToken cancellationToken)
+        public Task<string> ActAsync(
+            string action,
+            int? cardIndex,
+            int? targetIndex,
+            int? optionIndex,
+            int? x,
+            int? y,
+            string? tool,
+            CancellationToken cancellationToken)
         {
             ActCalls++;
+            LastAction = action;
+            LastX = x;
+            LastY = y;
+            LastTool = tool;
             return Task.FromResult(ActResultJson);
         }
 

--- a/STS2AIAgent.Tests/CrystalSphereSettlePolicyTests.cs
+++ b/STS2AIAgent.Tests/CrystalSphereSettlePolicyTests.cs
@@ -1,0 +1,71 @@
+using STS2AIAgent.Game;
+
+namespace STS2AIAgent.Tests;
+
+internal static class CrystalSphereSettlePolicyTests
+{
+    public static void RequiresObservedProgressOnSameScreen()
+    {
+        Assert.False(CrystalSphereSettlePolicy.IsSettled(
+            screenChanged: false,
+            minigameAvailable: true,
+            divinationsBefore: 3,
+            divinationsNow: 3,
+            isFinished: false,
+            canProceed: false));
+
+        Assert.True(CrystalSphereSettlePolicy.IsSettled(
+            screenChanged: false,
+            minigameAvailable: true,
+            divinationsBefore: 3,
+            divinationsNow: 2,
+            isFinished: false,
+            canProceed: false));
+    }
+
+    public static void WaitsForProceedAfterFinalDivination()
+    {
+        Assert.False(CrystalSphereSettlePolicy.IsSettled(
+            screenChanged: false,
+            minigameAvailable: true,
+            divinationsBefore: 1,
+            divinationsNow: 0,
+            isFinished: true,
+            canProceed: false));
+
+        Assert.True(CrystalSphereSettlePolicy.IsSettled(
+            screenChanged: false,
+            minigameAvailable: true,
+            divinationsBefore: 1,
+            divinationsNow: 0,
+            isFinished: true,
+            canProceed: true));
+
+        Assert.True(CrystalSphereSettlePolicy.IsSettled(
+            screenChanged: false,
+            minigameAvailable: false,
+            divinationsBefore: 1,
+            divinationsNow: 1,
+            isFinished: false,
+            canProceed: true));
+    }
+
+    public static void AcceptsChildScreenButNotMissingMinigame()
+    {
+        Assert.True(CrystalSphereSettlePolicy.IsSettled(
+            screenChanged: true,
+            minigameAvailable: false,
+            divinationsBefore: 1,
+            divinationsNow: 1,
+            isFinished: false,
+            canProceed: false));
+
+        Assert.False(CrystalSphereSettlePolicy.IsSettled(
+            screenChanged: false,
+            minigameAvailable: false,
+            divinationsBefore: 1,
+            divinationsNow: 1,
+            isFinished: false,
+            canProceed: false));
+    }
+}

--- a/STS2AIAgent.Tests/STS2AIAgent.Tests.csproj
+++ b/STS2AIAgent.Tests/STS2AIAgent.Tests.csproj
@@ -20,5 +20,6 @@
     <Compile Include="..\STS2AIAgent\Agent\IGameBridge.cs" Link="Agent\IGameBridge.cs" />
     <Compile Include="..\STS2AIAgent\Agent\PlayPrompt.cs" Link="Agent\PlayPrompt.cs" />
     <Compile Include="..\STS2AIAgent\Agent\McpProcessLauncher.cs" Link="Agent\McpProcessLauncher.cs" />
+    <Compile Include="..\STS2AIAgent\Game\CrystalSphereSettlePolicy.cs" Link="Game\CrystalSphereSettlePolicy.cs" />
   </ItemGroup>
 </Project>

--- a/STS2AIAgent.Tests/TestRunner.cs
+++ b/STS2AIAgent.Tests/TestRunner.cs
@@ -130,12 +130,15 @@ internal static class TestRunner
         yield return ("ActIndex.Validate", () => Task.Run(ActIndexValidatorTests.RejectsMissingAndStaleIndexes));
         yield return ("ActIndex.Unsettled", () => Task.Run(ActIndexValidatorTests.DetectsUnsettledActResults));
         yield return ("AgentLoop.PlayOnce", AgentLoopTests.PlayOnce_ExecutesSingleValidatedAct);
+        yield return ("AgentLoop.CrystalArgs", AgentLoopTests.PlayOnce_ForwardsCrystalSphereArguments);
+        yield return ("AgentTools.CrystalSchema", () => Task.Run(AgentLoopTests.ActToolSchema_IncludesCrystalSphereArguments));
         yield return ("AgentLoop.NotActionable", AgentLoopTests.PlayOnce_SkipsWhenNotActionable);
         yield return ("AgentLoop.RejectStaleIndex", AgentLoopTests.PlayOnce_RejectsIndexNotInLatestPayload);
         yield return ("AgentLoop.WaitPending", AgentLoopTests.PlayOnce_WaitsWhenActIsPending);
         yield return ("AgentLoop.NoVisionCapture", AgentLoopTests.PlayOnce_DoesNotCaptureWithoutVision);
         yield return ("AgentLoop.PerModelThinking", AgentLoopTests.PlayOnce_UsesPerModelThinkingIntensity);
         yield return ("AgentLoop.JsonActNoTools", AgentLoopTests.PlayOnce_TextOnlyJsonActWithoutTools);
+        yield return ("AgentLoop.CrystalJsonNoTools", AgentLoopTests.PlayOnce_TextOnlyCrystalJsonForwardsCoordinatesAndNullTool);
         yield return ("AgentLoop.WaitTool", AgentLoopTests.PlayOnce_WaitUntilActionableTool);
         yield return ("AgentLoop.ParseActJson", () => Task.Run(AgentLoopTests.ParsesActJsonFromMarkdownFence));
         yield return ("AgentLoop.ChatNoAct", AgentLoopTests.Chat_DoesNotExecuteAct);
@@ -145,5 +148,8 @@ internal static class TestRunner
         yield return ("AgentLoop.RetryFailedAct", AgentLoopTests.PlayOnce_RetriesAfterFailedAct);
         yield return ("AgentLoop.CancelPropagates", AgentLoopTests.PlayOnce_PropagatesCancellation);
         yield return ("McpLauncher.DetectRoot", () => Task.Run(AgentLoopTests.McpRoot_DetectsValidLayout));
+        yield return ("CrystalSettle.Progress", () => Task.Run(CrystalSphereSettlePolicyTests.RequiresObservedProgressOnSameScreen));
+        yield return ("CrystalSettle.FinalProceed", () => Task.Run(CrystalSphereSettlePolicyTests.WaitsForProceedAfterFinalDivination));
+        yield return ("CrystalSettle.ScreenChange", () => Task.Run(CrystalSphereSettlePolicyTests.AcceptsChildScreenButNotMissingMinigame));
     }
 }

--- a/STS2AIAgent/Agent/AgentLoop.cs
+++ b/STS2AIAgent/Agent/AgentLoop.cs
@@ -428,6 +428,9 @@ internal sealed class AgentLoop
             var cardIndex = ReadInt(args, "card_index");
             var targetIndex = ReadInt(args, "target_index");
             var optionIndex = ReadInt(args, "option_index");
+            var x = ReadInt(args, "x");
+            var y = ReadInt(args, "y");
+            var tool = ReadString(args, "tool");
             var actionsJson = await _bridge.GetAvailableActionsJsonAsync(cancellationToken);
             var compactJson = await _bridge.GetCompactStateJsonAsync(cancellationToken);
             var indexError = ActIndexValidator.Validate(
@@ -445,7 +448,10 @@ internal sealed class AgentLoop
                     action,
                     card_index = cardIndex,
                     target_index = targetIndex,
-                    option_index = optionIndex
+                    option_index = optionIndex,
+                    x,
+                    y,
+                    tool
                 }, JsonOptions);
                 return (null, json, indexError);
             }
@@ -455,6 +461,9 @@ internal sealed class AgentLoop
                 cardIndex,
                 targetIndex,
                 optionIndex,
+                x,
+                y,
+                tool,
                 cancellationToken);
             if (ActIndexValidator.IsUnsettled(result))
             {
@@ -513,6 +522,7 @@ internal sealed class AgentLoop
         {
             JsonValueKind.String => value.GetString(),
             JsonValueKind.Number => value.ToString(),
+            JsonValueKind.Null or JsonValueKind.Undefined => null,
             _ => value.GetRawText()
         };
     }

--- a/STS2AIAgent/Agent/AgentTools.cs
+++ b/STS2AIAgent/Agent/AgentTools.cs
@@ -12,7 +12,15 @@ internal static class AgentTools
             action = new { type = "string", description = "Action name from available_actions." },
             card_index = new { type = "integer", description = "Hand card index for play_card." },
             target_index = new { type = "integer", description = "Target index when the card or potion requires a target." },
-            option_index = new { type = "integer", description = "Option index for map/reward/shop/event/rest/lobby choices." }
+            option_index = new { type = "integer", description = "Option index for map/reward/shop/event/rest/lobby choices." },
+            x = new { type = "integer", description = "Crystal Sphere grid x-coordinate for crystal_clear_cell." },
+            y = new { type = "integer", description = "Crystal Sphere grid y-coordinate for crystal_clear_cell." },
+            tool = new
+            {
+                type = "string",
+                @enum = new[] { "big", "small" },
+                description = "Crystal Sphere tool."
+            }
         },
         required = new[] { "action" }
     };

--- a/STS2AIAgent/Agent/GameBridge.cs
+++ b/STS2AIAgent/Agent/GameBridge.cs
@@ -60,7 +60,15 @@ internal sealed class GameBridge : IGameBridge
         return GameThread.InvokeAsync(() => GameStateService.BuildStatePayload().screen);
     }
 
-    public Task<string> ActAsync(string action, int? cardIndex, int? targetIndex, int? optionIndex, CancellationToken cancellationToken)
+    public Task<string> ActAsync(
+        string action,
+        int? cardIndex,
+        int? targetIndex,
+        int? optionIndex,
+        int? x,
+        int? y,
+        string? tool,
+        CancellationToken cancellationToken)
     {
         return GameThread.InvokeAsync(async () =>
         {
@@ -70,6 +78,9 @@ internal sealed class GameBridge : IGameBridge
                 card_index = cardIndex,
                 target_index = targetIndex,
                 option_index = optionIndex,
+                x = x,
+                y = y,
+                tool = tool,
                 client_context = new
                 {
                     source = "in_game_agent",

--- a/STS2AIAgent/Agent/IGameBridge.cs
+++ b/STS2AIAgent/Agent/IGameBridge.cs
@@ -12,7 +12,15 @@ internal interface IGameBridge
 
     Task<string> GetScreenAsync(CancellationToken cancellationToken);
 
-    Task<string> ActAsync(string action, int? cardIndex, int? targetIndex, int? optionIndex, CancellationToken cancellationToken);
+    Task<string> ActAsync(
+        string action,
+        int? cardIndex,
+        int? targetIndex,
+        int? optionIndex,
+        int? x,
+        int? y,
+        string? tool,
+        CancellationToken cancellationToken);
 
     Task<string> GetGameDataItemJsonAsync(string collection, string itemId, CancellationToken cancellationToken);
 

--- a/STS2AIAgent/Agent/PlayPrompt.cs
+++ b/STS2AIAgent/Agent/PlayPrompt.cs
@@ -37,6 +37,7 @@ Screen playbook:
 - REST: only enabled choose_rest_option. Smith/relic flows may open CARD_SELECTION first.
 - CHEST: open_chest -> choose_treasure_relic -> wait until claimed -> proceed.
 - EVENT: always choose_event_option, including the synthetic proceed option after the event finishes. Reread after every branch.
+- CRYSTAL_SPHERE: crystal_clear_cell spends one divination; tool "big" clears a 3x3 area, "small" clears one cell (pass tool in the same call or switch with crystal_set_tool). Revealed items are granted at the end, including curses. Use crystal_sphere.items/hidden_cells to reveal good items without completing bad ones; all divinations must be spent before proceed appears.
 - MODAL: confirm_modal or dismiss_modal before anything else.
 - GAME_OVER: return_to_main_menu.
 

--- a/STS2AIAgent/Agent/PlayPrompt.cs
+++ b/STS2AIAgent/Agent/PlayPrompt.cs
@@ -48,7 +48,7 @@ If a screenshot or vision caption is present, treat it as supporting context; le
 
     public const string JsonActFallback = """
 If you cannot call tools, reply with a single JSON object and nothing else:
-{"action":"<name from available_actions>","card_index":0,"target_index":0,"option_index":0}
-Omit unused indexes. Do not wrap the JSON in markdown.
+{"action":"<name from available_actions>","card_index":0,"target_index":0,"option_index":0,"x":0,"y":0,"tool":"big"}
+Omit unused parameters. Do not wrap the JSON in markdown.
 """;
 }

--- a/STS2AIAgent/Game/CrystalSphereSettlePolicy.cs
+++ b/STS2AIAgent/Game/CrystalSphereSettlePolicy.cs
@@ -1,0 +1,34 @@
+namespace STS2AIAgent.Game;
+
+internal static class CrystalSphereSettlePolicy
+{
+    public static bool IsSettled(
+        bool screenChanged,
+        bool minigameAvailable,
+        int divinationsBefore,
+        int divinationsNow,
+        bool isFinished,
+        bool canProceed)
+    {
+        if (screenChanged || canProceed)
+        {
+            // Rewards can push a child screen. On the final divination the
+            // minigame entity may disappear before the proceed button is read.
+            return true;
+        }
+
+        if (!minigameAvailable)
+        {
+            // A transient reflection or node-read failure is not proof that the
+            // action settled; keep waiting so callers receive pending on timeout.
+            return false;
+        }
+
+        if (isFinished)
+        {
+            return false;
+        }
+
+        return divinationsNow < divinationsBefore;
+    }
+}

--- a/STS2AIAgent/Game/GameActionService.cs
+++ b/STS2AIAgent/Game/GameActionService.cs
@@ -10,6 +10,7 @@ using MegaCrit.Sts2.Core.Entities.Potions;
 using MegaCrit.Sts2.Core.Entities.RestSite;
 using MegaCrit.Sts2.Core.Context;
 using MegaCrit.Sts2.Core.DevConsole;
+using MegaCrit.Sts2.Core.Events.Custom.CrystalSphereEvent;
 using MegaCrit.Sts2.Core.GameActions;
 using MegaCrit.Sts2.Core.Helpers;
 using MegaCrit.Sts2.Core.Nodes;
@@ -119,6 +120,8 @@ internal static class GameActionService
             "open_chest" => ExecuteOpenChestAsync(),
             "choose_treasure_relic" => ExecuteChooseTreasureRelicAsync(request),
             "choose_event_option" => ExecuteChooseEventOptionAsync(request),
+            "crystal_set_tool" => ExecuteCrystalSetToolAsync(request),
+            "crystal_clear_cell" => ExecuteCrystalClearCellAsync(request),
             "choose_capstone_option" => ExecuteChooseCapstoneOptionAsync(request),
             "choose_bundle" => ExecuteChooseBundleAsync(request),
             "confirm_bundle" => ExecuteConfirmBundleAsync(),
@@ -1194,9 +1197,142 @@ internal static class GameActionService
         return IsStableScreenState(currentScreen, allowMapScreen: true);
     }
 
-    private static async Task<ActionResponsePayload> ExecuteResolveRewardsAsync(ActionRequest request)
+    private static async Task<ActionResponsePayload> ExecuteCrystalSetToolAsync(ActionRequest request)
     {
         var currentScreen = ActiveScreenContext.Instance.GetCurrentScreen();
+        var screen = GameStateService.ResolveScreen(currentScreen);
+        var minigame = GameStateService.GetCrystalSphereMinigame(currentScreen);
+        if (minigame == null || minigame.IsFinished)
+        {
+            throw new ApiException(409, "invalid_action", "Action is not available in the current state.", new
+            {
+                action = "crystal_set_tool",
+                screen
+            });
+        }
+
+        var tool = request.tool?.Trim().ToLowerInvariant() switch
+        {
+            "big" => CrystalSphereMinigame.CrystalSphereToolType.Big,
+            "small" => CrystalSphereMinigame.CrystalSphereToolType.Small,
+            _ => throw new ApiException(400, "invalid_request", "Parameter 'tool' must be \"big\" or \"small\".", new
+            {
+                action = "crystal_set_tool",
+                tool = request.tool
+            })
+        };
+
+        minigame.SetTool(tool);
+        await WaitForNextFrameAsync();
+
+        return new ActionResponsePayload
+        {
+            action = "crystal_set_tool",
+            status = "completed",
+            stable = true,
+            message = $"Crystal sphere tool set to {tool.ToString().ToLowerInvariant()}.",
+            state = GameStateService.BuildStatePayload()
+        };
+    }
+
+    private static async Task<ActionResponsePayload> ExecuteCrystalClearCellAsync(ActionRequest request)
+    {
+        var currentScreen = ActiveScreenContext.Instance.GetCurrentScreen();
+        var screen = GameStateService.ResolveScreen(currentScreen);
+        var minigame = GameStateService.GetCrystalSphereMinigame(currentScreen);
+        if (minigame == null || minigame.IsFinished)
+        {
+            throw new ApiException(409, "invalid_action", "Action is not available in the current state.", new
+            {
+                action = "crystal_clear_cell",
+                screen
+            });
+        }
+
+        if (request.x is not int x || request.y is not int y)
+        {
+            throw new ApiException(400, "invalid_request", "Parameters 'x' and 'y' are required.", new
+            {
+                action = "crystal_clear_cell",
+                screen
+            });
+        }
+
+        var grid = minigame.GridSize;
+        if (x < 0 || x >= grid.X || y < 0 || y >= grid.Y)
+        {
+            throw new ApiException(400, "invalid_request",
+                $"Cell ({x},{y}) is outside the {grid.X}x{grid.Y} crystal sphere grid.", new
+                {
+                    action = "crystal_clear_cell",
+                    screen,
+                    x,
+                    y
+                });
+        }
+
+        // Optional atomic tool switch so agents can play one divination per call.
+        if (request.tool != null)
+        {
+            var tool = request.tool.Trim().ToLowerInvariant() switch
+            {
+                "big" => CrystalSphereMinigame.CrystalSphereToolType.Big,
+                "small" => CrystalSphereMinigame.CrystalSphereToolType.Small,
+                _ => throw new ApiException(400, "invalid_request", "Parameter 'tool' must be \"big\" or \"small\".", new
+                {
+                    action = "crystal_clear_cell",
+                    tool = request.tool
+                })
+            };
+            minigame.SetTool(tool);
+        }
+
+        await minigame.CellClicked(minigame.cells[x, y]);
+        var stable = await WaitForCrystalSphereSettleAsync(currentScreen, TimeSpan.FromSeconds(10));
+
+        return new ActionResponsePayload
+        {
+            action = "crystal_clear_cell",
+            status = stable ? "completed" : "pending",
+            stable = stable,
+            message = stable ? "Action completed." : "Action queued but state is still transitioning.",
+            state = GameStateService.BuildStatePayload()
+        };
+    }
+
+    private static async Task<bool> WaitForCrystalSphereSettleAsync(IScreenContext? screenContext, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            await WaitForNextFrameAsync();
+
+            var currentScreen = ActiveScreenContext.Instance.GetCurrentScreen();
+            if (!ReferenceEquals(currentScreen, screenContext))
+            {
+                // Rewards (e.g. card selection) pushed a child screen on top.
+                return true;
+            }
+
+            var minigame = GameStateService.GetCrystalSphereMinigame(currentScreen);
+            if (minigame == null || !minigame.IsFinished)
+            {
+                // Divination consumed, minigame still running: ready for the next click.
+                return true;
+            }
+
+            if (GameStateService.CanProceed(currentScreen))
+            {
+                // Minigame finished and the proceed button became available.
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static async Task<ActionResponsePayload> ExecuteResolveRewardsAsync(ActionRequest request)
+    {        var currentScreen = ActiveScreenContext.Instance.GetCurrentScreen();
         var screen = GameStateService.ResolveScreen(currentScreen);
 
         if (!GameStateService.CanCollectRewardsAndProceed(currentScreen) &&
@@ -4802,6 +4938,12 @@ internal sealed class ActionRequest
     public int? target_index { get; init; }
 
     public int? option_index { get; init; }
+
+    public int? x { get; init; }
+
+    public int? y { get; init; }
+
+    public string? tool { get; init; }
 
     public string? command { get; init; }
 

--- a/STS2AIAgent/Game/GameActionService.cs
+++ b/STS2AIAgent/Game/GameActionService.cs
@@ -1211,18 +1211,16 @@ internal static class GameActionService
             });
         }
 
-        var tool = request.tool?.Trim().ToLowerInvariant() switch
+        var tool = ParseCrystalSphereTool(request.tool, "crystal_set_tool");
+        if (!GameStateService.TrySetCrystalSphereTool(currentScreen, tool))
         {
-            "big" => CrystalSphereMinigame.CrystalSphereToolType.Big,
-            "small" => CrystalSphereMinigame.CrystalSphereToolType.Small,
-            _ => throw new ApiException(400, "invalid_request", "Parameter 'tool' must be \"big\" or \"small\".", new
+            throw new ApiException(503, "state_unavailable", "Crystal Sphere tool controls are unavailable.", new
             {
                 action = "crystal_set_tool",
-                tool = request.tool
-            })
-        };
+                screen
+            }, retryable: true);
+        }
 
-        minigame.SetTool(tool);
         await WaitForNextFrameAsync();
 
         return new ActionResponsePayload
@@ -1274,21 +1272,21 @@ internal static class GameActionService
         // Optional atomic tool switch so agents can play one divination per call.
         if (request.tool != null)
         {
-            var tool = request.tool.Trim().ToLowerInvariant() switch
+            var tool = ParseCrystalSphereTool(request.tool, "crystal_clear_cell");
+            if (!GameStateService.TrySetCrystalSphereTool(currentScreen, tool))
             {
-                "big" => CrystalSphereMinigame.CrystalSphereToolType.Big,
-                "small" => CrystalSphereMinigame.CrystalSphereToolType.Small,
-                _ => throw new ApiException(400, "invalid_request", "Parameter 'tool' must be \"big\" or \"small\".", new
+                throw new ApiException(503, "state_unavailable", "Crystal Sphere tool controls are unavailable.", new
                 {
                     action = "crystal_clear_cell",
-                    tool = request.tool
-                })
-            };
-            minigame.SetTool(tool);
+                    screen
+                }, retryable: true);
+            }
         }
 
+        var divinationsBefore = minigame.DivinationCount;
         await minigame.CellClicked(minigame.cells[x, y]);
-        var stable = await WaitForCrystalSphereSettleAsync(currentScreen, TimeSpan.FromSeconds(10));
+        var stable = await WaitForCrystalSphereSettleAsync(
+            currentScreen, divinationsBefore, TimeSpan.FromSeconds(10));
 
         return new ActionResponsePayload
         {
@@ -1300,7 +1298,26 @@ internal static class GameActionService
         };
     }
 
-    private static async Task<bool> WaitForCrystalSphereSettleAsync(IScreenContext? screenContext, TimeSpan timeout)
+    private static CrystalSphereMinigame.CrystalSphereToolType ParseCrystalSphereTool(
+        string? rawTool,
+        string action)
+    {
+        return rawTool?.Trim().ToLowerInvariant() switch
+        {
+            "big" => CrystalSphereMinigame.CrystalSphereToolType.Big,
+            "small" => CrystalSphereMinigame.CrystalSphereToolType.Small,
+            _ => throw new ApiException(
+                400,
+                "invalid_request",
+                "Parameter 'tool' must be \"big\" or \"small\".",
+                new { action, tool = rawTool })
+        };
+    }
+
+    private static async Task<bool> WaitForCrystalSphereSettleAsync(
+        IScreenContext? screenContext,
+        int divinationsBefore,
+        TimeSpan timeout)
     {
         var deadline = DateTime.UtcNow + timeout;
         while (DateTime.UtcNow < deadline)
@@ -1308,22 +1325,16 @@ internal static class GameActionService
             await WaitForNextFrameAsync();
 
             var currentScreen = ActiveScreenContext.Instance.GetCurrentScreen();
-            if (!ReferenceEquals(currentScreen, screenContext))
-            {
-                // Rewards (e.g. card selection) pushed a child screen on top.
-                return true;
-            }
-
+            var screenChanged = !ReferenceEquals(currentScreen, screenContext);
             var minigame = GameStateService.GetCrystalSphereMinigame(currentScreen);
-            if (minigame == null || !minigame.IsFinished)
+            if (CrystalSphereSettlePolicy.IsSettled(
+                    screenChanged,
+                    minigame != null,
+                    divinationsBefore,
+                    minigame?.DivinationCount ?? divinationsBefore,
+                    minigame?.IsFinished ?? false,
+                    GameStateService.CanProceed(currentScreen)))
             {
-                // Divination consumed, minigame still running: ready for the next click.
-                return true;
-            }
-
-            if (GameStateService.CanProceed(currentScreen))
-            {
-                // Minigame finished and the proceed button became available.
                 return true;
             }
         }
@@ -1332,7 +1343,8 @@ internal static class GameActionService
     }
 
     private static async Task<ActionResponsePayload> ExecuteResolveRewardsAsync(ActionRequest request)
-    {        var currentScreen = ActiveScreenContext.Instance.GetCurrentScreen();
+    {
+        var currentScreen = ActiveScreenContext.Instance.GetCurrentScreen();
         var screen = GameStateService.ResolveScreen(currentScreen);
 
         if (!GameStateService.CanCollectRewardsAndProceed(currentScreen) &&

--- a/STS2AIAgent/Game/GameStateService.cs
+++ b/STS2AIAgent/Game/GameStateService.cs
@@ -29,6 +29,7 @@ using MegaCrit.Sts2.Core.Nodes.Cards.Holders;
 using MegaCrit.Sts2.Core.Nodes.Combat;
 using MegaCrit.Sts2.Core.Nodes.CommonUi;
 using MegaCrit.Sts2.Core.Nodes.Debug.Multiplayer;
+using MegaCrit.Sts2.Core.Nodes.Events;
 using MegaCrit.Sts2.Core.Nodes.Events.Custom.CrystalSphere;
 using MegaCrit.Sts2.Core.Nodes.Ftue;
 using MegaCrit.Sts2.Core.Nodes.GodotExtensions;
@@ -55,11 +56,13 @@ namespace STS2AIAgent.Game;
 
 internal static class GameStateService
 {
-    private const int StateVersion = 10;
-    private const int AgentViewVersion = 5;
+    private const int StateVersion = 11;
+    private const int AgentViewVersion = 6;
     private static readonly TimeSpan CombatActionSnapshotStableDelay = TimeSpan.FromMilliseconds(200);
     private static string? _lastCombatActionReadinessSignature;
     private static DateTime _lastCombatActionReadinessSinceUtc = DateTime.MinValue;
+    private static bool _crystalSphereEntityLookupWarningLogged;
+    private static bool _crystalSphereButtonLookupWarningLogged;
     private static readonly FieldInfo? StartRunLobbyMaxPlayersField =
         typeof(StartRunLobby).GetField("_maxPlayers", BindingFlags.Instance | BindingFlags.NonPublic);
 
@@ -137,6 +140,7 @@ internal static class GameStateService
                 timeline,
                 chest,
                 eventPayload,
+                crystalSphere,
                 shop,
                 rest,
                 reward,
@@ -903,20 +907,106 @@ internal static class GameStateService
             return null;
         }
 
-        try
+        if (CrystalSphereEntityField == null)
         {
-            return CrystalSphereEntityField?.GetValue(crystalSphereScreen) as CrystalSphereMinigame;
-        }
-        catch
-        {
+            LogCrystalSphereEntityLookupFailure(
+                "private field NCrystalSphereScreen._entity was not found");
             return null;
         }
+
+        try
+        {
+            var minigame = CrystalSphereEntityField.GetValue(crystalSphereScreen) as CrystalSphereMinigame;
+            if (minigame == null)
+            {
+                LogCrystalSphereEntityLookupFailure(
+                    "private field NCrystalSphereScreen._entity did not contain a CrystalSphereMinigame");
+            }
+
+            return minigame;
+        }
+        catch (Exception ex)
+        {
+            LogCrystalSphereEntityLookupFailure(
+                $"reading NCrystalSphereScreen._entity threw {ex.GetType().Name}: {ex.Message}");
+            return null;
+        }
+    }
+
+    private static void LogCrystalSphereEntityLookupFailure(string reason)
+    {
+        if (_crystalSphereEntityLookupWarningLogged)
+        {
+            return;
+        }
+
+        _crystalSphereEntityLookupWarningLogged = true;
+        Log.Warn($"[STS2AIAgent] Crystal Sphere state is unavailable: {reason}.");
     }
 
     public static bool CanPlayCrystalSphere(IScreenContext? currentScreen)
     {
         var minigame = GetCrystalSphereMinigame(currentScreen);
         return minigame is { IsFinished: false };
+    }
+
+    public static bool TrySetCrystalSphereTool(
+        IScreenContext? currentScreen,
+        CrystalSphereMinigame.CrystalSphereToolType tool)
+    {
+        var minigame = GetCrystalSphereMinigame(currentScreen);
+        if (minigame == null || minigame.IsFinished)
+        {
+            return false;
+        }
+
+        minigame.SetTool(tool);
+
+        if (currentScreen is not NCrystalSphereScreen crystalSphereScreen)
+        {
+            return true;
+        }
+
+        try
+        {
+            var bigButton = crystalSphereScreen.GetNodeOrNull<NDivinationButton>("%BigDivinationButton");
+            var smallButton = crystalSphereScreen.GetNodeOrNull<NDivinationButton>("%SmallDivinationButton");
+            if (bigButton == null || smallButton == null)
+            {
+                LogCrystalSphereButtonLookupFailure(
+                    $"missing button node(s): big={bigButton != null}, small={smallButton != null}");
+            }
+
+            if (bigButton != null && GodotObject.IsInstanceValid(bigButton))
+            {
+                bigButton.SetActive(tool == CrystalSphereMinigame.CrystalSphereToolType.Big);
+            }
+
+            if (smallButton != null && GodotObject.IsInstanceValid(smallButton))
+            {
+                smallButton.SetActive(tool == CrystalSphereMinigame.CrystalSphereToolType.Small);
+            }
+        }
+        catch (Exception ex)
+        {
+            // The model state is authoritative; keep the action valid even if a
+            // future UI scene revision prevents the visual active-state update.
+            LogCrystalSphereButtonLookupFailure(
+                $"button synchronization threw {ex.GetType().Name}: {ex.Message}");
+        }
+
+        return true;
+    }
+
+    private static void LogCrystalSphereButtonLookupFailure(string reason)
+    {
+        if (_crystalSphereButtonLookupWarningLogged)
+        {
+            return;
+        }
+
+        _crystalSphereButtonLookupWarningLogged = true;
+        Log.Warn($"[STS2AIAgent] Crystal Sphere tool button state could not be synchronized: {reason}.");
     }
 
     public static IReadOnlyList<NButton> GetCapstoneButtons(IScreenContext? currentScreen)
@@ -2487,6 +2577,7 @@ internal static class GameStateService
         TimelinePayload? timeline,
         ChestPayload? chest,
         EventPayload? eventPayload,
+        CrystalSpherePayload? crystalSphere,
         ShopPayload? shop,
         RestPayload? rest,
         RewardPayload? reward,
@@ -2516,6 +2607,7 @@ internal static class GameStateService
             timeline = BuildAgentTimelinePayload(timeline),
             chest = BuildAgentChestPayload(chest),
             @event = BuildAgentEventPayload(eventPayload),
+            crystal_sphere = crystalSphere,
             shop = BuildAgentShopPayload(shop, glossaryTerms),
             rest = BuildAgentRestPayload(rest),
             reward = BuildAgentRewardPayload(reward, glossaryTerms),
@@ -6235,6 +6327,7 @@ internal sealed class CrystalSphereItemPayload
 internal sealed class ShopPayload
 {
     public bool is_open { get; init; }
+
     public bool can_open { get; init; }
 
     public bool can_close { get; init; }

--- a/STS2AIAgent/Game/GameStateService.cs
+++ b/STS2AIAgent/Game/GameStateService.cs
@@ -13,6 +13,7 @@ using MegaCrit.Sts2.Core.Entities.Potions;
 using MegaCrit.Sts2.Core.Entities.RestSite;
 using MegaCrit.Sts2.Core.Events;
 using MegaCrit.Sts2.Core.Context;
+using MegaCrit.Sts2.Core.Events.Custom.CrystalSphereEvent;
 using MegaCrit.Sts2.Core.Helpers;
 using MegaCrit.Sts2.Core.Map;
 using MegaCrit.Sts2.Core.Models;
@@ -28,6 +29,7 @@ using MegaCrit.Sts2.Core.Nodes.Cards.Holders;
 using MegaCrit.Sts2.Core.Nodes.Combat;
 using MegaCrit.Sts2.Core.Nodes.CommonUi;
 using MegaCrit.Sts2.Core.Nodes.Debug.Multiplayer;
+using MegaCrit.Sts2.Core.Nodes.Events.Custom.CrystalSphere;
 using MegaCrit.Sts2.Core.Nodes.Ftue;
 using MegaCrit.Sts2.Core.Nodes.GodotExtensions;
 using MegaCrit.Sts2.Core.Nodes.Rewards;
@@ -80,6 +82,7 @@ internal static class GameStateService
         var unlock = BuildUnlockPayload(currentScreen);
         var chest = BuildChestPayload(currentScreen);
         var eventPayload = BuildEventPayload(currentScreen);
+        var crystalSphere = BuildCrystalSpherePayload(currentScreen);
         var shop = BuildShopPayload(currentScreen);
         var rest = BuildRestPayload(currentScreen, runState);
         var reward = BuildRewardPayload(currentScreen);
@@ -108,6 +111,7 @@ internal static class GameStateService
             unlock = unlock,
             chest = chest,
             @event = eventPayload,
+            crystal_sphere = crystalSphere,
             shop = shop,
             rest = rest,
             reward = reward,
@@ -454,6 +458,22 @@ internal static class GameStateService
                 name = "choose_capstone_option",
                 requires_target = false,
                 requires_index = true
+            });
+        }
+
+        if (CanPlayCrystalSphere(currentScreen))
+        {
+            descriptors.Add(new ActionDescriptor
+            {
+                name = "crystal_set_tool",
+                requires_target = false,
+                requires_index = false
+            });
+            descriptors.Add(new ActionDescriptor
+            {
+                name = "crystal_clear_cell",
+                requires_target = false,
+                requires_index = false
             });
         }
 
@@ -871,6 +891,32 @@ internal static class GameStateService
     public static bool CanChooseCapstoneOption(IScreenContext? currentScreen)
     {
         return GetCapstoneButtons(currentScreen).Count > 0;
+    }
+
+    private static readonly FieldInfo? CrystalSphereEntityField =
+        typeof(NCrystalSphereScreen).GetField("_entity", BindingFlags.NonPublic | BindingFlags.Instance);
+
+    public static CrystalSphereMinigame? GetCrystalSphereMinigame(IScreenContext? currentScreen)
+    {
+        if (currentScreen is not NCrystalSphereScreen crystalSphereScreen)
+        {
+            return null;
+        }
+
+        try
+        {
+            return CrystalSphereEntityField?.GetValue(crystalSphereScreen) as CrystalSphereMinigame;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public static bool CanPlayCrystalSphere(IScreenContext? currentScreen)
+    {
+        var minigame = GetCrystalSphereMinigame(currentScreen);
+        return minigame is { IsFinished: false };
     }
 
     public static IReadOnlyList<NButton> GetCapstoneButtons(IScreenContext? currentScreen)
@@ -2129,6 +2175,12 @@ internal static class GameStateService
         if (CanProceed(currentScreen))
         {
             names.Add("proceed");
+        }
+
+        if (CanPlayCrystalSphere(currentScreen))
+        {
+            names.Add("crystal_set_tool");
+            names.Add("crystal_clear_cell");
         }
 
         if (CanOpenChest(currentScreen))
@@ -3810,6 +3862,85 @@ internal static class GameStateService
         catch (Exception ex)
         {
             Log.Warn($"[STS2AIAgent] Failed to build event payload on screen {currentScreen.GetType().FullName}: {ex}");
+            return null;
+        }
+    }
+
+    private static CrystalSpherePayload? BuildCrystalSpherePayload(IScreenContext? currentScreen)
+    {
+        var minigame = GetCrystalSphereMinigame(currentScreen);
+        if (minigame == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            var grid = minigame.GridSize;
+            var cells = minigame.cells;
+            var hiddenCells = new List<int[]>();
+            var items = new List<CrystalSphereItemPayload>();
+
+            for (var x = 0; x < grid.X; x++)
+            {
+                for (var y = 0; y < grid.Y; y++)
+                {
+                    if (cells[x, y].IsHidden)
+                    {
+                        hiddenCells.Add(new[] { x, y });
+                    }
+                }
+            }
+
+            foreach (var item in minigame.Items)
+            {
+                // Occupied cells are the source of truth: items that failed to
+                // place occupy no cells, can never be revealed, and are omitted.
+                var occupied = new List<CrystalSphereCell>();
+                for (var x = 0; x < grid.X; x++)
+                {
+                    for (var y = 0; y < grid.Y; y++)
+                    {
+                        if (ReferenceEquals(cells[x, y].Item, item))
+                        {
+                            occupied.Add(cells[x, y]);
+                        }
+                    }
+                }
+
+                if (occupied.Count == 0)
+                {
+                    continue;
+                }
+
+                items.Add(new CrystalSphereItemPayload
+                {
+                    kind = item.GetType().Name.Replace("CrystalSphere", string.Empty),
+                    is_good = SafeReadBool(() => item.IsGood),
+                    x = occupied.Min(c => c.X),
+                    y = occupied.Min(c => c.Y),
+                    width = item.Size.X,
+                    height = item.Size.Y,
+                    revealed = occupied.All(c => !c.IsHidden),
+                    cells = occupied.Select(c => new[] { c.X, c.Y }).ToArray(),
+                    hidden_cells = occupied.Where(c => c.IsHidden).Select(c => new[] { c.X, c.Y }).ToArray()
+                });
+            }
+
+            return new CrystalSpherePayload
+            {
+                divinations_left = minigame.DivinationCount,
+                tool = minigame.CrystalSphereTool.ToString().ToLowerInvariant(),
+                is_finished = minigame.IsFinished,
+                grid_width = grid.X,
+                grid_height = grid.Y,
+                hidden_cells = hiddenCells.ToArray(),
+                items = items.ToArray()
+            };
+        }
+        catch (Exception ex)
+        {
+            Log.Warn($"[STS2AIAgent] Failed to build crystal sphere payload: {ex}");
             return null;
         }
     }
@@ -5540,6 +5671,7 @@ internal static class GameStateService
             NCharacterSelectScreen => "CHARACTER_SELECT",
             NChooseABundleSelectionScreen => "BUNDLE_SELECTION",
             NCapstoneSubmenuStack => "CAPSTONE_SELECTION",
+            NCrystalSphereScreen => "CRYSTAL_SPHERE",
             NPatchNotesScreen => "MAIN_MENU",
             NSubmenu => "MAIN_MENU",
             NLogoAnimation => "MAIN_MENU",
@@ -5685,6 +5817,8 @@ internal sealed class GameStatePayload
     public ChestPayload? chest { get; init; }
 
     public EventPayload? @event { get; init; }
+
+    public CrystalSpherePayload? crystal_sphere { get; init; }
 
     public ShopPayload? shop { get; init; }
 
@@ -6060,10 +6194,47 @@ internal sealed class RestOptionPayload
     public string[] valid_target_player_ids { get; init; } = Array.Empty<string>();
 }
 
+internal sealed class CrystalSpherePayload
+{
+    public int divinations_left { get; init; }
+
+    public string tool { get; init; } = "none";
+
+    public bool is_finished { get; init; }
+
+    public int grid_width { get; init; }
+
+    public int grid_height { get; init; }
+
+    public int[][] hidden_cells { get; init; } = Array.Empty<int[]>();
+
+    public CrystalSphereItemPayload[] items { get; init; } = Array.Empty<CrystalSphereItemPayload>();
+}
+
+internal sealed class CrystalSphereItemPayload
+{
+    public string kind { get; init; } = string.Empty;
+
+    public bool is_good { get; init; }
+
+    public int x { get; init; }
+
+    public int y { get; init; }
+
+    public int width { get; init; }
+
+    public int height { get; init; }
+
+    public bool revealed { get; init; }
+
+    public int[][] cells { get; init; } = Array.Empty<int[]>();
+
+    public int[][] hidden_cells { get; init; } = Array.Empty<int[]>();
+}
+
 internal sealed class ShopPayload
 {
     public bool is_open { get; init; }
-
     public bool can_open { get; init; }
 
     public bool can_close { get; init; }

--- a/docs/api.md
+++ b/docs/api.md
@@ -65,6 +65,7 @@
 | `MAP` | 地图界面 |
 | `COMBAT` | 战斗中 |
 | `EVENT` | 事件交互 |
+| `CRYSTAL_SPHERE` | 水晶球占卜小游戏 |
 | `SHOP` | 商店 |
 | `REST` | 休息点 |
 | `REWARD` | 奖励结算 / 卡牌奖励选择 |
@@ -115,7 +116,7 @@
 
 | 字段 | 类型 | 说明 |
 | --- | --- | --- |
-| `state_version` | number | 状态模型版本（当前固定为 6） |
+| `state_version` | number | 状态模型版本（当前固定为 11） |
 | `run_id` | string | 本局运行标识（种子字符串） |
 | `screen` | string | 当前逻辑界面（见 Screen 枚举） |
 | `in_combat` | boolean | 是否处于战斗流程 |
@@ -128,6 +129,7 @@
 | `selection` | object \| null | 选牌状态（仅选牌界面存在） |
 | `chest` | object \| null | 宝箱状态（仅宝箱房存在） |
 | `event` | object \| null | 事件状态（仅事件房存在） |
+| `crystal_sphere` | object \| null | 水晶球棋盘状态（仅占卜小游戏存在） |
 | `shop` | object \| null | 商店状态（仅商店房存在） |
 | `rest` | object \| null | 休息点状态（仅休息点存在） |
 | `character_select` | object \| null | 角色选择状态（仅角色选择界面存在） |
@@ -450,6 +452,24 @@
 | `will_kill_player` | boolean | 该选项是否会导致玩家死亡（若模型提供） |
 | `has_relic_preview` | boolean | 该选项是否包含遗物预览（若模型提供） |
 
+### `crystal_sphere` 子结构
+
+当 `screen` 为 `CRYSTAL_SPHERE` 时存在。完整 `/state` 与 compact
+`agent_view` 都包含同一棋盘信息，因此默认 MCP `get_game_state` 可以直接规划点击。
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `divinations_left` | number | 剩余占卜次数；必须用完才会出现 `proceed` |
+| `tool` | string | 当前工具：`big`（3×3）或 `small`（单格） |
+| `is_finished` | boolean | 是否已用完占卜次数 |
+| `grid_width` / `grid_height` | number | 棋盘尺寸 |
+| `hidden_cells` | number[][] | 尚未清开的 `[x,y]` 坐标 |
+| `items[]` | object[] | 已成功放置的奖励/诅咒及其占格信息 |
+
+`items[]` 包含 `kind`、`is_good`、`x/y/width/height`、`revealed`、
+`cells` 和 `hidden_cells`。物品的全部占格被清开后才会揭示；结束时所有已揭示物品都会发放，
+包括诅咒。
+
 ### `rest` 子结构
 
 当 `screen` 为 `REST` 时存在。
@@ -521,7 +541,7 @@
   "ok": true,
   "request_id": "req_20260310_120000_1234",
   "data": {
-    "state_version": 6,
+    "state_version": 11,
     "run_id": "WXJVZBQFK2",
     "screen": "COMBAT",
     "in_combat": true,
@@ -877,6 +897,9 @@
 | `card_index` | number \| null | 手牌索引（`play_card` 时使用） |
 | `target_index` | number \| null | 目标索引（需要指定目标的卡牌使用） |
 | `option_index` | number \| null | 选项索引（地图/奖励/选牌等使用） |
+| `x` | number \| null | 水晶球格子的 X 坐标（`crystal_clear_cell`） |
+| `y` | number \| null | 水晶球格子的 Y 坐标（`crystal_clear_cell`） |
+| `tool` | string \| null | 水晶球工具：`big` 或 `small` |
 | `client_context` | object \| null | 可选的客户端上下文（如调用来源标识） |
 
 ### 通用响应结构（ActionResponsePayload）
@@ -1106,6 +1129,30 @@
 请求: { "action": "choose_event_option", "option_index": 0 }
 ```
 
+### `crystal_set_tool`
+
+切换水晶球占卜工具，并同步游戏画面中大小占卜按钮的 active 状态。
+
+- **前提**：`screen = "CRYSTAL_SPHERE"` 且 `is_finished = false`
+- **参数**：`tool`（必填），只能是 `big` 或 `small`
+
+```json
+{ "action": "crystal_set_tool", "tool": "small" }
+```
+
+### `crystal_clear_cell`
+
+在指定坐标消耗一次占卜。可以在同一请求中原子切换工具，避免“先切工具、后点格子”之间读取到
+过期状态。
+
+- **前提**：`screen = "CRYSTAL_SPHERE"` 且 `is_finished = false`
+- **参数**：`x`、`y` 必填；`tool` 可选（`big` 或 `small`）
+- **稳定条件**：剩余次数实际下降、奖励子屏接管，或最后一次占卜后 `proceed` 可用
+
+```json
+{ "action": "crystal_clear_cell", "x": 5, "y": 6, "tool": "big" }
+```
+
 ### `choose_rest_option`
 
 选择休息点的一个操作。
@@ -1272,6 +1319,16 @@
 4. GET /state                          → 事件可能更新选项或完成
 5. 若 event.is_finished=true，选项仅剩 proceed（index=0）
 6. POST /action { choose_event_option, option_index=0 }  → 离开事件，返回地图
+```
+
+### 水晶球占卜
+
+```
+1. GET /state                          → screen=CRYSTAL_SPHERE
+2. 读取 crystal_sphere.items / hidden_cells，规划不完整揭示坏物品的坐标
+3. POST /action { crystal_clear_cell, x, y, tool="big" }
+4. 重复 1-3，直到 divinations_left=0
+5. 处理可能出现的奖励子屏；回到占卜屏后 POST /action { proceed }
 ```
 
 ### 休息点（恢复 HP）

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -87,6 +87,8 @@
 - `open_chest`
 - `choose_treasure_relic`
 - `choose_event_option`
+- `crystal_set_tool`
+- `crystal_clear_cell`
 - `choose_rest_option`
 - `open_shop_inventory`
 - `close_shop_inventory`
@@ -131,6 +133,11 @@ Modal：
 3. 只调用当前 `available_actions` 里出现的动作。
 4. 每次动作后重新读取状态，不复用旧索引。
 5. 优先用高层动作，不要把可合并流程拆碎。
+
+`guided` / `layered` profile 使用统一 `act` 工具时，水晶球动作额外接受
+`x`、`y`、`tool`：`crystal_clear_cell` 必须传坐标，可选在同一调用传
+`tool="big"|"small"`；`crystal_set_tool` 只传 `tool`。完整棋盘来自
+`get_game_state().crystal_sphere`。
 
 高层动作优先级：
 

--- a/mcp_server/src/sts2_mcp/client.py
+++ b/mcp_server/src/sts2_mcp/client.py
@@ -423,6 +423,28 @@ class Sts2Client:
             },
         )
 
+    def crystal_set_tool(self, tool: str) -> dict[str, Any]:
+        return self.execute_action(
+            "crystal_set_tool",
+            tool=tool,
+            client_context={
+                "source": "mcp",
+                "tool_name": "crystal_set_tool",
+            },
+        )
+
+    def crystal_clear_cell(self, x: int, y: int, tool: str | None = None) -> dict[str, Any]:
+        return self.execute_action(
+            "crystal_clear_cell",
+            x=x,
+            y=y,
+            tool=tool,
+            client_context={
+                "source": "mcp",
+                "tool_name": "crystal_clear_cell",
+            },
+        )
+
     def choose_capstone_option(self, option_index: int) -> dict[str, Any]:
         return self.execute_action(
             "choose_capstone_option",
@@ -631,6 +653,9 @@ class Sts2Client:
         card_index: int | None = None,
         target_index: int | None = None,
         option_index: int | None = None,
+        x: int | None = None,
+        y: int | None = None,
+        tool: str | None = None,
         command: str | None = None,
         client_context: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
@@ -642,6 +667,9 @@ class Sts2Client:
                 "card_index": card_index,
                 "target_index": target_index,
                 "option_index": option_index,
+                "x": x,
+                "y": y,
+                "tool": tool,
                 "command": command,
                 "client_context": client_context,
             },

--- a/mcp_server/src/sts2_mcp/server.py
+++ b/mcp_server/src/sts2_mcp/server.py
@@ -4,7 +4,7 @@ import os
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any, Callable, Literal
 
 from fastmcp import FastMCP
 
@@ -13,6 +13,7 @@ from .handoff import Sts2HandoffService
 from .knowledge import Sts2KnowledgeBase
 
 ToolHandler = Callable[..., dict[str, Any]]
+CrystalSphereTool = Literal["big", "small"]
 
 KNOWN_ITEM_ID_KEYS = ("id", "ID", "Id")
 ITEM_IDS_SEPARATOR = ","
@@ -68,6 +69,8 @@ _LEGACY_ACTION_TOOLS: tuple[ActionToolSpec, ...] = (
     ActionToolSpec("open_chest", "no_args", "Open the treasure chest in the current room."),
     ActionToolSpec("choose_treasure_relic", "option_index", "Choose a relic from an opened chest."),
     ActionToolSpec("choose_event_option", "option_index", "Choose an option in the current event room."),
+    ActionToolSpec("crystal_set_tool", "crystal_tool", "Choose the big or small Crystal Sphere divination tool."),
+    ActionToolSpec("crystal_clear_cell", "crystal_cell", "Spend one divination at a Crystal Sphere grid coordinate."),
     ActionToolSpec("choose_capstone_option", "option_index", "Choose an option on the capstone selection screen."),
     ActionToolSpec("choose_bundle", "option_index", "Choose a card bundle on the bundle selection screen."),
     ActionToolSpec("confirm_bundle", "no_args", "Confirm the selected card bundle."),
@@ -387,6 +390,24 @@ def _register_option_target_tool(mcp: FastMCP, name: str, description: str, hand
     mcp.tool(name=name, description=description)(tool)
 
 
+def _register_crystal_tool(mcp: FastMCP, name: str, description: str, handler: ToolHandler) -> None:
+    def action_tool(tool: CrystalSphereTool) -> dict[str, Any]:
+        return handler(tool=tool)
+
+    action_tool.__name__ = name
+    action_tool.__doc__ = description
+    mcp.tool(name=name, description=description)(action_tool)
+
+
+def _register_crystal_cell_tool(mcp: FastMCP, name: str, description: str, handler: ToolHandler) -> None:
+    def action_tool(x: int, y: int, tool: CrystalSphereTool | None = None) -> dict[str, Any]:
+        return handler(x=x, y=y, tool=tool)
+
+    action_tool.__name__ = name
+    action_tool.__doc__ = description
+    mcp.tool(name=name, description=description)(action_tool)
+
+
 def _register_legacy_action_tools(mcp: FastMCP, sts2: Sts2Client) -> None:
     for spec in _LEGACY_ACTION_TOOLS:
         handler = getattr(sts2, spec.name)
@@ -404,6 +425,14 @@ def _register_legacy_action_tools(mcp: FastMCP, sts2: Sts2Client) -> None:
 
         if spec.kind == "option_target":
             _register_option_target_tool(mcp, spec.name, spec.description, handler)
+            continue
+
+        if spec.kind == "crystal_tool":
+            _register_crystal_tool(mcp, spec.name, spec.description, handler)
+            continue
+
+        if spec.kind == "crystal_cell":
+            _register_crystal_cell_tool(mcp, spec.name, spec.description, handler)
             continue
 
         raise RuntimeError(f"Unsupported action tool kind: {spec.kind}")
@@ -757,6 +786,9 @@ def create_server(client: Sts2Client | None = None, tool_profile: str | None = N
         card_index: int | None = None,
         target_index: int | None = None,
         option_index: int | None = None,
+        x: int | None = None,
+        y: int | None = None,
+        tool: CrystalSphereTool | None = None,
     ) -> dict[str, Any]:
         """Execute one currently available game action through the compact tool surface.
 
@@ -764,7 +796,8 @@ def create_server(client: Sts2Client | None = None, tool_profile: str | None = N
             1. Call `get_game_state()` or `get_available_actions()`.
             2. Branch on `state.session.mode` and `state.session.phase`.
             3. Pick an action that is currently available.
-            4. Pass only the indices required by that action from the latest state.
+            4. Pass only the indexes or Crystal Sphere coordinates required by
+               that action from the latest state.
             5. Read state again after the action completes.
 
         Compact-tool rules:
@@ -780,6 +813,9 @@ def create_server(client: Sts2Client | None = None, tool_profile: str | None = N
             - Use `option_index` for map, reward, shop, event, rest, selection,
               and multiplayer-lobby actions.
             - Use `target_index` when the latest state marks a card, potion, or rest option as `requires_target=true`.
+            - Use `x` and `y` for `crystal_clear_cell`; optionally pass
+              `tool="big"` or `tool="small"` atomically. Use `tool` alone
+              with `crystal_set_tool`.
             - Read `target_index_space` and `valid_target_indices` from state to know whether `target_index`
               refers to `combat.enemies[]`, `combat.players[]`, or `run.players[]`.
             - `run_console_command` is intentionally excluded from this compact tool.
@@ -793,6 +829,9 @@ def create_server(client: Sts2Client | None = None, tool_profile: str | None = N
             card_index=card_index,
             target_index=target_index,
             option_index=option_index,
+            x=x,
+            y=y,
+            tool=tool,
             client_context={
                 "source": "mcp",
                 "tool_name": "act",

--- a/mcp_server/tests/test_crystal_sphere_tools.py
+++ b/mcp_server/tests/test_crystal_sphere_tools.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import asyncio
+import unittest
+from unittest.mock import patch
+
+from sts2_mcp.client import Sts2Client
+from sts2_mcp.server import create_server
+
+
+class RecordingClient:
+    def __init__(self, state: dict) -> None:
+        self.state = state
+        self.action_calls: list[tuple[str, dict]] = []
+
+    def get_state(self) -> dict:
+        return self.state
+
+    def execute_action(self, action: str, **kwargs) -> dict:
+        self.action_calls.append((action, kwargs))
+        return {"action": action, "status": "completed", "stable": True}
+
+
+class CrystalSphereToolTests(unittest.TestCase):
+    def test_guided_get_game_state_exposes_crystal_sphere(self) -> None:
+        crystal_sphere = {
+            "divinations_left": 3,
+            "grid_width": 11,
+            "grid_height": 11,
+            "hidden_cells": [[4, 5]],
+            "items": [{"kind": "Relic", "hidden_cells": [[4, 5]]}],
+        }
+        client = RecordingClient(
+            {
+                "screen": "CRYSTAL_SPHERE",
+                "crystal_sphere": crystal_sphere,
+                "agent_view": {
+                    "screen": "CRYSTAL_SPHERE",
+                    "actions": ["crystal_clear_cell"],
+                    "crystal_sphere": crystal_sphere,
+                },
+            }
+        )
+        server = create_server(client=client, tool_profile="guided")
+        tool = asyncio.run(server.get_tool("get_game_state"))
+
+        result = tool.fn()
+
+        self.assertEqual(result["screen"], "CRYSTAL_SPHERE")
+        self.assertEqual(result["crystal_sphere"], crystal_sphere)
+        self.assertEqual(result["available_actions"], ["crystal_clear_cell"])
+
+    def test_guided_act_forwards_crystal_coordinates_and_tool(self) -> None:
+        client = RecordingClient({"screen": "CRYSTAL_SPHERE"})
+        server = create_server(client=client, tool_profile="guided")
+        tool = asyncio.run(server.get_tool("act"))
+
+        tool_schema = tool.parameters["properties"]["tool"]
+        string_schema = next(
+            schema for schema in tool_schema["anyOf"] if schema.get("type") == "string"
+        )
+        self.assertEqual(string_schema["enum"], ["big", "small"])
+
+        result = tool.fn(
+            action="crystal_clear_cell",
+            x=4,
+            y=7,
+            tool="small",
+        )
+
+        self.assertTrue(result["stable"])
+        self.assertEqual(len(client.action_calls), 1)
+        action, kwargs = client.action_calls[0]
+        self.assertEqual(action, "crystal_clear_cell")
+        self.assertEqual(kwargs["x"], 4)
+        self.assertEqual(kwargs["y"], 7)
+        self.assertEqual(kwargs["tool"], "small")
+
+    def test_client_execute_action_posts_crystal_fields(self) -> None:
+        client = Sts2Client(base_url="http://127.0.0.1:8080")
+
+        with patch.object(client, "_request", return_value={"ok": True}) as request_mock:
+            client.execute_action(
+                "crystal_clear_cell",
+                x=2,
+                y=9,
+                tool="big",
+                client_context={"source": "test"},
+            )
+
+        request_mock.assert_called_once_with(
+            "POST",
+            "/action",
+            payload={
+                "action": "crystal_clear_cell",
+                "card_index": None,
+                "target_index": None,
+                "option_index": None,
+                "x": 2,
+                "y": 9,
+                "tool": "big",
+                "command": None,
+                "client_context": {"source": "test"},
+            },
+            is_action=True,
+        )
+
+    def test_full_profile_exposes_crystal_actions(self) -> None:
+        client = Sts2Client(base_url="http://127.0.0.1:8080")
+        with patch.object(
+            client,
+            "execute_action",
+            return_value={"action": "crystal_clear_cell", "stable": True},
+        ) as execute_mock:
+            server = create_server(client=client, tool_profile="full")
+            clear_tool = asyncio.run(server.get_tool("crystal_clear_cell"))
+            set_tool = asyncio.run(server.get_tool("crystal_set_tool"))
+
+            self.assertEqual(
+                set_tool.parameters["properties"]["tool"]["enum"],
+                ["big", "small"],
+            )
+
+            clear_tool.fn(x=5, y=6, tool="big")
+            set_tool.fn(tool="small")
+
+        self.assertEqual(execute_mock.call_count, 2)
+        first = execute_mock.call_args_list[0]
+        self.assertEqual(first.args, ("crystal_clear_cell",))
+        self.assertEqual(first.kwargs["x"], 5)
+        self.assertEqual(first.kwargs["y"], 6)
+        self.assertEqual(first.kwargs["tool"], "big")
+        second = execute_mock.call_args_list[1]
+        self.assertEqual(second.args, ("crystal_set_tool",))
+        self.assertEqual(second.kwargs["tool"], "small")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/sts2-mcp-player/references/screen-playbooks.md
+++ b/skills/sts2-mcp-player/references/screen-playbooks.md
@@ -74,6 +74,21 @@ Use this reference when the active screen is clear and you need the exact action
 - Expect event flows like `EVENT -> COMBAT -> EVENT` or `EVENT -> COMBAT -> MAP`.
 - Re-read state after every branch because events mutate in place.
 
+## CRYSTAL_SPHERE
+
+- Read `crystal_sphere.items` and `crystal_sphere.hidden_cells` from compact
+  `get_game_state`; vision is not required.
+- `crystal_clear_cell` requires `x` and `y`. Pass `tool="big"` for a
+  3×3 clear or `tool="small"` for one cell; the tool can be switched atomically
+  in the same `act` call.
+- An item is revealed when all of its occupied cells are clear. Revealed bad
+  items, including curses, are granted when the minigame ends, so do not complete
+  their remaining hidden cells.
+- Every divination must be spent. If no safe reward remains, spend a small
+  divination on an already clear cell.
+- After the last divination, resolve any reward child screens, then use
+  `proceed` when it reappears.
+
 ## MODAL and GAME_OVER
 
 - Resolve `MODAL` before anything else with `confirm_modal` or `dismiss_modal`.


### PR DESCRIPTION
## Problem and root cause

`NCrystalSphereScreen` was not recognized, so agents originally saw `UNKNOWN` and stalled in the fortune-teller event.

The first version of this PR fixed the raw HTTP path, but review found a second integration gap: `crystal_sphere` existed only in the full `/state` payload. The default guided MCP `get_game_state` and the in-game Agent both consume compact `agent_view`, so they could see the Crystal Sphere actions without seeing the board needed to choose `x/y` coordinates.

A full self-review also found that `x`, `y`, and `tool` stopped at the raw C# `ActionRequest`. They were not exposed through the Python guided/full MCP tools or the in-game Agent schema/bridge, so the feature worked through direct HTTP but not through the normal agent entry points.

## What changed

- Recognize `NCrystalSphereScreen` as `CRYSTAL_SPHERE`.
- Expose `crystal_sphere` in both full `/state` and compact `agent_view`:
  - remaining divinations and selected tool;
  - grid dimensions and hidden cells;
  - placed items, footprints, hidden cells, reveal state, and good/bad classification.
- Add `crystal_set_tool` and `crystal_clear_cell`, including bounds/phase validation and an optional atomic `tool` switch on a cell clear.
- Carry `x`, `y`, and `tool` end-to-end through:
  - guided MCP `act`;
  - full-profile Crystal Sphere tools;
  - `Sts2Client` HTTP requests;
  - the in-game Agent tool schema, JSON fallback, loop, bridge, and `ActionRequest`.
- Restrict MCP tool values to `big | small`, while treating explicit JSON `null` as an omitted optional tool.
- Synchronize the game's big/small button active state when switching tools.
- Tighten settle detection: a clear is complete only after observed divination progress, a reward child screen takes over, or `proceed` becomes available. A transient missing private entity no longer falsely reports success.
- Add warn-once diagnostics for private minigame lookup and tool-button lookup/synchronization failures.
- Bump state schema `10 -> 11` and compact agent-view schema `5 -> 6`.
- Update the API guide, MCP README, in-game prompt, and screen playbook.
- Remove the unrelated unlock private-field commit that had accidentally landed on this PR branch; that work remains separate.

This directly addresses the review comment at https://github.com/CharTyr/STS2-Agent/pull/48#issuecomment-5395359811.

## Verification

- Built `STS2AIAgent` in Release against Slay the Spire 2 v0.111.0: 0 warnings, 0 errors.
- 41/41 C# tests pass on the clean PR branch, including tool-call and no-tools JSON argument forwarding plus settle-state cases.
- 29/29 Python MCP tests pass, including the requested guided `get_game_state` compact-state regression, guided/full action dispatch, schema enums, and HTTP payload forwarding.
- `git diff --check upstream/main...HEAD` passes.
- The original gameplay path was exercised live on an 11x11 board through reward child screens and back to the map; the review-specific compact/MCP/Agent paths are now covered by regressions.
