### PR TITLE
Fix confirm_unlock for derived unlock screens

### DIFF
--- a/STS2AIAgent.Tests/ReflectionMemberAccessorTests.cs
+++ b/STS2AIAgent.Tests/ReflectionMemberAccessorTests.cs
@@ -39,16 +39,29 @@ internal static class ReflectionMemberAccessorTests
         Assert.Equal(typeof(DerivedFixture), declaringType);
     }
 
+    public static void DoesNotFallBackWhenDerivedGetterThrows()
+    {
+        var instance = new DerivedFixture();
+
+        var value = ReflectionMemberAccessor.TryGetValue(
+            instance, "_throwing", out var declaringType);
+
+        Assert.Null(value);
+        Assert.Equal(typeof(DerivedFixture), declaringType);
+    }
+
     private class BaseFixture
     {
         private readonly string _baseField = "base-field";
         private readonly string _shadowed = "base";
+        private readonly string _throwing = "base";
         private string BaseProperty => "base-property";
     }
 
     private sealed class DerivedFixture : BaseFixture
     {
         private readonly string _shadowed = "derived";
+        private string _throwing => throw new InvalidOperationException("fixture getter failure");
     }
 }
 

--- a/STS2AIAgent.Tests/ReflectionMemberAccessorTests.cs
+++ b/STS2AIAgent.Tests/ReflectionMemberAccessorTests.cs
@@ -1,0 +1,55 @@
+using STS2AIAgent.Game;
+
+namespace STS2AIAgent.Tests;
+
+#pragma warning disable CS0414 // Fixture fields are intentionally read only through reflection.
+
+internal static class ReflectionMemberAccessorTests
+{
+    public static void ReadsPrivateBaseFieldFromDerivedInstance()
+    {
+        var instance = new DerivedFixture();
+
+        var value = ReflectionMemberAccessor.TryGetValue(
+            instance, "_baseField", out var declaringType);
+
+        Assert.Equal("base-field", value as string);
+        Assert.Equal(typeof(BaseFixture), declaringType);
+    }
+
+    public static void ReadsPrivateBasePropertyFromDerivedInstance()
+    {
+        var instance = new DerivedFixture();
+
+        var value = ReflectionMemberAccessor.TryGetValue(
+            instance, "BaseProperty", out var declaringType);
+
+        Assert.Equal("base-property", value as string);
+        Assert.Equal(typeof(BaseFixture), declaringType);
+    }
+
+    public static void PrefersDerivedMemberWithSameName()
+    {
+        var instance = new DerivedFixture();
+
+        var value = ReflectionMemberAccessor.TryGetValue(
+            instance, "_shadowed", out var declaringType);
+
+        Assert.Equal("derived", value as string);
+        Assert.Equal(typeof(DerivedFixture), declaringType);
+    }
+
+    private class BaseFixture
+    {
+        private readonly string _baseField = "base-field";
+        private readonly string _shadowed = "base";
+        private string BaseProperty => "base-property";
+    }
+
+    private sealed class DerivedFixture : BaseFixture
+    {
+        private readonly string _shadowed = "derived";
+    }
+}
+
+#pragma warning restore CS0414

--- a/STS2AIAgent.Tests/STS2AIAgent.Tests.csproj
+++ b/STS2AIAgent.Tests/STS2AIAgent.Tests.csproj
@@ -21,5 +21,6 @@
     <Compile Include="..\STS2AIAgent\Agent\PlayPrompt.cs" Link="Agent\PlayPrompt.cs" />
     <Compile Include="..\STS2AIAgent\Agent\McpProcessLauncher.cs" Link="Agent\McpProcessLauncher.cs" />
     <Compile Include="..\STS2AIAgent\Game\ReflectionMemberAccessor.cs" Link="Game\ReflectionMemberAccessor.cs" />
+    <Compile Include="..\STS2AIAgent\Game\UnlockConfirmResolutionPolicy.cs" Link="Game\UnlockConfirmResolutionPolicy.cs" />
   </ItemGroup>
 </Project>

--- a/STS2AIAgent.Tests/STS2AIAgent.Tests.csproj
+++ b/STS2AIAgent.Tests/STS2AIAgent.Tests.csproj
@@ -20,5 +20,6 @@
     <Compile Include="..\STS2AIAgent\Agent\IGameBridge.cs" Link="Agent\IGameBridge.cs" />
     <Compile Include="..\STS2AIAgent\Agent\PlayPrompt.cs" Link="Agent\PlayPrompt.cs" />
     <Compile Include="..\STS2AIAgent\Agent\McpProcessLauncher.cs" Link="Agent\McpProcessLauncher.cs" />
+    <Compile Include="..\STS2AIAgent\Game\ReflectionMemberAccessor.cs" Link="Game\ReflectionMemberAccessor.cs" />
   </ItemGroup>
 </Project>

--- a/STS2AIAgent.Tests/TestRunner.cs
+++ b/STS2AIAgent.Tests/TestRunner.cs
@@ -132,6 +132,10 @@ internal static class TestRunner
         yield return ("Reflection.PrivateBaseField", () => Task.Run(ReflectionMemberAccessorTests.ReadsPrivateBaseFieldFromDerivedInstance));
         yield return ("Reflection.PrivateBaseProperty", () => Task.Run(ReflectionMemberAccessorTests.ReadsPrivateBasePropertyFromDerivedInstance));
         yield return ("Reflection.DerivedPrecedence", () => Task.Run(ReflectionMemberAccessorTests.PrefersDerivedMemberWithSameName));
+        yield return ("Reflection.ThrowingDerived", () => Task.Run(ReflectionMemberAccessorTests.DoesNotFallBackWhenDerivedGetterThrows));
+        yield return ("UnlockConfirm.Reflected", () => Task.Run(UnlockConfirmResolutionPolicyTests.PrefersUsableReflectedCandidate));
+        yield return ("UnlockConfirm.Fallback", () => Task.Run(UnlockConfirmResolutionPolicyTests.SkipsUnusableCandidatesBeforeUsableFallback));
+        yield return ("UnlockConfirm.Session", () => Task.Run(UnlockConfirmResolutionPolicyTests.ProbeSignatureIncludesScreenInstance));
         yield return ("AgentLoop.PlayOnce", AgentLoopTests.PlayOnce_ExecutesSingleValidatedAct);
         yield return ("AgentLoop.NotActionable", AgentLoopTests.PlayOnce_SkipsWhenNotActionable);
         yield return ("AgentLoop.RejectStaleIndex", AgentLoopTests.PlayOnce_RejectsIndexNotInLatestPayload);

--- a/STS2AIAgent.Tests/TestRunner.cs
+++ b/STS2AIAgent.Tests/TestRunner.cs
@@ -129,6 +129,9 @@ internal static class TestRunner
         yield return ("PlayIntent.Detect", () => Task.Run(PlayIntentTests.DetectsPlayPhrasesAndIgnoresQuestions));
         yield return ("ActIndex.Validate", () => Task.Run(ActIndexValidatorTests.RejectsMissingAndStaleIndexes));
         yield return ("ActIndex.Unsettled", () => Task.Run(ActIndexValidatorTests.DetectsUnsettledActResults));
+        yield return ("Reflection.PrivateBaseField", () => Task.Run(ReflectionMemberAccessorTests.ReadsPrivateBaseFieldFromDerivedInstance));
+        yield return ("Reflection.PrivateBaseProperty", () => Task.Run(ReflectionMemberAccessorTests.ReadsPrivateBasePropertyFromDerivedInstance));
+        yield return ("Reflection.DerivedPrecedence", () => Task.Run(ReflectionMemberAccessorTests.PrefersDerivedMemberWithSameName));
         yield return ("AgentLoop.PlayOnce", AgentLoopTests.PlayOnce_ExecutesSingleValidatedAct);
         yield return ("AgentLoop.NotActionable", AgentLoopTests.PlayOnce_SkipsWhenNotActionable);
         yield return ("AgentLoop.RejectStaleIndex", AgentLoopTests.PlayOnce_RejectsIndexNotInLatestPayload);

--- a/STS2AIAgent.Tests/UnlockConfirmResolutionPolicyTests.cs
+++ b/STS2AIAgent.Tests/UnlockConfirmResolutionPolicyTests.cs
@@ -1,0 +1,43 @@
+using STS2AIAgent.Game;
+
+namespace STS2AIAgent.Tests;
+
+internal static class UnlockConfirmResolutionPolicyTests
+{
+    public static void PrefersUsableReflectedCandidate()
+    {
+        var reflected = new Candidate("reflected", Usable: true);
+        var fallback = new Candidate("fallback", Usable: true);
+
+        var selected = UnlockConfirmResolutionPolicy.SelectUsable(
+            reflected, new[] { fallback }, candidate => candidate.Usable);
+
+        Assert.Equal(reflected, selected);
+    }
+
+    public static void SkipsUnusableCandidatesBeforeUsableFallback()
+    {
+        var reflected = new Candidate("reflected", Usable: false);
+        var hiddenFallback = new Candidate("hidden", Usable: false);
+        var usableFallback = new Candidate("usable", Usable: true);
+
+        var selected = UnlockConfirmResolutionPolicy.SelectUsable(
+            reflected,
+            new[] { hiddenFallback, usableFallback },
+            candidate => candidate.Usable);
+
+        Assert.Equal(usableFallback, selected);
+    }
+
+    public static void ProbeSignatureIncludesScreenInstance()
+    {
+        var first = UnlockConfirmResolutionPolicy.BuildProbeSignature(
+            "NUnlockRelicsScreen", 100, "member", "NUnlockConfirmButton", "/Confirm", true, true);
+        var second = UnlockConfirmResolutionPolicy.BuildProbeSignature(
+            "NUnlockRelicsScreen", 101, "member", "NUnlockConfirmButton", "/Confirm", true, true);
+
+        Assert.False(string.Equals(first, second, StringComparison.Ordinal));
+    }
+
+    private sealed record Candidate(string Name, bool Usable);
+}

--- a/STS2AIAgent/Game/GameStateService.cs
+++ b/STS2AIAgent/Game/GameStateService.cs
@@ -5249,32 +5249,59 @@ internal static class GameStateService
 
         var reflected = ReflectionMemberAccessor.TryGetValue(
             unlockScreen, "_unlockConfirmButton", out var declaringType) as NButton;
-        if (reflected != null && GodotObject.IsInstanceValid(reflected))
+        var memberSource = $"member:{declaringType?.FullName ?? "unknown"}";
+        var reflectedValid = reflected != null && GodotObject.IsInstanceValid(reflected);
+        var memberStatus = reflectedValid ? "unusable" : "unavailable";
+
+        // Keep an exact-type node-tree fallback in case a future game build renames the field
+        // or leaves a stale, non-actionable backing-field node behind.
+        var descendants = FindDescendants<NUnlockConfirmButton>(unlockScreen);
+        var selected = UnlockConfirmResolutionPolicy.SelectUsable(
+            reflected, descendants, IsUnlockConfirmButtonUsable);
+        if (selected != null)
         {
-            LogUnlockConfirmProbe(
-                currentScreen, reflected, $"member:{declaringType?.FullName ?? "unknown"}");
-            return reflected.IsVisibleInTree() && reflected.IsEnabled ? reflected : null;
+            var source = ReferenceEquals(selected, reflected)
+                ? memberSource
+                : $"descendant:NUnlockConfirmButton;{memberSource}:{memberStatus}";
+            LogUnlockConfirmProbe(unlockScreen, selected, source);
+            return selected;
         }
 
-        // Keep an exact-type node-tree fallback in case a future game build renames the field.
-        var descendant = FindDescendants<NUnlockConfirmButton>(unlockScreen)
-            .FirstOrDefault(GodotObject.IsInstanceValid);
-        LogUnlockConfirmProbe(currentScreen, descendant, "descendant:NUnlockConfirmButton");
-        return descendant != null && descendant.IsVisibleInTree() && descendant.IsEnabled
-            ? descendant
-            : null;
+        // Emit one final-resolution probe per state instead of logging both the unusable
+        // reflected candidate and the failed fallback, which would alternate signatures
+        // and defeat deduplication on every state poll.
+        var validDiagnosticDescendant = descendants.FirstOrDefault(GodotObject.IsInstanceValid);
+        var diagnosticButton = reflectedValid ? reflected : validDiagnosticDescendant;
+        var descendantStatus = descendants.Count == 0 ? "none" : "no-usable";
+        var diagnosticSource = reflectedValid
+            ? $"{memberSource}:unusable;descendant:{descendantStatus}"
+            : validDiagnosticDescendant != null
+                ? $"descendant:NUnlockConfirmButton:unusable;{memberSource}:{memberStatus}"
+                : $"{memberSource}:{memberStatus};descendant:{descendantStatus}";
+        LogUnlockConfirmProbe(unlockScreen, diagnosticButton, diagnosticSource);
+        return null;
+    }
+
+    private static bool IsUnlockConfirmButtonUsable(NButton? button)
+    {
+        return button != null &&
+               GodotObject.IsInstanceValid(button) &&
+               button.IsVisibleInTree() &&
+               button.IsEnabled;
     }
 
     private static void LogUnlockConfirmProbe(
-        IScreenContext? currentScreen, NButton? button, string source)
+        NUnlockScreen unlockScreen, NButton? button, string source)
     {
         var valid = button != null && GodotObject.IsInstanceValid(button);
         var visible = valid && button!.IsVisibleInTree();
         var enabled = valid && button!.IsEnabled;
-        var screenType = currentScreen?.GetType().FullName ?? "null";
+        var screenType = unlockScreen.GetType().FullName ?? unlockScreen.GetType().Name;
+        var screenInstanceId = unlockScreen.GetInstanceId();
         var buttonType = valid ? button!.GetType().FullName ?? button.GetType().Name : "null";
         var buttonPath = valid ? button!.GetPath().ToString() : "null";
-        var signature = $"{screenType}|{source}|{buttonType}|{buttonPath}|{visible}|{enabled}";
+        var signature = UnlockConfirmResolutionPolicy.BuildProbeSignature(
+            screenType, screenInstanceId, source, buttonType, buttonPath, visible, enabled);
         if (signature == _lastUnlockConfirmProbeSignature)
         {
             return;
@@ -5282,7 +5309,8 @@ internal static class GameStateService
 
         _lastUnlockConfirmProbeSignature = signature;
         Log.Info(
-            $"[STS2AIAgent] Unlock confirm probe: screen={screenType}, source={source}, " +
+            $"[STS2AIAgent] Unlock confirm probe: screen={screenType}, instance={screenInstanceId}, " +
+            $"source={source}, " +
             $"button={buttonType}, path={buttonPath}, visible={visible}, enabled={enabled}");
     }
 

--- a/STS2AIAgent/Game/GameStateService.cs
+++ b/STS2AIAgent/Game/GameStateService.cs
@@ -58,6 +58,7 @@ internal static class GameStateService
     private static readonly TimeSpan CombatActionSnapshotStableDelay = TimeSpan.FromMilliseconds(200);
     private static string? _lastCombatActionReadinessSignature;
     private static DateTime _lastCombatActionReadinessSinceUtc = DateTime.MinValue;
+    private static string? _lastUnlockConfirmProbeSignature;
     private static readonly FieldInfo? StartRunLobbyMaxPlayersField =
         typeof(StartRunLobby).GetField("_maxPlayers", BindingFlags.Instance | BindingFlags.NonPublic);
 
@@ -3274,27 +3275,7 @@ internal static class GameStateService
 
     private static object? TryGetMemberValue(object instance, string memberName)
     {
-        const BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
-
-        try
-        {
-            var property = instance.GetType().GetProperty(memberName, flags);
-            if (property != null)
-            {
-                return property.GetValue(instance);
-            }
-
-            var field = instance.GetType().GetField(memberName, flags);
-            if (field != null)
-            {
-                return field.GetValue(instance);
-            }
-        }
-        catch
-        {
-        }
-
-        return null;
+        return ReflectionMemberAccessor.TryGetValue(instance, memberName);
     }
 
     private static string[] GetCardModifierTags(CardModel? card)
@@ -5262,11 +5243,47 @@ internal static class GameStateService
         var unlockScreen = GetActiveUnlockScreen(currentScreen);
         if (unlockScreen == null)
         {
+            _lastUnlockConfirmProbeSignature = null;
             return null;
         }
 
-        var button = TryGetMemberValue(unlockScreen, "_unlockConfirmButton") as NButton;
-        return button != null && button.IsVisibleInTree() && button.IsEnabled ? button : null;
+        var reflected = ReflectionMemberAccessor.TryGetValue(
+            unlockScreen, "_unlockConfirmButton", out var declaringType) as NButton;
+        if (reflected != null && GodotObject.IsInstanceValid(reflected))
+        {
+            LogUnlockConfirmProbe(
+                currentScreen, reflected, $"member:{declaringType?.FullName ?? "unknown"}");
+            return reflected.IsVisibleInTree() && reflected.IsEnabled ? reflected : null;
+        }
+
+        // Keep an exact-type node-tree fallback in case a future game build renames the field.
+        var descendant = FindDescendants<NUnlockConfirmButton>(unlockScreen)
+            .FirstOrDefault(GodotObject.IsInstanceValid);
+        LogUnlockConfirmProbe(currentScreen, descendant, "descendant:NUnlockConfirmButton");
+        return descendant != null && descendant.IsVisibleInTree() && descendant.IsEnabled
+            ? descendant
+            : null;
+    }
+
+    private static void LogUnlockConfirmProbe(
+        IScreenContext? currentScreen, NButton? button, string source)
+    {
+        var valid = button != null && GodotObject.IsInstanceValid(button);
+        var visible = valid && button!.IsVisibleInTree();
+        var enabled = valid && button!.IsEnabled;
+        var screenType = currentScreen?.GetType().FullName ?? "null";
+        var buttonType = valid ? button!.GetType().FullName ?? button.GetType().Name : "null";
+        var buttonPath = valid ? button!.GetPath().ToString() : "null";
+        var signature = $"{screenType}|{source}|{buttonType}|{buttonPath}|{visible}|{enabled}";
+        if (signature == _lastUnlockConfirmProbeSignature)
+        {
+            return;
+        }
+
+        _lastUnlockConfirmProbeSignature = signature;
+        Log.Info(
+            $"[STS2AIAgent] Unlock confirm probe: screen={screenType}, source={source}, " +
+            $"button={buttonType}, path={buttonPath}, visible={visible}, enabled={enabled}");
     }
 
     public static bool CanConfirmUnlock(IScreenContext? currentScreen)

--- a/STS2AIAgent/Game/ReflectionMemberAccessor.cs
+++ b/STS2AIAgent/Game/ReflectionMemberAccessor.cs
@@ -1,0 +1,59 @@
+using System.Reflection;
+
+namespace STS2AIAgent.Game;
+
+internal static class ReflectionMemberAccessor
+{
+    private const BindingFlags DeclaredInstanceMembers =
+        BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
+
+    /// <summary>
+    /// Reads an instance property or field, including private members declared on a base class.
+    /// Type.GetField/GetProperty on a derived runtime type does not return inherited private
+    /// members, so each level must be inspected explicitly.
+    /// </summary>
+    public static object? TryGetValue(object instance, string memberName)
+    {
+        return TryGetValue(instance, memberName, out _);
+    }
+
+    public static object? TryGetValue(object instance, string memberName, out Type? declaringType)
+    {
+        declaringType = null;
+
+        for (var type = instance.GetType(); type != null; type = type.BaseType)
+        {
+            try
+            {
+                var property = type.GetProperty(memberName, DeclaredInstanceMembers);
+                if (property != null)
+                {
+                    var value = property.GetValue(instance);
+                    declaringType = type;
+                    return value;
+                }
+            }
+            catch
+            {
+                // Reflection is best-effort. Keep walking in case a base field is usable.
+            }
+
+            try
+            {
+                var field = type.GetField(memberName, DeclaredInstanceMembers);
+                if (field != null)
+                {
+                    var value = field.GetValue(instance);
+                    declaringType = type;
+                    return value;
+                }
+            }
+            catch
+            {
+                // A game update may make a member unreadable; callers already handle null.
+            }
+        }
+
+        return null;
+    }
+}

--- a/STS2AIAgent/Game/ReflectionMemberAccessor.cs
+++ b/STS2AIAgent/Game/ReflectionMemberAccessor.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Reflection;
 
 namespace STS2AIAgent.Game;
@@ -6,6 +7,8 @@ internal static class ReflectionMemberAccessor
 {
     private const BindingFlags DeclaredInstanceMembers =
         BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
+    private static readonly ConcurrentDictionary<(Type RuntimeType, string MemberName), MemberLookup>
+        MemberCache = new();
 
     /// <summary>
     /// Reads an instance property or field, including private members declared on a base class.
@@ -20,22 +23,54 @@ internal static class ReflectionMemberAccessor
     public static object? TryGetValue(object instance, string memberName, out Type? declaringType)
     {
         declaringType = null;
+        if (string.IsNullOrEmpty(memberName))
+        {
+            return null;
+        }
 
-        for (var type = instance.GetType(); type != null; type = type.BaseType)
+        var lookup = MemberCache.GetOrAdd(
+            (instance.GetType(), memberName),
+            static key => FindMember(key.RuntimeType, key.MemberName));
+        declaringType = lookup.DeclaringType;
+        if (lookup.Member == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return lookup.Member switch
+            {
+                PropertyInfo property => property.GetValue(instance),
+                FieldInfo field => field.GetValue(instance),
+                _ => null
+            };
+        }
+        catch
+        {
+            // Once the most-derived matching member is found, do not fall back to a
+            // shadowed base member: a failed read means this member is unavailable.
+            return null;
+        }
+    }
+
+    private static MemberLookup FindMember(Type runtimeType, string memberName)
+    {
+        for (var type = runtimeType; type != null; type = type.BaseType)
         {
             try
             {
                 var property = type.GetProperty(memberName, DeclaredInstanceMembers);
                 if (property != null)
                 {
-                    var value = property.GetValue(instance);
-                    declaringType = type;
-                    return value;
+                    return new MemberLookup(property, type);
                 }
             }
             catch
             {
-                // Reflection is best-effort. Keep walking in case a base field is usable.
+                // An ambiguous or otherwise unreadable most-derived declaration must not
+                // expose a shadowed base member as if it were the requested member.
+                return new MemberLookup(null, type);
             }
 
             try
@@ -43,17 +78,17 @@ internal static class ReflectionMemberAccessor
                 var field = type.GetField(memberName, DeclaredInstanceMembers);
                 if (field != null)
                 {
-                    var value = field.GetValue(instance);
-                    declaringType = type;
-                    return value;
+                    return new MemberLookup(field, type);
                 }
             }
             catch
             {
-                // A game update may make a member unreadable; callers already handle null.
+                return new MemberLookup(null, type);
             }
         }
 
-        return null;
+        return new MemberLookup(null, null);
     }
+
+    private sealed record MemberLookup(MemberInfo? Member, Type? DeclaringType);
 }

--- a/STS2AIAgent/Game/UnlockConfirmResolutionPolicy.cs
+++ b/STS2AIAgent/Game/UnlockConfirmResolutionPolicy.cs
@@ -1,0 +1,30 @@
+namespace STS2AIAgent.Game;
+
+internal static class UnlockConfirmResolutionPolicy
+{
+    public static T? SelectUsable<T>(
+        T? preferred,
+        IEnumerable<T> fallbacks,
+        Func<T, bool> isUsable)
+        where T : class
+    {
+        if (preferred != null && isUsable(preferred))
+        {
+            return preferred;
+        }
+
+        return fallbacks.FirstOrDefault(isUsable);
+    }
+
+    public static string BuildProbeSignature(
+        string screenType,
+        ulong screenInstanceId,
+        string source,
+        string buttonType,
+        string buttonPath,
+        bool visible,
+        bool enabled)
+    {
+        return $"{screenType}|{screenInstanceId}|{source}|{buttonType}|{buttonPath}|{visible}|{enabled}";
+    }
+}


### PR DESCRIPTION
## Summary

This is a follow-up to #47.

#47 correctly recognizes the post-run unlock showcase as an `UNLOCK` screen and exposes `confirm_unlock`. A real relic unlock screen nevertheless remained stuck in this state:

```json
{
  "screen": "UNLOCK",
  "available_actions": [],
  "unlock": {
    "unlock_type": "NUnlockRelicsScreen",
    "items": ["红头骨", "纸蛙", "损毁头盔"],
    "can_confirm": false
  }
}
```

The confirm button was visibly present and enabled, while `POST /action` with `confirm_unlock` returned HTTP 503 `state_unavailable`: `Unlock confirm button is unavailable.`

## Root cause

The game metadata shows that:

- `_relics` is a private field declared on the runtime derived type, `NUnlockRelicsScreen`.
- `_unlockConfirmButton` is a private field declared on its base type, `NUnlockScreen`.

The existing reflection helper queried only the derived runtime type. In .NET, that lookup does not return private members declared by a base class. The API could therefore read the derived `_relics` field and return all three item names, but it resolved the base-class confirm-button field to `null`. Consequently, `can_confirm` stayed false, `confirm_unlock` was omitted, and the explicit action returned 503.

This was not an animation or stale-deployment issue: the same state remained unchanged for roughly 40 minutes, the button was visibly available, the deployed DLL hash matched the tested build, and the API was already returning the correct unlock screen and relic list.

## Changes

- Add a hierarchy-aware `ReflectionMemberAccessor` that walks from the runtime type through every base type with `DeclaredOnly`.
  - Preserve most-derived-member precedence.
  - Report the actual declaring type for diagnostics.
  - Cache member metadata by runtime type and name so existing reflected card-state reads do not repeat hierarchy scans on hot paths.
  - If the most-derived matching member throws while being read, return unavailable instead of silently exposing a shadowed base member.
- Route existing best-effort member reads through the shared accessor.
- Resolve unlock confirmation from the reflected field first, then inspect exact `NUnlockConfirmButton` descendants when the reflected candidate is missing, invalid, hidden, or disabled.
- Select the first descendant that is valid, visible, and enabled; an earlier unusable descendant can no longer mask a later actionable one.
- Emit one final-resolution diagnostic per distinct state and include the unlock-screen instance ID in its signature, so directly consecutive sessions each produce a probe without poll-time log spam.
- Add focused regression coverage for hierarchy reflection, throwing derived getters, reflected/fallback candidate selection, and per-screen-session probe signatures.

No API schema changes are introduced; this restores and hardens the `confirm_unlock` behavior added by #47.

## Review follow-up

All PR comments were audited after commit [`74858e1`](https://github.com/CharTyr/STS2-Agent/commit/74858e189418f86ceccd953d3e7b9371e81d5b94):

| Comment | Assessment | Resolution |
| --- | --- | --- |
| [Valid reflected button can block fallback](https://github.com/CharTyr/STS2-Agent/pull/49#discussion_r3856018469) | Accepted: this is a real bug when the backing-field node is hidden or disabled. | Reflected candidates must pass the full usability predicate; otherwise descendant resolution continues. |
| [First valid descendant can mask a later usable one](https://github.com/CharTyr/STS2-Agent/pull/49#discussion_r3856018481) | Accepted: validity alone is insufficient. | Fallback selection filters validity, visibility, and enabled state before choosing a node. |
| [Probe signature misses direct session replacement](https://github.com/CharTyr/STS2-Agent/pull/49#discussion_r3856018488) | Accepted: this violates the stated per-session diagnostic guarantee. | The signature and log now include the unlock-screen instance ID. |

The Codex quota notice and Sourcery reviewer guide are informational bot messages rather than code findings, so they require no code change. An independent pass over the complete PR also found and fixed the reflection hot-path scan and throwing-derived-member issues described above.

## Validation

- [x] Release build against Slay the Spire 2 v0.111.0 assemblies: 0 warnings, 0 errors
- [x] C# test suite: all 42 tests passed
- [x] New reflection and unlock-resolution regressions passed
- [x] `git diff --check`
- [x] The original rebuilt mod loaded successfully and `/health` reported `ready`

## Live verification limitation

The affected unlock showcase is a one-shot progression screen. Replacing the DLL required restarting the game, which finalized that screen and marked its timeline slots complete.

The developer-console `unlock relics` command is not a safe reproduction path: it writes permanent “seen” progress but does not instantiate `NUnlockRelicsScreen`. The save was therefore not mutated merely to force another showcase. Post-fix validation covers build/load health and regressions reproducing the exact private-base-member and fallback failures, but not a second end-to-end click on the original one-shot screen.

## Base branch note

This PR intentionally targets `main`. PR #47 is present on `main`, while the current upstream `dev` branch still predates #47; targeting `dev` would mix the already-merged #47 changes back into this follow-up.

## Summary by Sourcery

Fix unlock confirmation resolution for derived unlock screens and harden reflected control discovery.

Bug Fixes:
- Restore `confirm_unlock` for relic unlock screens whose confirmation control is declared on a private base-class member.
- Fall back to actionable unlock-confirm descendants when reflected controls are unavailable, stale, hidden, or disabled.

Enhancements:
- Add hierarchy-aware, cached reflection for private members while preserving derived-member precedence and safe failure behavior.
- Add deduplicated unlock-confirm diagnostics that distinguish unlock-screen instances and resolution sources.

Tests:
- Add regression coverage for private base-member reflection, derived-member precedence, throwing getters, fallback selection, and per-session diagnostics.