### PR TITLE
Add authoritative fact events, schemas, and complete multiplayer state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@
 
 ### Notes
 
-- None yet.
+- Protocol `2026-08-31-v2` publishes Draft 2020-12 schemas for health, all state scenes, events, and static data collections.
+
+### Added
+
+- Added authoritative `action_started`, `damage_resolved`, `action_finished`, and optional `ai_decision` events with run/combat/correlation IDs.
+- Added exact damage settlement values and model source attribution for cards, powers, relics, potions, orbs, and monsters.
+- Added explicit `normal` / `elite` / `boss` encounter types and `victory` / `defeat` combat outcomes.
+- Added complete hand, piles, deck, relic, potion, power, and orb data for every multiplayer combat player, plus complete run inventories.
+- Added `GET /schemas` and `GET /schemas/{name}`.
 
 ## v0.9.1 - 2026-08-27
 

--- a/README.md
+++ b/README.md
@@ -118,8 +118,9 @@ Default MCP endpoint: `http://127.0.0.1:8765/mcp`
 - Driving combat, rewards, shops, map routing, events, rest sites, chests, capstone selection, and bundle selection
 - Optional MCP over `stdio` or HTTP for external agents
 - Live game metadata for cards, relics, monsters, potions, and events via the Mod API
+- Authoritative card/damage/AI-decision events, exact combat outcome and encounter tier, complete multiplayer inventories, and published JSON Schemas
 
-See [mcp_server/README.md](./mcp_server/README.md) for the MCP tool surface.
+See [Protocol v2 fact events](./docs/fact-events-v2.md) for the event and schema formats, and [mcp_server/README.md](./mcp_server/README.md) for the MCP tool surface.
 
 ## FAQ
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -118,8 +118,9 @@ powershell -ExecutionPolicy Bypass -File ".\scripts\start-mcp-network.ps1"
 - 执行战斗、奖励、商店、地图、事件、休息点、宝箱、尖塔选择、Bundle 选择等操作
 - 可选 MCP（`stdio` 或 HTTP）给外部 Agent
 - 通过 Mod API 提供卡牌、遗物、敌人、药水、事件等实时元数据
+- 提供逐卡牌/逐伤害/AI 决策事实、明确战斗胜负和遭遇类型、完整多人库存及正式 JSON Schema
 
-更细的 MCP 工具说明在 [mcp_server/README.md](./mcp_server/README.md)。
+事件与 Schema 格式见 [Protocol v2 事实事件](./docs/fact-events-v2.md)，更细的 MCP 工具说明在 [mcp_server/README.md](./mcp_server/README.md)。
 
 ## 常见问题
 

--- a/STS2AIAgent.Tests/GameFactInstrumentationTests.cs
+++ b/STS2AIAgent.Tests/GameFactInstrumentationTests.cs
@@ -1,0 +1,73 @@
+#if STS2_RUNTIME_TESTS
+using STS2AIAgent.Game;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Models;
+
+namespace STS2AIAgent.Server
+{
+    internal sealed class GameEventService
+    {
+        public static GameEventService Instance { get; } = new();
+
+        public void RecordDamageFact(DamageFact fact)
+        {
+        }
+
+        public void RecordAiDecisionFact(AiDecisionFact fact)
+        {
+        }
+    }
+}
+
+namespace STS2AIAgent.Tests
+{
+    internal static class GameFactInstrumentationTests
+    {
+        public static void Install_FindsActualDamageSinkAndEffectSources()
+        {
+            GameFactInstrumentation.SuppressLoggingForTests = true;
+            try
+            {
+                GameFactInstrumentation.Install();
+                var poisonType = typeof(AbstractModel).Assembly.GetType("MegaCrit.Sts2.Core.Models.Powers.PoisonPower");
+                var trigger = poisonType?.GetMethod("Trigger");
+                var stateMachineType = trigger?.GetCustomAttributes(typeof(System.Runtime.CompilerServices.AsyncStateMachineAttribute), false)
+                    .OfType<System.Runtime.CompilerServices.AsyncStateMachineAttribute>()
+                    .Single().StateMachineType;
+                var moveNext = stateMachineType?.GetMethod(
+                    "MoveNext",
+                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic);
+                Assert.NotNull(moveNext);
+                Assert.True(Harmony.GetPatchInfo(moveNext!)?.Prefixes.Count > 0);
+                GameFactInstrumentation.Uninstall();
+            }
+            finally
+            {
+                GameFactInstrumentation.SuppressLoggingForTests = false;
+            }
+        }
+
+        public static void OptionalAiTelemetry_PatchesActualWorkshopAssemblyWhenProvided()
+        {
+            var assemblyPath = Environment.GetEnvironmentVariable("STS2_AI_TEAMMATE_DLL");
+            if (string.IsNullOrWhiteSpace(assemblyPath) || !File.Exists(assemblyPath))
+            {
+                return;
+            }
+
+            OptionalAiTeammateTelemetry.SuppressLoggingForTests = true;
+            try
+            {
+                System.Reflection.Assembly.LoadFrom(assemblyPath);
+                OptionalAiTeammateTelemetry.Install();
+                Assert.True(OptionalAiTeammateTelemetry.LastPatchedDecisionMethodCount > 0);
+                OptionalAiTeammateTelemetry.Uninstall();
+            }
+            finally
+            {
+                OptionalAiTeammateTelemetry.SuppressLoggingForTests = false;
+            }
+        }
+    }
+}
+#endif

--- a/STS2AIAgent.Tests/ProtocolSchemaTests.cs
+++ b/STS2AIAgent.Tests/ProtocolSchemaTests.cs
@@ -1,0 +1,54 @@
+using STS2AIAgent.Server;
+
+namespace STS2AIAgent.Tests;
+
+internal static class ProtocolSchemaTests
+{
+    private static readonly string[] SceneProperties =
+    [
+        "combat", "run", "multiplayer", "multiplayer_lobby", "map", "selection", "character_select",
+        "timeline", "unlock", "chest", "event", "crystal_sphere", "shop", "rest", "reward", "bundles",
+        "capstone", "modal", "game_over", "agent_view"
+    ];
+
+    public static void Catalog_EmbedsEveryPublishedSchema()
+    {
+        Assert.Equal(4, ProtocolSchemaService.Names.Length);
+        foreach (var name in ProtocolSchemaService.Names)
+        {
+            Assert.True(ProtocolSchemaService.TryGet(name, out var schema), name);
+            Assert.Equal(ProtocolContract.SchemaDraft, schema.GetProperty("$schema").GetString());
+            Assert.True(schema.TryGetProperty("examples", out var examples) && examples.GetArrayLength() > 0, name);
+        }
+    }
+
+    public static void StateSchema_CoversEveryTopLevelScene()
+    {
+        Assert.True(ProtocolSchemaService.TryGet("state.schema.json", out var schema));
+        var properties = schema.GetProperty("properties");
+        foreach (var propertyName in SceneProperties)
+        {
+            Assert.True(properties.TryGetProperty(propertyName, out _), propertyName);
+        }
+
+        Assert.Equal(12, properties.GetProperty("state_version").GetProperty("const").GetInt32());
+        Assert.True(schema.GetProperty("allOf").GetArrayLength() >= 16);
+    }
+
+    public static void EventSchema_CoversFactEventsAndCorrelationFields()
+    {
+        Assert.True(ProtocolSchemaService.TryGet("event", out var schema));
+        var properties = schema.GetProperty("properties");
+        foreach (var field in new[] { "event_id", "sequence", "protocol_version", "correlation_id", "run_id", "combat_id", "type", "timestamp_utc", "data" })
+        {
+            Assert.True(properties.TryGetProperty(field, out _), field);
+        }
+
+        var eventTypes = properties.GetProperty("type").GetProperty("enum")
+            .EnumerateArray().Select(value => value.GetString()).ToHashSet(StringComparer.Ordinal);
+        foreach (var eventType in new[] { "action_started", "damage_resolved", "action_finished", "ai_decision", "combat_ended" })
+        {
+            Assert.True(eventTypes.Contains(eventType), eventType);
+        }
+    }
+}

--- a/STS2AIAgent.Tests/STS2AIAgent.Tests.csproj
+++ b/STS2AIAgent.Tests/STS2AIAgent.Tests.csproj
@@ -6,7 +6,28 @@
     <Nullable>enable</Nullable>
     <RootNamespace>STS2AIAgent.Tests</RootNamespace>
     <AssemblyName>STS2AIAgent.Tests</AssemblyName>
+    <Sts2DataDirFromEnv>$([System.Environment]::GetEnvironmentVariable('STS2_DATA_DIR'))</Sts2DataDirFromEnv>
+    <Sts2DataDir Condition="'$(Sts2DataDir)' == '' and '$(Sts2DataDirFromEnv)' != ''">$(Sts2DataDirFromEnv)</Sts2DataDir>
+    <Sts2DataDir Condition="'$(Sts2DataDir)' == ''">C:/Program Files (x86)/Steam/steamapps/common/Slay the Spire 2/data_sts2_windows_x86_64</Sts2DataDir>
+    <HasSts2TestAssemblies>false</HasSts2TestAssemblies>
+    <HasSts2TestAssemblies Condition="Exists('$(Sts2DataDir)/sts2.dll') and Exists('$(Sts2DataDir)/0Harmony.dll') and Exists('$(Sts2DataDir)/GodotSharp.dll')">true</HasSts2TestAssemblies>
+    <DefineConstants Condition="'$(HasSts2TestAssemblies)' == 'true'">$(DefineConstants);STS2_RUNTIME_TESTS</DefineConstants>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(HasSts2TestAssemblies)' == 'true'">
+    <Reference Include="sts2">
+      <HintPath>$(Sts2DataDir)/sts2.dll</HintPath>
+      <Private>true</Private>
+    </Reference>
+    <Reference Include="0Harmony">
+      <HintPath>$(Sts2DataDir)/0Harmony.dll</HintPath>
+      <Private>true</Private>
+    </Reference>
+    <Reference Include="GodotSharp">
+      <HintPath>$(Sts2DataDir)/GodotSharp.dll</HintPath>
+      <Private>true</Private>
+    </Reference>
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\STS2AIAgent\Config\*.cs" Link="Config\%(Filename)%(Extension)" />
@@ -23,5 +44,15 @@
     <Compile Include="..\STS2AIAgent\Game\ReflectionMemberAccessor.cs" Link="Game\ReflectionMemberAccessor.cs" />
     <Compile Include="..\STS2AIAgent\Game\UnlockConfirmResolutionPolicy.cs" Link="Game\UnlockConfirmResolutionPolicy.cs" />
     <Compile Include="..\STS2AIAgent\Game\CrystalSphereSettlePolicy.cs" Link="Game\CrystalSphereSettlePolicy.cs" />
+    <Compile Include="..\STS2AIAgent\Server\ProtocolContract.cs" Link="Server\ProtocolContract.cs" />
+    <Compile Include="..\STS2AIAgent\Server\ProtocolSchemaService.cs" Link="Server\ProtocolSchemaService.cs" />
+    <EmbeddedResource Include="..\STS2AIAgent\Schemas\2026-08-31-v2\*.schema.json">
+      <LogicalName>STS2AIAgent.Schemas.2026-08-31-v2.%(Filename)%(Extension)</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(HasSts2TestAssemblies)' == 'true'">
+    <Compile Include="..\STS2AIAgent\Game\GameFactInstrumentation.cs" Link="Game\GameFactInstrumentation.cs" />
+    <Compile Include="..\STS2AIAgent\Game\OptionalAiTeammateTelemetry.cs" Link="Game\OptionalAiTeammateTelemetry.cs" />
   </ItemGroup>
 </Project>

--- a/STS2AIAgent.Tests/TestRunner.cs
+++ b/STS2AIAgent.Tests/TestRunner.cs
@@ -158,5 +158,12 @@ internal static class TestRunner
         yield return ("CrystalSettle.Progress", () => Task.Run(CrystalSphereSettlePolicyTests.RequiresObservedProgressOnSameScreen));
         yield return ("CrystalSettle.FinalProceed", () => Task.Run(CrystalSphereSettlePolicyTests.WaitsForProceedAfterFinalDivination));
         yield return ("CrystalSettle.ScreenChange", () => Task.Run(CrystalSphereSettlePolicyTests.AcceptsChildScreenButNotMissingMinigame));
+        yield return ("ProtocolSchemas.Catalog", () => Task.Run(ProtocolSchemaTests.Catalog_EmbedsEveryPublishedSchema));
+        yield return ("ProtocolSchemas.StateScenes", () => Task.Run(ProtocolSchemaTests.StateSchema_CoversEveryTopLevelScene));
+        yield return ("ProtocolSchemas.FactEvents", () => Task.Run(ProtocolSchemaTests.EventSchema_CoversFactEventsAndCorrelationFields));
+#if STS2_RUNTIME_TESTS
+        yield return ("FactInstrumentation.ActualGameAssembly", () => Task.Run(GameFactInstrumentationTests.Install_FindsActualDamageSinkAndEffectSources));
+        yield return ("FactInstrumentation.OptionalAiTeammate", () => Task.Run(GameFactInstrumentationTests.OptionalAiTelemetry_PatchesActualWorkshopAssemblyWhenProvided));
+#endif
     }
 }

--- a/STS2AIAgent/Game/GameFactInstrumentation.cs
+++ b/STS2AIAgent/Game/GameFactInstrumentation.cs
@@ -1,0 +1,316 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Commands;
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Entities.Creatures;
+using MegaCrit.Sts2.Core.GameActions.Multiplayer;
+using MegaCrit.Sts2.Core.Logging;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.ValueProps;
+using STS2AIAgent.Server;
+
+namespace STS2AIAgent.Game;
+
+/// <summary>
+/// Captures damage at the game's authoritative settlement command. Snapshot polling cannot represent
+/// multi-hit or rapid consecutive actions without collapsing them, and CombatHistory intentionally drops
+/// CardPlay from DamageReceivedEntry. The command arguments and DamageResult values retain both.
+/// </summary>
+internal static class GameFactInstrumentation
+{
+    private const string HarmonyId = "com.chart.sts2-ai-agent.fact-events";
+    private const string LogPrefix = "[STS2AIAgent.GameFactInstrumentation]";
+
+    private static readonly AsyncLocal<AbstractModel?> ActiveEffectSource = new();
+    private static Harmony? _harmony;
+
+    internal static bool SuppressLoggingForTests { get; set; }
+
+    public static void Install()
+    {
+        if (_harmony != null)
+        {
+            return;
+        }
+
+        var harmony = new Harmony(HarmonyId);
+        var damageMethod = typeof(CreatureCmd).GetMethod(
+            nameof(CreatureCmd.Damage),
+            BindingFlags.Public | BindingFlags.Static,
+            binder: null,
+            types:
+            [
+                typeof(PlayerChoiceContext),
+                typeof(IEnumerable<Creature>),
+                typeof(decimal),
+                typeof(ValueProp),
+                typeof(Creature),
+                typeof(CardModel),
+                typeof(CardPlay)
+            ],
+            modifiers: null)
+            ?? throw new MissingMethodException("Could not find the authoritative CreatureCmd.Damage overload.");
+
+        harmony.Patch(
+            damageMethod,
+            postfix: new HarmonyMethod(typeof(GameFactInstrumentation), nameof(DamagePostfix)));
+
+        var sourcePatchCount = PatchEffectSourceCallers(harmony);
+        _harmony = harmony;
+        Info($"Installed damage settlement patch and {sourcePatchCount} exact effect-source patches.");
+    }
+
+    public static void Uninstall()
+    {
+        var harmony = Interlocked.Exchange(ref _harmony, null);
+        harmony?.UnpatchAll(HarmonyId);
+        ActiveEffectSource.Value = null;
+    }
+
+    private static int PatchEffectSourceCallers(Harmony harmony)
+    {
+        var patched = new HashSet<MethodBase>();
+        var modelAssembly = typeof(AbstractModel).Assembly;
+        foreach (var modelType in SafeGetTypes(modelAssembly)
+                     .Where(type => typeof(AbstractModel).IsAssignableFrom(type)))
+        {
+            foreach (var method in EnumerateSourceCandidateMethods(modelType))
+            {
+                var executionMethod = ResolveExecutionMethod(method);
+                if (executionMethod == null || executionMethod.IsStatic || !CallsDamage(executionMethod) || !patched.Add(executionMethod))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    harmony.Patch(
+                        executionMethod,
+                        prefix: new HarmonyMethod(typeof(GameFactInstrumentation), nameof(EffectSourcePrefix)),
+                        postfix: new HarmonyMethod(typeof(GameFactInstrumentation), nameof(EffectSourcePostfix)),
+                        finalizer: new HarmonyMethod(typeof(GameFactInstrumentation), nameof(EffectSourceFinalizer)));
+                }
+                catch (Exception ex)
+                {
+                    patched.Remove(executionMethod);
+                    Warn($"Could not instrument source method {executionMethod.FullDescription()}: {ex.Message}");
+                }
+            }
+        }
+
+        return patched.Count;
+    }
+
+    private static IEnumerable<MethodInfo> EnumerateSourceCandidateMethods(Type modelType)
+    {
+        const BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
+        foreach (var method in modelType.GetMethods(flags))
+        {
+            yield return method;
+        }
+
+        foreach (var nested in EnumerateNestedTypes(modelType))
+        {
+            foreach (var method in nested.GetMethods(flags))
+            {
+                yield return method;
+            }
+        }
+    }
+
+    private static IEnumerable<Type> EnumerateNestedTypes(Type type)
+    {
+        foreach (var nested in type.GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic))
+        {
+            yield return nested;
+            foreach (var descendant in EnumerateNestedTypes(nested))
+            {
+                yield return descendant;
+            }
+        }
+    }
+
+    private static MethodInfo? ResolveExecutionMethod(MethodInfo method)
+    {
+        var asyncStateMachine = method.GetCustomAttribute<AsyncStateMachineAttribute>()?.StateMachineType;
+        if (asyncStateMachine != null)
+        {
+            return asyncStateMachine.GetMethod("MoveNext", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+        }
+
+        return method;
+    }
+
+    private static bool CallsDamage(MethodBase method)
+    {
+        try
+        {
+            return PatchProcessor.GetOriginalInstructions(method).Any(instruction =>
+                instruction.operand is MethodInfo called &&
+                called.DeclaringType == typeof(CreatureCmd) &&
+                string.Equals(called.Name, nameof(CreatureCmd.Damage), StringComparison.Ordinal));
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static Type[] SafeGetTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return ex.Types.OfType<Type>().ToArray();
+        }
+    }
+
+    private static void EffectSourcePrefix(object __instance, out EffectSourceScope? __state)
+    {
+        var model = FindOwningModel(__instance, depth: 0, new HashSet<object>(ReferenceEqualityComparer.Instance));
+        __state = model == null ? null : new EffectSourceScope(model);
+    }
+
+    private static void EffectSourcePostfix(EffectSourceScope? __state) => __state?.Dispose();
+
+    private static Exception? EffectSourceFinalizer(Exception? __exception, EffectSourceScope? __state)
+    {
+        __state?.Dispose();
+        return __exception;
+    }
+
+    private static AbstractModel? FindOwningModel(object? value, int depth, HashSet<object> visited)
+    {
+        if (value is AbstractModel model)
+        {
+            return model;
+        }
+
+        if (value == null || depth >= 3 || !visited.Add(value))
+        {
+            return null;
+        }
+
+        var type = value.GetType();
+        if (!type.IsDefined(typeof(CompilerGeneratedAttribute), inherit: false) && depth > 0)
+        {
+            return null;
+        }
+
+        const BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+        foreach (var field in type.GetFields(flags))
+        {
+            if (typeof(AbstractModel).IsAssignableFrom(field.FieldType))
+            {
+                return field.GetValue(value) as AbstractModel;
+            }
+        }
+
+        foreach (var field in type.GetFields(flags).Where(field =>
+                     field.FieldType.IsDefined(typeof(CompilerGeneratedAttribute), inherit: false) ||
+                     field.Name.Contains("this", StringComparison.Ordinal)))
+        {
+            var nested = FindOwningModel(field.GetValue(value), depth + 1, visited);
+            if (nested != null)
+            {
+                return nested;
+            }
+        }
+
+        return null;
+    }
+
+    private static void DamagePostfix(
+        PlayerChoiceContext choiceContext,
+        IEnumerable<Creature>? targets,
+        decimal amount,
+        ValueProp props,
+        Creature? dealer,
+        CardModel? cardSource,
+        CardPlay? cardPlay,
+        ref Task<IEnumerable<DamageResult>> __result)
+    {
+        // Do not infer a source from the choice context: it can retain the card that triggered a
+        // later poison/power callback. A live model callsite or an explicit card argument is exact.
+        var effectSource = cardPlay != null
+            ? cardSource
+            : ActiveEffectSource.Value ?? cardSource;
+        __result = CaptureDamageAsync(__result, amount, props, dealer, cardSource, cardPlay, effectSource);
+    }
+
+    private static async Task<IEnumerable<DamageResult>> CaptureDamageAsync(
+        Task<IEnumerable<DamageResult>> task,
+        decimal requestedAmount,
+        ValueProp props,
+        Creature? dealer,
+        CardModel? cardSource,
+        CardPlay? cardPlay,
+        AbstractModel? effectSource)
+    {
+        var results = (await task).ToArray();
+        GameEventService.Instance.RecordDamageFact(new DamageFact(
+            requestedAmount,
+            GetValueProps(props),
+            dealer,
+            cardSource,
+            cardPlay,
+            effectSource,
+            results));
+        return results;
+    }
+
+    private static string[] GetValueProps(ValueProp props) =>
+        Enum.GetValues<ValueProp>()
+            .Where(value => props.HasFlag(value))
+            .Select(static value => value.ToString().ToLowerInvariant())
+            .ToArray();
+
+    private static void Info(string message)
+    {
+        if (!SuppressLoggingForTests)
+        {
+            Log.Info($"{LogPrefix} {message}");
+        }
+    }
+
+    private static void Warn(string message)
+    {
+        if (!SuppressLoggingForTests)
+        {
+            Log.Warn($"{LogPrefix} {message}");
+        }
+    }
+
+    private sealed class EffectSourceScope : IDisposable
+    {
+        private readonly AbstractModel? _previous;
+        private int _disposed;
+
+        public EffectSourceScope(AbstractModel source)
+        {
+            _previous = ActiveEffectSource.Value;
+            ActiveEffectSource.Value = source;
+        }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 0)
+            {
+                ActiveEffectSource.Value = _previous;
+            }
+        }
+    }
+}
+
+internal sealed record DamageFact(
+    decimal RequestedAmount,
+    string[] Props,
+    Creature? Dealer,
+    CardModel? CardSource,
+    CardPlay? CardPlay,
+    AbstractModel? EffectSource,
+    IReadOnlyList<DamageResult> Results);

--- a/STS2AIAgent/Game/GameStateService.cs
+++ b/STS2AIAgent/Game/GameStateService.cs
@@ -51,13 +51,14 @@ using MegaCrit.Sts2.Core.Rewards;
 using MegaCrit.Sts2.Core.Runs;
 using MegaCrit.Sts2.Core.Timeline;
 using MegaCrit.Sts2.addons.mega_text;
+using STS2AIAgent.Server;
 
 namespace STS2AIAgent.Game;
 
 internal static class GameStateService
 {
-    private const int StateVersion = 11;
-    private const int AgentViewVersion = 6;
+    private const int StateVersion = ProtocolContract.StateVersion;
+    private const int AgentViewVersion = ProtocolContract.AgentViewVersion;
     private static readonly TimeSpan CombatActionSnapshotStableDelay = TimeSpan.FromMilliseconds(200);
     private static string? _lastCombatActionReadinessSignature;
     private static DateTime _lastCombatActionReadinessSinceUtc = DateTime.MinValue;
@@ -75,7 +76,7 @@ internal static class GameStateService
         var screen = ResolveScreen(currentScreen);
         var session = BuildSessionPayload(currentScreen, runState);
         var availableActions = BuildAvailableActionNames(currentScreen, combatState, runState);
-        var combat = BuildCombatPayload(combatState);
+        var combat = BuildCombatPayload(currentScreen, combatState);
         var run = BuildRunPayload(currentScreen, combatState, runState);
         var multiplayer = BuildMultiplayerPayload(currentScreen, runState);
         var multiplayerLobby = BuildMultiplayerLobbyPayload(currentScreen);
@@ -2402,7 +2403,7 @@ internal static class GameStateService
         return names.ToArray();
     }
 
-    private static CombatPayload? BuildCombatPayload(CombatState? combatState)
+    private static CombatPayload? BuildCombatPayload(IScreenContext? currentScreen, CombatState? combatState)
     {
         var me = GetLocalPlayer(combatState);
         if (combatState == null || me?.PlayerCombatState == null)
@@ -2439,9 +2440,17 @@ internal static class GameStateService
 
         return new CombatPayload
         {
+            combat_id = CombatManager.Instance.CurrentCombatId is { } combatId ? $"combat_{combatId.Value}" : null,
+            encounter_id = combatState.Encounter?.Id.Entry,
+            encounter_type = GameFactEventSource.ResolveEncounterType(combatState.Encounter?.RoomType ?? RoomType.Unassigned),
             player = playerPayload,
             players = GetOrderedCombatPlayers(combatState)
-                .Select(player => BuildCombatPlayerSummaryPayload(player, combatState, connectedPlayerIds, me.NetId))
+                .Select(player => BuildCombatPlayerSummaryPayload(
+                    currentScreen,
+                    player,
+                    combatState,
+                    connectedPlayerIds,
+                    me.NetId))
                 .ToArray(),
             hand = hand.Select((card, index) => BuildHandCardPayload(combatState, card, index)).ToArray(),
             enemies = enemyPayloads,
@@ -2543,7 +2552,13 @@ internal static class GameStateService
             relics = player.Relics.Select((relic, index) => BuildRunRelicPayload(relic, index)).ToArray(),
             players = runState!.Players
                 .OrderBy(runState.GetPlayerSlotIndex)
-                .Select(otherPlayer => BuildRunPlayerSummaryPayload(runState, otherPlayer, connectedPlayerIds, player.NetId))
+                .Select(otherPlayer => BuildRunPlayerSummaryPayload(
+                    currentScreen,
+                    combatState,
+                    runState,
+                    otherPlayer,
+                    connectedPlayerIds,
+                    player.NetId))
                 .ToArray(),
             potions = player.PotionSlots.Select((potion, index) =>
                 BuildRunPotionPayload(currentScreen, combatState, player, potion, index)).ToArray()
@@ -4874,6 +4889,8 @@ internal static class GameStateService
     }
 
     private static RunPlayerSummaryPayload BuildRunPlayerSummaryPayload(
+        IScreenContext? currentScreen,
+        CombatState? combatState,
         RunState runState,
         Player player,
         IReadOnlyCollection<ulong> connectedPlayerIds,
@@ -4890,16 +4907,26 @@ internal static class GameStateService
             current_hp = player.Creature.CurrentHp,
             max_hp = player.Creature.MaxHp,
             gold = player.Gold,
-            is_alive = player.Creature.IsAlive
+            max_energy = player.MaxEnergy,
+            base_orb_slots = player.BaseOrbSlotCount,
+            is_alive = player.Creature.IsAlive,
+            deck = player.Deck.Cards.Select((card, index) => BuildDeckCardPayload(card, index)).ToArray(),
+            relics = player.Relics.Select((relic, index) => BuildRunRelicPayload(relic, index)).ToArray(),
+            potions = player.PotionSlots.Select((potion, index) =>
+                BuildRunPotionPayload(currentScreen, combatState, player, potion, index)).ToArray()
         };
     }
 
     private static CombatPlayerSummaryPayload BuildCombatPlayerSummaryPayload(
+        IScreenContext? currentScreen,
         Player player,
         CombatState combatState,
         IReadOnlyCollection<ulong> connectedPlayerIds,
         ulong localPlayerId)
     {
+        var playerCombatState = player.PlayerCombatState;
+        var orbQueue = playerCombatState?.OrbQueue;
+        var orbs = orbQueue?.Orbs.ToList() ?? new List<OrbModel>();
         return new CombatPlayerSummaryPayload
         {
             player_id = NetIdToString(player.NetId),
@@ -4914,9 +4941,29 @@ internal static class GameStateService
             energy = player.PlayerCombatState?.Energy ?? 0,
             stars = player.PlayerCombatState?.Stars ?? 0,
             focus = player.Creature.GetPowerAmount<FocusPower>(),
-            is_alive = player.Creature.IsAlive
+            is_alive = player.Creature.IsAlive,
+            powers = BuildCreaturePowerPayloads(player.Creature),
+            base_orb_slots = player.BaseOrbSlotCount,
+            orb_capacity = orbQueue?.Capacity ?? 0,
+            empty_orb_slots = Math.Max(0, (orbQueue?.Capacity ?? 0) - orbs.Count),
+            orbs = orbs.Select((orb, index) => BuildCombatOrbPayload(orb, index)).ToArray(),
+            hand = playerCombatState?.Hand.Cards
+                .Select((card, index) => BuildHandCardPayload(combatState, card, index)).ToArray()
+                ?? Array.Empty<CombatHandCardPayload>(),
+            draw_pile = BuildPilePayload(playerCombatState?.DrawPile.Cards),
+            discard_pile = BuildPilePayload(playerCombatState?.DiscardPile.Cards),
+            exhaust_pile = BuildPilePayload(playerCombatState?.ExhaustPile.Cards),
+            play_pile = BuildPilePayload(playerCombatState?.PlayPile.Cards),
+            deck = player.Deck.Cards.Select((card, index) => BuildDeckCardPayload(card, index)).ToArray(),
+            relics = player.Relics.Select((relic, index) => BuildRunRelicPayload(relic, index)).ToArray(),
+            potions = player.PotionSlots.Select((potion, index) =>
+                BuildRunPotionPayload(currentScreen, combatState, player, potion, index)).ToArray()
         };
     }
+
+    private static DeckCardPayload[] BuildPilePayload(IEnumerable<CardModel>? cards) =>
+        cards?.Select((card, index) => BuildDeckCardPayload(card, index)).ToArray()
+        ?? Array.Empty<DeckCardPayload>();
 
     private static string? GetCardTargetIndexSpace(CardModel card)
     {
@@ -5992,6 +6039,12 @@ internal sealed class AvailableActionsPayload
 
 internal sealed class CombatPayload
 {
+    public string? combat_id { get; init; }
+
+    public string? encounter_id { get; init; }
+
+    public string encounter_type { get; init; } = "unassigned";
+
     public CombatPlayerPayload player { get; init; } = new();
 
     public CombatPlayerSummaryPayload[] players { get; init; } = Array.Empty<CombatPlayerSummaryPayload>();
@@ -6594,6 +6647,32 @@ internal sealed class CombatPlayerSummaryPayload
     public int focus { get; init; }
 
     public bool is_alive { get; init; }
+
+    public CombatPowerPayload[] powers { get; init; } = Array.Empty<CombatPowerPayload>();
+
+    public int base_orb_slots { get; init; }
+
+    public int orb_capacity { get; init; }
+
+    public int empty_orb_slots { get; init; }
+
+    public CombatOrbPayload[] orbs { get; init; } = Array.Empty<CombatOrbPayload>();
+
+    public CombatHandCardPayload[] hand { get; init; } = Array.Empty<CombatHandCardPayload>();
+
+    public DeckCardPayload[] draw_pile { get; init; } = Array.Empty<DeckCardPayload>();
+
+    public DeckCardPayload[] discard_pile { get; init; } = Array.Empty<DeckCardPayload>();
+
+    public DeckCardPayload[] exhaust_pile { get; init; } = Array.Empty<DeckCardPayload>();
+
+    public DeckCardPayload[] play_pile { get; init; } = Array.Empty<DeckCardPayload>();
+
+    public DeckCardPayload[] deck { get; init; } = Array.Empty<DeckCardPayload>();
+
+    public RunRelicPayload[] relics { get; init; } = Array.Empty<RunRelicPayload>();
+
+    public RunPotionPayload[] potions { get; init; } = Array.Empty<RunPotionPayload>();
 }
 
 internal sealed class RunPlayerSummaryPayload
@@ -6616,7 +6695,17 @@ internal sealed class RunPlayerSummaryPayload
 
     public int gold { get; init; }
 
+    public int max_energy { get; init; }
+
+    public int base_orb_slots { get; init; }
+
     public bool is_alive { get; init; }
+
+    public DeckCardPayload[] deck { get; init; } = Array.Empty<DeckCardPayload>();
+
+    public RunRelicPayload[] relics { get; init; } = Array.Empty<RunRelicPayload>();
+
+    public RunPotionPayload[] potions { get; init; } = Array.Empty<RunPotionPayload>();
 }
 
 internal sealed class CombatOrbPayload

--- a/STS2AIAgent/Game/OptionalAiTeammateTelemetry.cs
+++ b/STS2AIAgent/Game/OptionalAiTeammateTelemetry.cs
@@ -1,0 +1,284 @@
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Reflection;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Logging;
+using STS2AIAgent.Server;
+
+namespace STS2AIAgent.Game;
+
+/// <summary>
+/// Optional, dependency-free adapter for the workshop AI teammate. The mod already retains its selected action,
+/// concrete card/target and decision reason in AiDecisionRequest/AiDecisionResult, but exposes no public API.
+/// Reflection keeps STS2AIAgent usable when that optional assembly is absent.
+/// </summary>
+internal static class OptionalAiTeammateTelemetry
+{
+    private const string HarmonyId = "com.chart.sts2-ai-agent.optional-ai-teammate-telemetry";
+    private const string AssemblyName = "sts2AITeammate";
+    private const string LogPrefix = "[STS2AIAgent.OptionalAiTeammateTelemetry]";
+    private const int MaximumRememberedRequests = 2048;
+
+    private static readonly object Gate = new();
+    private static readonly ConcurrentDictionary<string, byte> EmittedRequestIds = new(StringComparer.Ordinal);
+    private static Harmony? _harmony;
+    private static bool _installed;
+
+    internal static bool SuppressLoggingForTests { get; set; }
+
+    internal static int LastPatchedDecisionMethodCount { get; private set; }
+
+    public static void Install()
+    {
+        lock (Gate)
+        {
+            if (_installed)
+            {
+                return;
+            }
+
+            _installed = true;
+            _harmony = new Harmony(HarmonyId);
+            AppDomain.CurrentDomain.AssemblyLoad += OnAssemblyLoad;
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                TryPatchAssembly(assembly);
+            }
+        }
+    }
+
+    public static void Uninstall()
+    {
+        lock (Gate)
+        {
+            if (!_installed)
+            {
+                return;
+            }
+
+            _installed = false;
+            AppDomain.CurrentDomain.AssemblyLoad -= OnAssemblyLoad;
+            _harmony?.UnpatchAll(HarmonyId);
+            _harmony = null;
+            EmittedRequestIds.Clear();
+            LastPatchedDecisionMethodCount = 0;
+        }
+    }
+
+    private static void OnAssemblyLoad(object? sender, AssemblyLoadEventArgs args) => TryPatchAssembly(args.LoadedAssembly);
+
+    private static void TryPatchAssembly(Assembly assembly)
+    {
+        if (!_installed || !string.Equals(assembly.GetName().Name, AssemblyName, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var harmony = _harmony;
+        if (harmony == null)
+        {
+            return;
+        }
+
+        var patched = 0;
+        foreach (var type in SafeGetTypes(assembly))
+        {
+            const BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+            foreach (var method in type.GetMethods(flags).Where(IsDecisionMethod))
+            {
+                if (Harmony.GetPatchInfo(method)?.Postfixes.Any(patch => patch.owner == HarmonyId) == true)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    harmony.Patch(
+                        method,
+                        postfix: new HarmonyMethod(typeof(OptionalAiTeammateTelemetry), nameof(DecisionPostfix)));
+                    patched += 1;
+                }
+                catch (Exception ex)
+                {
+                    Warn($"Could not patch {method.FullDescription()}: {ex.Message}");
+                }
+            }
+        }
+
+        LastPatchedDecisionMethodCount += patched;
+        Info($"Patched {patched} decision backend method(s) in {assembly.GetName().Name} {assembly.GetName().Version}.");
+    }
+
+    private static bool IsDecisionMethod(MethodInfo method)
+    {
+        if (!string.Equals(method.Name, "DecideAsync", StringComparison.Ordinal) || method.GetParameters().Length != 2)
+        {
+            return false;
+        }
+
+        var returnType = method.ReturnType;
+        return returnType.IsGenericType &&
+               returnType.GetGenericTypeDefinition() == typeof(Task<>) &&
+               string.Equals(returnType.GetGenericArguments()[0].Name, "AiDecisionResult", StringComparison.Ordinal) &&
+               string.Equals(method.GetParameters()[0].ParameterType.Name, "AiDecisionRequest", StringComparison.Ordinal);
+    }
+
+    private static void DecisionPostfix(object __0, Task __result)
+    {
+        _ = CaptureDecisionAsync(__0, __result);
+    }
+
+    private static async Task CaptureDecisionAsync(object request, Task resultTask)
+    {
+        try
+        {
+            await resultTask.ConfigureAwait(false);
+            var result = resultTask.GetType().GetProperty("Result", BindingFlags.Instance | BindingFlags.Public)?.GetValue(resultTask);
+            if (result == null || !AiDecisionFactParser.TryParse(request, result, out var fact))
+            {
+                return;
+            }
+
+            if (!EmittedRequestIds.TryAdd(fact.RequestId, 0))
+            {
+                return;
+            }
+
+            if (EmittedRequestIds.Count > MaximumRememberedRequests)
+            {
+                EmittedRequestIds.Clear();
+                EmittedRequestIds.TryAdd(fact.RequestId, 0);
+            }
+
+            GameEventService.Instance.RecordAiDecisionFact(fact);
+        }
+        catch (Exception ex)
+        {
+            Warn($"Failed to capture an optional AI decision: {ex.Message}");
+        }
+    }
+
+    private static void Info(string message)
+    {
+        if (!SuppressLoggingForTests)
+        {
+            Log.Info($"{LogPrefix} {message}");
+        }
+    }
+
+    private static void Warn(string message)
+    {
+        if (!SuppressLoggingForTests)
+        {
+            Log.Warn($"{LogPrefix} {message}");
+        }
+    }
+
+    private static Type[] SafeGetTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return ex.Types.OfType<Type>().ToArray();
+        }
+    }
+}
+
+internal static class AiDecisionFactParser
+{
+    public static bool TryParse(object request, object result, out AiDecisionFact fact)
+    {
+        var requestId = ReadString(request, "RequestId");
+        var chosenActionId = ReadString(result, "ChosenActionId");
+        if (string.IsNullOrWhiteSpace(requestId) || string.IsNullOrWhiteSpace(chosenActionId))
+        {
+            fact = default!;
+            return false;
+        }
+
+        var option = ReadEnumerable(request, "LegalActions")
+            .FirstOrDefault(candidate => string.Equals(ReadString(candidate, "ActionId"), chosenActionId, StringComparison.Ordinal));
+        fact = new AiDecisionFact(
+            requestId,
+            ReadString(request, "SnapshotId"),
+            ReadString(request, "ActorId"),
+            chosenActionId,
+            ReadStrings(result, "RankedActionIds"),
+            ReadString(result, "Reason") ?? ReadString(result, "Reasoning"),
+            option == null ? null : new AiDecisionOptionFact(
+                ReadString(option, "ActionId") ?? chosenActionId,
+                ReadString(option, "ActionType"),
+                ReadString(option, "Description"),
+                ReadString(option, "Label"),
+                ReadString(option, "Summary"),
+                ReadString(option, "CardId"),
+                ReadString(option, "CardInstanceId"),
+                ReadString(option, "TargetId"),
+                ReadString(option, "TargetLabel"),
+                ReadNullableInt(option, "EnergyCost"),
+                ReadStrings(option, "PriorityTags"),
+                ReadStringDictionary(option, "Metadata")));
+        return true;
+    }
+
+    private static string? ReadString(object target, string propertyName) =>
+        target.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            ?.GetValue(target)?.ToString();
+
+    private static int? ReadNullableInt(object target, string propertyName)
+    {
+        var value = target.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            ?.GetValue(target);
+        return value == null ? null : Convert.ToInt32(value);
+    }
+
+    private static object[] ReadEnumerable(object target, string propertyName)
+    {
+        var value = target.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            ?.GetValue(target);
+        return value is IEnumerable enumerable ? enumerable.Cast<object>().ToArray() : Array.Empty<object>();
+    }
+
+    private static string[] ReadStrings(object target, string propertyName) =>
+        ReadEnumerable(target, propertyName).Select(static value => value.ToString() ?? string.Empty).ToArray();
+
+    private static IReadOnlyDictionary<string, string> ReadStringDictionary(object target, string propertyName)
+    {
+        var value = target.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            ?.GetValue(target);
+        if (value is not IDictionary dictionary)
+        {
+            return new Dictionary<string, string>();
+        }
+
+        return dictionary.Keys.Cast<object>()
+            .Where(key => key != null)
+            .ToDictionary(key => key.ToString() ?? string.Empty, key => dictionary[key]?.ToString() ?? string.Empty, StringComparer.Ordinal);
+    }
+}
+
+internal sealed record AiDecisionFact(
+    string RequestId,
+    string? SnapshotId,
+    string? ActorId,
+    string ChosenActionId,
+    string[] RankedActionIds,
+    string? Reason,
+    AiDecisionOptionFact? Option);
+
+internal sealed record AiDecisionOptionFact(
+    string ActionId,
+    string? ActionType,
+    string? Description,
+    string? Label,
+    string? Summary,
+    string? CardId,
+    string? CardInstanceId,
+    string? TargetId,
+    string? TargetLabel,
+    int? EnergyCost,
+    string[] PriorityTags,
+    IReadOnlyDictionary<string, string> Metadata);

--- a/STS2AIAgent/ModEntry.cs
+++ b/STS2AIAgent/ModEntry.cs
@@ -21,6 +21,8 @@ public static class ModEntry
         RegisterShutdownHooks();
         GameThread.Initialize();
         GameEventService.Instance.Start();
+        GameFactInstrumentation.Install();
+        OptionalAiTeammateTelemetry.Install();
         HttpServer.Instance.Start();
         AgentRuntime.Instance.Initialize();
         AgentOverlayHost.Install();
@@ -44,6 +46,8 @@ public static class ModEntry
         {
             AgentRuntime.Instance.Shutdown();
             AgentOverlayHost.Uninstall();
+            OptionalAiTeammateTelemetry.Uninstall();
+            GameFactInstrumentation.Uninstall();
             GameEventService.Instance.Stop();
             HttpServer.Instance.Stop();
         }

--- a/STS2AIAgent/STS2AIAgent.csproj
+++ b/STS2AIAgent/STS2AIAgent.csproj
@@ -28,4 +28,10 @@
       <Private>false</Private>
     </Reference>
   </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Schemas\2026-08-31-v2\*.schema.json">
+      <LogicalName>STS2AIAgent.Schemas.2026-08-31-v2.%(Filename)%(Extension)</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/STS2AIAgent/Schemas/2026-08-31-v2/data-collection.schema.json
+++ b/STS2AIAgent/Schemas/2026-08-31-v2/data-collection.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/CharTyr/STS2-Agent/schemas/2026-08-31-v2/data-collection.schema.json",
+  "title": "STS2-Agent static game-data collection",
+  "description": "The data field returned by GET /data/cards, /data/relics, /data/monsters, /data/potions, /data/events, /data/powers, or /data/characters.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["id"],
+    "properties": {
+      "id": { "type": "string", "minLength": 1 },
+      "name": { "type": ["string", "null"] },
+      "description": { "type": ["string", "null"] }
+    },
+    "additionalProperties": true
+  },
+  "examples": [
+    [
+      { "id": "STRIKE_IRONCLAD", "name": "Strike", "type": "Attack", "rarity": "Basic" }
+    ]
+  ]
+}

--- a/STS2AIAgent/Schemas/2026-08-31-v2/event.schema.json
+++ b/STS2AIAgent/Schemas/2026-08-31-v2/event.schema.json
@@ -1,0 +1,263 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/CharTyr/STS2-Agent/schemas/2026-08-31-v2/event.schema.json",
+  "title": "STS2-Agent SSE event envelope",
+  "type": "object",
+  "required": ["event_id", "sequence", "protocol_version", "correlation_id", "run_id", "combat_id", "type", "timestamp_utc", "data"],
+  "properties": {
+    "event_id": { "type": "integer", "minimum": 1 },
+    "sequence": { "type": "integer", "minimum": 1 },
+    "protocol_version": { "const": "2026-08-31-v2" },
+    "correlation_id": { "type": ["string", "null"] },
+    "run_id": { "type": ["string", "null"] },
+    "combat_id": { "type": ["string", "null"] },
+    "type": {
+      "enum": [
+        "session_started", "stream_ready", "screen_changed", "combat_started", "combat_turn_changed", "combat_ended",
+        "action_started", "damage_resolved", "action_finished", "ai_decision", "player_action_window_opened",
+        "player_action_window_closed", "route_decision_required", "reward_decision_required", "event_state_changed",
+        "available_actions_changed"
+      ]
+    },
+    "timestamp_utc": { "type": "string", "format": "date-time" },
+    "data": { "type": "object" }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "type": { "const": "combat_started" } } },
+      "then": { "properties": { "data": { "$ref": "#/$defs/combatStarted" } }, "required": ["correlation_id", "run_id", "combat_id"] }
+    },
+    {
+      "if": { "properties": { "type": { "const": "combat_ended" } } },
+      "then": { "properties": { "data": { "$ref": "#/$defs/combatEnded" } }, "required": ["correlation_id", "run_id", "combat_id"] }
+    },
+    {
+      "if": { "properties": { "type": { "const": "action_started" } } },
+      "then": { "properties": { "data": { "$ref": "#/$defs/cardAction" } }, "required": ["correlation_id"] }
+    },
+    {
+      "if": { "properties": { "type": { "const": "action_finished" } } },
+      "then": { "properties": { "data": { "$ref": "#/$defs/cardActionFinished" } }, "required": ["correlation_id"] }
+    },
+    {
+      "if": { "properties": { "type": { "const": "damage_resolved" } } },
+      "then": { "properties": { "data": { "$ref": "#/$defs/damageResolved" } }, "required": ["correlation_id"] }
+    },
+    {
+      "if": { "properties": { "type": { "const": "ai_decision" } } },
+      "then": { "properties": { "data": { "$ref": "#/$defs/aiDecision" } }, "required": ["correlation_id"] }
+    }
+  ],
+  "additionalProperties": false,
+  "$defs": {
+    "encounter": {
+      "type": "object",
+      "required": ["encounter_id", "encounter_type"],
+      "properties": {
+        "encounter_id": { "type": "string" },
+        "encounter_type": { "enum": ["normal", "elite", "boss", "unassigned", "treasure", "shop", "event", "restsite", "map"] }
+      },
+      "additionalProperties": false
+    },
+    "entity": {
+      "type": ["object", "null"],
+      "required": ["entity_id", "entity_type", "model_id", "name", "player_id", "is_local"],
+      "properties": {
+        "entity_id": { "type": "string" },
+        "entity_type": { "enum": ["player", "enemy"] },
+        "model_id": { "type": "string" },
+        "name": { "type": "string" },
+        "player_id": { "type": ["string", "null"] },
+        "is_local": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "source": {
+      "type": ["object", "null"],
+      "required": ["source_type", "source_id", "source_name", "card_instance_id"],
+      "properties": {
+        "source_type": { "enum": ["card", "power", "relic", "potion", "orb", "monster", "unknown"] },
+        "source_id": { "type": "string" },
+        "source_name": { "type": "string" },
+        "card_instance_id": { "type": ["string", "null"] }
+      },
+      "additionalProperties": false
+    },
+    "card": {
+      "type": "object",
+      "required": ["card_id", "card_instance_id", "name", "upgraded", "auto_play", "play_index", "play_count"],
+      "properties": {
+        "card_id": { "type": "string" },
+        "card_instance_id": { "type": ["string", "null"] },
+        "name": { "type": "string" },
+        "upgraded": { "type": "boolean" },
+        "auto_play": { "type": "boolean" },
+        "play_index": { "type": "integer", "minimum": 0 },
+        "play_count": { "type": "integer", "minimum": 1 }
+      },
+      "additionalProperties": false
+    },
+    "combatStarted": {
+      "type": "object",
+      "required": ["run_id", "combat_id", "turn", "encounter"],
+      "properties": {
+        "run_id": { "type": "string" },
+        "combat_id": { "type": "string" },
+        "turn": { "type": "integer" },
+        "encounter": { "$ref": "#/$defs/encounter" }
+      },
+      "additionalProperties": false
+    },
+    "combatEnded": {
+      "type": "object",
+      "required": ["run_id", "combat_id", "outcome", "victory", "outcome_source", "encounter"],
+      "properties": {
+        "run_id": { "type": "string" },
+        "combat_id": { "type": "string" },
+        "outcome": { "enum": ["victory", "defeat"] },
+        "victory": { "type": "boolean" },
+        "outcome_source": { "enum": ["combat_manager.combat_won", "combat_manager.combat_ended_without_combat_won"] },
+        "encounter": { "$ref": "#/$defs/encounter" }
+      },
+      "additionalProperties": false
+    },
+    "cardAction": {
+      "type": "object",
+      "required": ["action_type", "actor", "source", "target", "card"],
+      "properties": {
+        "action_type": { "const": "card_play" },
+        "actor": { "$ref": "#/$defs/entity" },
+        "source": { "$ref": "#/$defs/source" },
+        "target": { "$ref": "#/$defs/entity" },
+        "card": { "$ref": "#/$defs/card" }
+      },
+      "additionalProperties": true
+    },
+    "targetTotal": {
+      "type": "object",
+      "required": ["target_id", "target_name", "blocked_damage", "hp_loss", "overkill_damage", "hit_count"],
+      "properties": {
+        "target_id": { "type": "string" },
+        "target_name": { "type": "string" },
+        "blocked_damage": { "type": "integer", "minimum": 0 },
+        "hp_loss": { "type": "integer", "minimum": 0 },
+        "overkill_damage": { "type": "integer", "minimum": 0 },
+        "hit_count": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "cardActionFinished": {
+      "allOf": [
+        { "$ref": "#/$defs/cardAction" },
+        {
+          "type": "object",
+          "required": ["damage"],
+          "properties": {
+            "damage": {
+              "type": "object",
+              "required": ["targets", "total_blocked_damage", "total_hp_loss", "total_overkill_damage", "hit_count"],
+              "properties": {
+                "targets": { "type": "array", "items": { "$ref": "#/$defs/targetTotal" } },
+                "total_blocked_damage": { "type": "integer", "minimum": 0 },
+                "total_hp_loss": { "type": "integer", "minimum": 0 },
+                "total_overkill_damage": { "type": "integer", "minimum": 0 },
+                "hit_count": { "type": "integer", "minimum": 0 }
+              },
+              "additionalProperties": false
+            }
+          }
+        }
+      ]
+    },
+    "damageTarget": {
+      "type": "object",
+      "required": ["target", "blocked_damage", "hp_loss", "overkill_damage", "total_damage", "was_block_broken", "was_fully_blocked", "was_target_killed"],
+      "properties": {
+        "target": { "$ref": "#/$defs/entity" },
+        "blocked_damage": { "type": "integer", "minimum": 0 },
+        "hp_loss": { "type": "integer", "minimum": 0 },
+        "overkill_damage": { "type": "integer", "minimum": 0 },
+        "total_damage": { "type": "integer", "minimum": 0 },
+        "was_block_broken": { "type": "boolean" },
+        "was_fully_blocked": { "type": "boolean" },
+        "was_target_killed": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "damageResolved": {
+      "type": "object",
+      "required": ["action_type", "requested_amount", "value_props", "source_attribution", "source", "actor", "targets", "total_blocked_damage", "total_hp_loss", "total_overkill_damage"],
+      "properties": {
+        "action_type": { "enum": ["card_play", "effect"] },
+        "requested_amount": { "type": "number" },
+        "value_props": { "type": "array", "items": { "enum": ["unblockable", "unpowered", "move", "skiphurtanim"] } },
+        "source_attribution": { "enum": ["exact", "unavailable"] },
+        "source": { "$ref": "#/$defs/source" },
+        "actor": { "$ref": "#/$defs/entity" },
+        "targets": { "type": "array", "items": { "$ref": "#/$defs/damageTarget" } },
+        "total_blocked_damage": { "type": "integer", "minimum": 0 },
+        "total_hp_loss": { "type": "integer", "minimum": 0 },
+        "total_overkill_damage": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "aiDecision": {
+      "type": "object",
+      "required": ["request_id", "snapshot_id", "actor_id", "actor_role", "chosen_action_id", "ranked_action_ids", "reason", "chosen_action", "provenance"],
+      "properties": {
+        "request_id": { "type": "string" },
+        "snapshot_id": { "type": ["string", "null"] },
+        "actor_id": { "type": ["string", "null"] },
+        "actor_role": { "const": "ai_teammate" },
+        "chosen_action_id": { "type": "string" },
+        "ranked_action_ids": { "type": "array", "items": { "type": "string" } },
+        "reason": { "type": ["string", "null"] },
+        "chosen_action": {
+          "type": ["object", "null"],
+          "properties": {
+            "action_id": { "type": "string" },
+            "action_type": { "type": ["string", "null"] },
+            "card_id": { "type": ["string", "null"] },
+            "card_instance_id": { "type": ["string", "null"] },
+            "target_id": { "type": ["string", "null"] },
+            "target_label": { "type": ["string", "null"] },
+            "energy_cost": { "type": ["integer", "null"] }
+          },
+          "additionalProperties": true
+        },
+        "provenance": { "const": "optional_ai_teammate_decision_backend" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "examples": [
+    {
+      "event_id": 42,
+      "sequence": 42,
+      "protocol_version": "2026-08-31-v2",
+      "correlation_id": "combat_4_card_12",
+      "run_id": "ABC123",
+      "combat_id": "combat_4",
+      "type": "damage_resolved",
+      "timestamp_utc": "2026-08-31T10:00:00.0000000Z",
+      "data": {
+        "action_type": "card_play",
+        "requested_amount": 9,
+        "value_props": ["move"],
+        "source_attribution": "exact",
+        "source": { "source_type": "card", "source_id": "STRIKE_IRONCLAD", "source_name": "Strike", "card_instance_id": "combat_17" },
+        "actor": { "entity_id": "player_2", "entity_type": "player", "model_id": "IRONCLAD", "name": "Chiba", "player_id": "2", "is_local": false },
+        "targets": [
+          {
+            "target": { "entity_id": "creature_8", "entity_type": "enemy", "model_id": "CULTIST", "name": "Cultist", "player_id": null, "is_local": false },
+            "blocked_damage": 3, "hp_loss": 6, "overkill_damage": 0, "total_damage": 9,
+            "was_block_broken": true, "was_fully_blocked": false, "was_target_killed": false
+          }
+        ],
+        "total_blocked_damage": 3,
+        "total_hp_loss": 6,
+        "total_overkill_damage": 0
+      }
+    }
+  ]
+}

--- a/STS2AIAgent/Schemas/2026-08-31-v2/health.schema.json
+++ b/STS2AIAgent/Schemas/2026-08-31-v2/health.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/CharTyr/STS2-Agent/schemas/2026-08-31-v2/health.schema.json",
+  "title": "STS2-Agent health payload",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["service", "mod_version", "protocol_version", "schema_version", "game_version", "status", "api_host", "api_port", "instance_role"],
+  "properties": {
+    "service": { "const": "sts2-ai-agent" },
+    "mod_version": { "type": "string", "minLength": 1 },
+    "protocol_version": { "const": "2026-08-31-v2" },
+    "schema_version": { "const": "2026-08-31-v2" },
+    "game_version": { "type": "string", "minLength": 1 },
+    "status": { "const": "ready" },
+    "api_host": { "type": "string", "minLength": 1 },
+    "api_port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+    "instance_role": { "enum": ["human", "companion"] }
+  },
+  "examples": [
+    {
+      "service": "sts2-ai-agent",
+      "mod_version": "0.9.1",
+      "protocol_version": "2026-08-31-v2",
+      "schema_version": "2026-08-31-v2",
+      "game_version": "0.111.0",
+      "status": "ready",
+      "api_host": "127.0.0.1",
+      "api_port": 8080,
+      "instance_role": "human"
+    }
+  ]
+}

--- a/STS2AIAgent/Schemas/2026-08-31-v2/state.schema.json
+++ b/STS2AIAgent/Schemas/2026-08-31-v2/state.schema.json
@@ -1,0 +1,463 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/CharTyr/STS2-Agent/schemas/2026-08-31-v2/state.schema.json",
+  "title": "STS2-Agent complete game state",
+  "type": "object",
+  "required": [
+    "state_version", "run_id", "screen", "session", "in_combat", "turn", "available_actions",
+    "combat", "run", "multiplayer", "multiplayer_lobby", "map", "selection", "character_select",
+    "timeline", "unlock", "chest", "event", "crystal_sphere", "shop", "rest", "reward", "bundles",
+    "capstone", "modal", "game_over", "agent_view"
+  ],
+  "properties": {
+    "state_version": { "const": 12 },
+    "run_id": { "type": "string", "minLength": 1 },
+    "screen": {
+      "enum": [
+        "MAIN_MENU", "MULTIPLAYER_LOBBY", "CHARACTER_SELECT", "MAP", "COMBAT", "CARD_SELECTION",
+        "CARDS_VIEW", "REWARD", "CHEST", "REST", "SHOP", "EVENT", "BUNDLE_SELECTION",
+        "CAPSTONE_SELECTION", "CRYSTAL_SPHERE", "MODAL", "UNLOCK", "GAME_OVER", "UNKNOWN"
+      ]
+    },
+    "session": { "$ref": "#/$defs/session" },
+    "in_combat": { "type": "boolean" },
+    "turn": { "type": ["integer", "null"], "minimum": 0 },
+    "available_actions": { "type": "array", "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
+    "combat": { "oneOf": [{ "$ref": "#/$defs/combat" }, { "type": "null" }] },
+    "run": { "oneOf": [{ "$ref": "#/$defs/run" }, { "type": "null" }] },
+    "multiplayer": { "oneOf": [{ "$ref": "#/$defs/multiplayer" }, { "type": "null" }] },
+    "multiplayer_lobby": { "oneOf": [{ "$ref": "#/$defs/multiplayerLobby" }, { "type": "null" }] },
+    "map": { "oneOf": [{ "$ref": "#/$defs/map" }, { "type": "null" }] },
+    "selection": { "oneOf": [{ "$ref": "#/$defs/selection" }, { "type": "null" }] },
+    "character_select": { "oneOf": [{ "$ref": "#/$defs/characterSelect" }, { "type": "null" }] },
+    "timeline": { "oneOf": [{ "$ref": "#/$defs/timeline" }, { "type": "null" }] },
+    "unlock": { "oneOf": [{ "$ref": "#/$defs/unlock" }, { "type": "null" }] },
+    "chest": { "oneOf": [{ "$ref": "#/$defs/chest" }, { "type": "null" }] },
+    "event": { "oneOf": [{ "$ref": "#/$defs/gameEvent" }, { "type": "null" }] },
+    "crystal_sphere": { "oneOf": [{ "$ref": "#/$defs/crystalSphere" }, { "type": "null" }] },
+    "shop": { "oneOf": [{ "$ref": "#/$defs/shop" }, { "type": "null" }] },
+    "rest": { "oneOf": [{ "$ref": "#/$defs/rest" }, { "type": "null" }] },
+    "reward": { "oneOf": [{ "$ref": "#/$defs/reward" }, { "type": "null" }] },
+    "bundles": { "type": ["array", "null"], "items": { "$ref": "#/$defs/bundle" } },
+    "capstone": { "oneOf": [{ "$ref": "#/$defs/capstone" }, { "type": "null" }] },
+    "modal": { "oneOf": [{ "$ref": "#/$defs/modal" }, { "type": "null" }] },
+    "game_over": { "oneOf": [{ "$ref": "#/$defs/gameOver" }, { "type": "null" }] },
+    "agent_view": { "type": ["object", "null"], "additionalProperties": true }
+  },
+  "allOf": [
+    { "if": { "properties": { "screen": { "const": "COMBAT" } } }, "then": { "properties": { "combat": { "$ref": "#/$defs/combat" } } } },
+    { "if": { "properties": { "screen": { "const": "MAP" } } }, "then": { "properties": { "map": { "type": "object" } } } },
+    { "if": { "properties": { "screen": { "const": "CARD_SELECTION" } } }, "then": { "properties": { "selection": { "type": "object" } } } },
+    { "if": { "properties": { "screen": { "const": "CHARACTER_SELECT" } } }, "then": { "properties": { "character_select": { "type": "object" } } } },
+    { "if": { "properties": { "screen": { "const": "MULTIPLAYER_LOBBY" } } }, "then": { "properties": { "multiplayer_lobby": { "type": "object" } } } },
+    { "if": { "properties": { "screen": { "const": "REWARD" } } }, "then": { "properties": { "reward": { "type": "object" } } } },
+    { "if": { "properties": { "screen": { "const": "CHEST" } } }, "then": { "properties": { "chest": { "type": "object" } } } },
+    { "if": { "properties": { "screen": { "const": "REST" } } }, "then": { "properties": { "rest": { "type": "object" } } } },
+    { "if": { "properties": { "screen": { "const": "SHOP" } } }, "then": { "properties": { "shop": { "type": "object" } } } },
+    { "if": { "properties": { "screen": { "const": "EVENT" } } }, "then": { "properties": { "event": { "type": "object" } } } },
+    { "if": { "properties": { "screen": { "const": "BUNDLE_SELECTION" } } }, "then": { "properties": { "bundles": { "type": "array" } } } },
+    { "if": { "properties": { "screen": { "const": "CAPSTONE_SELECTION" } } }, "then": { "properties": { "capstone": { "type": "object" } } } },
+    { "if": { "properties": { "screen": { "const": "CRYSTAL_SPHERE" } } }, "then": { "properties": { "crystal_sphere": { "type": "object" } } } },
+    { "if": { "properties": { "screen": { "const": "MODAL" } } }, "then": { "properties": { "modal": { "type": "object" } } } },
+    { "if": { "properties": { "screen": { "const": "UNLOCK" } } }, "then": { "properties": { "unlock": { "type": "object" } } } },
+    { "if": { "properties": { "screen": { "const": "GAME_OVER" } } }, "then": { "properties": { "game_over": { "type": "object" } } } }
+  ],
+  "additionalProperties": false,
+  "$defs": {
+    "session": {
+      "type": "object",
+      "required": ["mode", "phase", "control_scope"],
+      "properties": {
+        "mode": { "enum": ["singleplayer", "multiplayer"] },
+        "phase": { "enum": ["menu", "multiplayer_lobby", "character_select", "run"] },
+        "control_scope": { "const": "local_player" }
+      },
+      "additionalProperties": false
+    },
+    "multiplayer": {
+      "type": "object",
+      "required": ["is_multiplayer", "net_game_type", "local_player_id", "player_count", "connected_player_ids"],
+      "properties": {
+        "is_multiplayer": { "type": "boolean" },
+        "net_game_type": { "type": "string" },
+        "local_player_id": { "type": ["string", "null"] },
+        "player_count": { "type": "integer", "minimum": 0 },
+        "connected_player_ids": { "type": "array", "items": { "type": "string" }, "uniqueItems": true }
+      },
+      "additionalProperties": false
+    },
+    "multiplayerLobby": {
+      "type": "object",
+      "required": [
+        "net_game_type", "join_host", "join_port", "local_net_id_hint", "has_lobby", "is_host", "is_client",
+        "local_ready", "can_host", "can_join", "can_ready", "can_disconnect", "can_unready",
+        "selected_character_id", "player_count", "max_players", "players", "characters"
+      ],
+      "properties": {
+        "net_game_type": { "type": "string" },
+        "join_host": { "type": "string" },
+        "join_port": { "type": "integer", "minimum": 0, "maximum": 65535 },
+        "local_net_id_hint": { "type": ["string", "null"] },
+        "has_lobby": { "type": "boolean" },
+        "is_host": { "type": "boolean" },
+        "is_client": { "type": "boolean" },
+        "local_ready": { "type": "boolean" },
+        "can_host": { "type": "boolean" },
+        "can_join": { "type": "boolean" },
+        "can_ready": { "type": "boolean" },
+        "can_disconnect": { "type": "boolean" },
+        "can_unready": { "type": "boolean" },
+        "selected_character_id": { "type": ["string", "null"] },
+        "player_count": { "type": "integer", "minimum": 0 },
+        "max_players": { "type": "integer", "minimum": 0 },
+        "players": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+        "characters": { "type": "array", "items": { "type": "object", "additionalProperties": true } }
+      },
+      "additionalProperties": false
+    },
+    "coordinate": {
+      "type": ["object", "null"],
+      "required": ["row", "col"],
+      "properties": { "row": { "type": "integer" }, "col": { "type": "integer" } },
+      "additionalProperties": false
+    },
+    "map": {
+      "type": "object",
+      "required": [
+        "current_node", "is_travel_enabled", "is_traveling", "map_generation_count", "rows", "cols",
+        "starting_node", "boss_node", "second_boss_node", "nodes", "available_nodes", "local_vote", "player_votes"
+      ],
+      "properties": {
+        "current_node": { "$ref": "#/$defs/coordinate" },
+        "is_travel_enabled": { "type": "boolean" },
+        "is_traveling": { "type": "boolean" },
+        "map_generation_count": { "type": "integer", "minimum": 0 },
+        "rows": { "type": "integer", "minimum": 0 },
+        "cols": { "type": "integer", "minimum": 0 },
+        "starting_node": { "$ref": "#/$defs/coordinate" },
+        "boss_node": { "$ref": "#/$defs/coordinate" },
+        "second_boss_node": { "$ref": "#/$defs/coordinate" },
+        "nodes": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+        "available_nodes": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+        "local_vote": { "$ref": "#/$defs/coordinate" },
+        "player_votes": { "type": "array", "items": { "type": "object", "additionalProperties": true } }
+      },
+      "additionalProperties": false
+    },
+    "selection": {
+      "type": "object",
+      "required": ["kind", "prompt", "min_select", "max_select", "selected_count", "requires_confirmation", "can_confirm", "cards"],
+      "properties": {
+        "kind": { "type": "string" }, "prompt": { "type": "string" },
+        "min_select": { "type": "integer", "minimum": 0 }, "max_select": { "type": "integer", "minimum": 0 },
+        "selected_count": { "type": "integer", "minimum": 0 },
+        "requires_confirmation": { "type": "boolean" }, "can_confirm": { "type": "boolean" },
+        "cards": { "type": "array", "items": { "$ref": "#/$defs/card" } }
+      },
+      "additionalProperties": false
+    },
+    "characterSelect": {
+      "type": "object",
+      "required": [
+        "selected_character_id", "is_multiplayer", "net_game_type", "can_embark", "can_unready",
+        "can_increase_ascension", "can_decrease_ascension", "local_ready", "is_waiting_for_players",
+        "player_count", "max_players", "ascension", "max_ascension", "seed", "modifier_ids", "players", "characters"
+      ],
+      "properties": {
+        "selected_character_id": { "type": ["string", "null"] }, "is_multiplayer": { "type": "boolean" },
+        "net_game_type": { "type": "string" }, "can_embark": { "type": "boolean" }, "can_unready": { "type": "boolean" },
+        "can_increase_ascension": { "type": "boolean" }, "can_decrease_ascension": { "type": "boolean" },
+        "local_ready": { "type": "boolean" }, "is_waiting_for_players": { "type": "boolean" },
+        "player_count": { "type": "integer", "minimum": 0 }, "max_players": { "type": "integer", "minimum": 0 },
+        "ascension": { "type": "integer", "minimum": 0 }, "max_ascension": { "type": "integer", "minimum": 0 },
+        "seed": { "type": ["string", "null"] },
+        "modifier_ids": { "type": "array", "items": { "type": "string" } },
+        "players": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+        "characters": { "type": "array", "items": { "type": "object", "additionalProperties": true } }
+      },
+      "additionalProperties": false
+    },
+    "timeline": {
+      "type": "object",
+      "required": ["back_enabled", "inspect_open", "unlock_screen_open", "can_choose_epoch", "can_confirm_overlay", "slots"],
+      "properties": {
+        "back_enabled": { "type": "boolean" }, "inspect_open": { "type": "boolean" },
+        "unlock_screen_open": { "type": "boolean" }, "can_choose_epoch": { "type": "boolean" },
+        "can_confirm_overlay": { "type": "boolean" },
+        "slots": { "type": "array", "items": { "type": "object", "additionalProperties": true } }
+      },
+      "additionalProperties": false
+    },
+    "unlock": {
+      "type": "object",
+      "required": ["unlock_type", "items", "can_confirm"],
+      "properties": {
+        "unlock_type": { "type": "string" }, "items": { "type": "array", "items": { "type": "string" } },
+        "can_confirm": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "chest": {
+      "type": "object",
+      "required": ["is_opened", "has_relic_been_claimed", "relic_options"],
+      "properties": {
+        "is_opened": { "type": "boolean" }, "has_relic_been_claimed": { "type": "boolean" },
+        "relic_options": { "type": "array", "items": { "type": "object", "additionalProperties": true } }
+      },
+      "additionalProperties": false
+    },
+    "gameEvent": {
+      "type": "object",
+      "required": ["event_id", "title", "description", "is_finished", "options"],
+      "properties": {
+        "event_id": { "type": "string" }, "title": { "type": "string" }, "description": { "type": "string" },
+        "is_finished": { "type": "boolean" },
+        "options": { "type": "array", "items": { "type": "object", "additionalProperties": true } }
+      },
+      "additionalProperties": false
+    },
+    "crystalSphere": {
+      "type": "object",
+      "required": ["divinations_left", "tool", "is_finished", "grid_width", "grid_height", "hidden_cells", "items"],
+      "properties": {
+        "divinations_left": { "type": "integer", "minimum": 0 }, "tool": { "type": "string" },
+        "is_finished": { "type": "boolean" }, "grid_width": { "type": "integer", "minimum": 0 },
+        "grid_height": { "type": "integer", "minimum": 0 },
+        "hidden_cells": { "type": "array", "items": { "type": "array", "items": { "type": "integer" }, "minItems": 2, "maxItems": 2 } },
+        "items": { "type": "array", "items": { "type": "object", "additionalProperties": true } }
+      },
+      "additionalProperties": false
+    },
+    "shop": {
+      "type": "object",
+      "required": ["is_open", "can_open", "can_close", "cards", "relics", "potions", "card_removal"],
+      "properties": {
+        "is_open": { "type": "boolean" }, "can_open": { "type": "boolean" }, "can_close": { "type": "boolean" },
+        "cards": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+        "relics": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+        "potions": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+        "card_removal": { "type": ["object", "null"], "additionalProperties": true }
+      },
+      "additionalProperties": false
+    },
+    "rest": {
+      "type": "object", "required": ["options"],
+      "properties": { "options": { "type": "array", "items": { "type": "object", "additionalProperties": true } } },
+      "additionalProperties": false
+    },
+    "reward": {
+      "type": "object",
+      "required": ["pending_card_choice", "can_proceed", "rewards", "card_options", "alternatives"],
+      "properties": {
+        "pending_card_choice": { "type": "boolean" }, "can_proceed": { "type": "boolean" },
+        "rewards": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+        "card_options": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+        "alternatives": { "type": "array", "items": { "type": "object", "additionalProperties": true } }
+      },
+      "additionalProperties": false
+    },
+    "bundle": {
+      "type": "object", "required": ["index", "cards"],
+      "properties": {
+        "index": { "type": "integer", "minimum": 0 },
+        "cards": { "type": "array", "items": { "type": "object", "additionalProperties": true } }
+      },
+      "additionalProperties": false
+    },
+    "capstone": {
+      "type": "object", "required": ["options"],
+      "properties": { "options": { "type": "array", "items": { "type": "object", "additionalProperties": true } } },
+      "additionalProperties": false
+    },
+    "modal": {
+      "type": "object",
+      "required": ["type_name", "underlying_screen", "can_confirm", "can_dismiss", "confirm_label", "dismiss_label"],
+      "properties": {
+        "type_name": { "type": "string" }, "underlying_screen": { "type": ["string", "null"] },
+        "can_confirm": { "type": "boolean" }, "can_dismiss": { "type": "boolean" },
+        "confirm_label": { "type": ["string", "null"] }, "dismiss_label": { "type": ["string", "null"] }
+      },
+      "additionalProperties": false
+    },
+    "gameOver": {
+      "type": "object",
+      "required": ["is_victory", "floor", "character_id", "can_continue", "can_return_to_main_menu", "showing_summary"],
+      "properties": {
+        "is_victory": { "type": "boolean" }, "floor": { "type": ["integer", "null"] },
+        "character_id": { "type": ["string", "null"] }, "can_continue": { "type": "boolean" },
+        "can_return_to_main_menu": { "type": "boolean" }, "showing_summary": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "card": {
+      "type": "object",
+      "required": ["index", "card_id", "name", "upgraded"],
+      "properties": {
+        "index": { "type": "integer", "minimum": 0 },
+        "card_id": { "type": "string", "minLength": 1 },
+        "name": { "type": "string" },
+        "upgraded": { "type": "boolean" }
+      },
+      "additionalProperties": true
+    },
+    "relic": {
+      "type": "object",
+      "required": ["index", "relic_id", "name", "is_melted"],
+      "properties": {
+        "index": { "type": "integer", "minimum": 0 },
+        "relic_id": { "type": "string", "minLength": 1 },
+        "name": { "type": "string" },
+        "is_melted": { "type": "boolean" }
+      },
+      "additionalProperties": true
+    },
+    "potion": {
+      "type": "object",
+      "required": ["index", "occupied"],
+      "properties": {
+        "index": { "type": "integer", "minimum": 0 },
+        "potion_id": { "type": ["string", "null"] },
+        "name": { "type": ["string", "null"] },
+        "occupied": { "type": "boolean" }
+      },
+      "additionalProperties": true
+    },
+    "combatPlayer": {
+      "type": "object",
+      "required": [
+        "player_id", "slot_index", "is_local", "character_id", "character_name", "current_hp", "max_hp",
+        "is_connected", "block", "energy", "stars", "focus", "is_alive", "powers", "base_orb_slots",
+        "orb_capacity", "empty_orb_slots", "orbs", "hand", "draw_pile", "discard_pile", "exhaust_pile",
+        "play_pile", "deck", "relics", "potions"
+      ],
+      "properties": {
+        "player_id": { "type": "string" },
+        "slot_index": { "type": "integer", "minimum": 0 },
+        "is_local": { "type": "boolean" },
+        "character_id": { "type": "string" },
+        "character_name": { "type": "string" },
+        "is_connected": { "type": "boolean" },
+        "current_hp": { "type": "integer" },
+        "max_hp": { "type": "integer", "minimum": 0 },
+        "block": { "type": "integer", "minimum": 0 },
+        "energy": { "type": "integer", "minimum": 0 },
+        "stars": { "type": "integer", "minimum": 0 },
+        "focus": { "type": "integer" },
+        "is_alive": { "type": "boolean" },
+        "powers": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+        "base_orb_slots": { "type": "integer", "minimum": 0 },
+        "orb_capacity": { "type": "integer", "minimum": 0 },
+        "empty_orb_slots": { "type": "integer", "minimum": 0 },
+        "orbs": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+        "hand": { "type": "array", "items": { "$ref": "#/$defs/card" } },
+        "draw_pile": { "type": "array", "items": { "$ref": "#/$defs/card" } },
+        "discard_pile": { "type": "array", "items": { "$ref": "#/$defs/card" } },
+        "exhaust_pile": { "type": "array", "items": { "$ref": "#/$defs/card" } },
+        "play_pile": { "type": "array", "items": { "$ref": "#/$defs/card" } },
+        "deck": { "type": "array", "items": { "$ref": "#/$defs/card" } },
+        "relics": { "type": "array", "items": { "$ref": "#/$defs/relic" } },
+        "potions": { "type": "array", "items": { "$ref": "#/$defs/potion" } }
+      },
+      "additionalProperties": true
+    },
+    "combat": {
+      "type": "object",
+      "required": ["combat_id", "encounter_id", "encounter_type", "player", "players", "hand", "enemies", "end_turn_will_kill_player", "lethal_risks"],
+      "properties": {
+        "combat_id": { "type": ["string", "null"] },
+        "encounter_id": { "type": ["string", "null"] },
+        "encounter_type": { "enum": ["normal", "elite", "boss", "unassigned", "treasure", "shop", "event", "restsite", "map"] },
+        "player": { "type": "object", "additionalProperties": true },
+        "players": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/combatPlayer" } },
+        "hand": { "type": "array", "items": { "$ref": "#/$defs/card" } },
+        "enemies": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+        "end_turn_will_kill_player": { "type": "boolean" },
+        "lethal_risks": { "type": "array", "items": { "type": "object", "additionalProperties": true } }
+      },
+      "additionalProperties": false
+    },
+    "runPlayer": {
+      "type": "object",
+      "required": [
+        "player_id", "slot_index", "is_local", "is_connected", "character_id", "character_name",
+        "current_hp", "max_hp", "gold", "max_energy", "base_orb_slots", "is_alive", "deck", "relics", "potions"
+      ],
+      "properties": {
+        "player_id": { "type": "string" },
+        "slot_index": { "type": "integer", "minimum": 0 },
+        "is_local": { "type": "boolean" },
+        "is_connected": { "type": "boolean" },
+        "character_id": { "type": "string" },
+        "character_name": { "type": "string" },
+        "current_hp": { "type": "integer" },
+        "max_hp": { "type": "integer", "minimum": 0 },
+        "gold": { "type": "integer", "minimum": 0 },
+        "max_energy": { "type": "integer", "minimum": 0 },
+        "base_orb_slots": { "type": "integer", "minimum": 0 },
+        "is_alive": { "type": "boolean" },
+        "deck": { "type": "array", "items": { "$ref": "#/$defs/card" } },
+        "relics": { "type": "array", "items": { "$ref": "#/$defs/relic" } },
+        "potions": { "type": "array", "items": { "$ref": "#/$defs/potion" } }
+      },
+      "additionalProperties": true
+    },
+    "run": {
+      "type": "object",
+      "required": [
+        "character_id", "character_name", "ascension", "ascension_effects", "floor", "current_hp", "max_hp",
+        "gold", "max_energy", "base_orb_slots", "act_id", "boss_id", "deck", "relics", "players", "potions"
+      ],
+      "properties": {
+        "character_id": { "type": "string" },
+        "character_name": { "type": "string" },
+        "ascension": { "type": "integer", "minimum": 0 },
+        "ascension_effects": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+        "floor": { "type": "integer", "minimum": 0 },
+        "current_hp": { "type": "integer" },
+        "max_hp": { "type": "integer", "minimum": 0 },
+        "gold": { "type": "integer", "minimum": 0 },
+        "max_energy": { "type": "integer", "minimum": 0 },
+        "base_orb_slots": { "type": "integer", "minimum": 0 },
+        "act_id": { "type": ["string", "null"] },
+        "boss_id": { "type": ["string", "null"] },
+        "deck": { "type": "array", "items": { "$ref": "#/$defs/card" } },
+        "relics": { "type": "array", "items": { "$ref": "#/$defs/relic" } },
+        "players": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/runPlayer" } },
+        "potions": { "type": "array", "items": { "$ref": "#/$defs/potion" } }
+      },
+      "additionalProperties": true
+    }
+  },
+  "examples": [
+    {
+      "state_version": 12,
+      "run_id": "ABC123",
+      "screen": "COMBAT",
+      "session": { "mode": "multiplayer", "phase": "run", "control_scope": "local_player" },
+      "in_combat": true,
+      "turn": 2,
+      "available_actions": ["play_card", "end_turn"],
+      "combat": {
+        "combat_id": "combat_4",
+        "encounter_id": "CULTIST_ENCOUNTER",
+        "encounter_type": "normal",
+        "player": {},
+        "players": [
+          {
+            "player_id": "1", "slot_index": 0, "is_local": true, "is_connected": true,
+            "character_id": "IRONCLAD", "character_name": "Ironclad",
+            "current_hp": 70, "max_hp": 80, "block": 5, "energy": 2, "stars": 0, "focus": 0, "is_alive": true,
+            "base_orb_slots": 0, "orb_capacity": 0, "empty_orb_slots": 0,
+            "powers": [], "orbs": [], "hand": [], "draw_pile": [], "discard_pile": [], "exhaust_pile": [], "play_pile": [],
+            "deck": [], "relics": [], "potions": []
+          }
+        ],
+        "hand": [], "enemies": [], "end_turn_will_kill_player": false, "lethal_risks": []
+      },
+      "run": null, "multiplayer": null, "multiplayer_lobby": null, "map": null, "selection": null,
+      "character_select": null, "timeline": null, "unlock": null, "chest": null, "event": null,
+      "crystal_sphere": null, "shop": null, "rest": null, "reward": null, "bundles": null,
+      "capstone": null, "modal": null, "game_over": null, "agent_view": null
+    }
+  ]
+}

--- a/STS2AIAgent/Server/GameEventService.cs
+++ b/STS2AIAgent/Server/GameEventService.cs
@@ -49,12 +49,14 @@ internal sealed class GameEventService
 
             _cts = new CancellationTokenSource();
             _loopTask = Task.Run(() => PollLoopAsync(_cts.Token));
+            GameFactEventSource.Instance.Start();
             Log.Info($"{LogPrefix} Started with poll interval {_pollInterval.TotalMilliseconds:0}ms");
         }
     }
 
     public void Stop()
     {
+        GameFactEventSource.Instance.Stop();
         CancellationTokenSource? cts;
         Task? loopTask;
         List<Channel<GameEventEnvelope>> channels;
@@ -101,31 +103,42 @@ internal sealed class GameEventService
     {
         var channel = Channel.CreateBounded<GameEventEnvelope>(new BoundedChannelOptions(SubscriberQueueCapacity)
         {
-            FullMode = BoundedChannelFullMode.DropOldest,
+            // Never silently discard fact events. A lagging subscriber is closed so its client can
+            // observe the interruption and reconnect instead of persisting a plausible but incomplete timeline.
+            FullMode = BoundedChannelFullMode.Wait,
             SingleReader = true,
             SingleWriter = false
         });
 
         long subscriberId;
-        StateDigest? snapshot;
         lock (_gate)
         {
             subscriberId = ++_nextSubscriberId;
             _subscribers[subscriberId] = channel;
-            snapshot = _lastState;
-        }
-
-        if (snapshot != null)
-        {
-            var streamReady = BuildEnvelope("stream_ready", new
+            if (_lastState is { } snapshot)
             {
-                run_id = snapshot.RunId,
-                screen = snapshot.Screen,
-                in_combat = snapshot.InCombat,
-                turn = snapshot.Turn,
-                action_window_open = snapshot.PlayerActionWindowOpen
-            });
-            channel.Writer.TryWrite(streamReady);
+                // stream_ready is a subscription cursor, not a new global fact. Reusing the latest
+                // sequence keeps existing subscribers gap-free and guarantees that the next envelope
+                // observed by this subscriber has a greater sequence.
+                var cursor = Volatile.Read(ref _nextEventId);
+                channel.Writer.TryWrite(new GameEventEnvelope
+                {
+                    event_id = cursor,
+                    sequence = cursor,
+                    protocol_version = ProtocolContract.Version,
+                    type = "stream_ready",
+                    timestamp_utc = DateTime.UtcNow.ToString("O"),
+                    data = new
+                    {
+                        latest_sequence = cursor,
+                        run_id = snapshot.RunId,
+                        screen = snapshot.Screen,
+                        in_combat = snapshot.InCombat,
+                        turn = snapshot.Turn,
+                        action_window_open = snapshot.PlayerActionWindowOpen
+                    }
+                });
+            }
         }
 
         return new GameEventSubscription(subscriberId, channel.Reader, Unsubscribe);
@@ -172,18 +185,25 @@ internal sealed class GameEventService
 
     private void ProcessState(GameStatePayload state)
     {
-        var current = StateDigest.FromState(state);
+        lock (_gate)
+        {
+            ProcessStateLocked(StateDigest.FromState(state));
+        }
+    }
+
+    private void ProcessStateLocked(StateDigest current)
+    {
         var previous = _lastState;
 
         if (previous == null)
         {
+            _lastState = current;
             Publish("session_started", new
             {
                 run_id = current.RunId,
                 screen = current.Screen,
                 session_phase = current.SessionPhase
             });
-            _lastState = current;
             return;
         }
 
@@ -194,31 +214,6 @@ internal sealed class GameEventService
                 from = previous.Screen,
                 to = current.Screen,
                 run_id = current.RunId
-            });
-        }
-
-        if (!previous.InCombat && current.InCombat)
-        {
-            Publish("combat_started", new
-            {
-                run_id = current.RunId,
-                turn = current.Turn
-            });
-        }
-        else if (previous.InCombat && !current.InCombat)
-        {
-            Publish("combat_ended", new
-            {
-                run_id = current.RunId
-            });
-        }
-        else if (current.InCombat && previous.Turn != current.Turn)
-        {
-            Publish("combat_turn_changed", new
-            {
-                run_id = current.RunId,
-                from = previous.Turn,
-                to = current.Turn
             });
         }
 
@@ -282,13 +277,24 @@ internal sealed class GameEventService
         _lastState = current;
     }
 
-    private void Publish(string eventType, object data)
+    internal void RecordDamageFact(DamageFact fact) => GameFactEventSource.Instance.RecordDamage(fact);
+
+    internal void RecordAiDecisionFact(AiDecisionFact fact) => GameFactEventSource.Instance.RecordAiDecision(fact);
+
+    internal void Publish(
+        string eventType,
+        object data,
+        string? correlationId = null,
+        string? runId = null,
+        string? combatId = null)
     {
-        var envelope = BuildEnvelope(eventType, data);
         List<long> staleSubscriberIds = new();
 
         lock (_gate)
         {
+            // Allocate the sequence while holding the same lock used for channel writes so concurrent
+            // AI-decision and combat callbacks cannot appear out of sequence on the wire.
+            var envelope = BuildEnvelope(eventType, data, correlationId, runId, combatId);
             foreach (var (subscriberId, channel) in _subscribers)
             {
                 if (!channel.Writer.TryWrite(envelope))
@@ -307,12 +313,22 @@ internal sealed class GameEventService
         }
     }
 
-    private GameEventEnvelope BuildEnvelope(string eventType, object data)
+    private GameEventEnvelope BuildEnvelope(
+        string eventType,
+        object data,
+        string? correlationId = null,
+        string? runId = null,
+        string? combatId = null)
     {
         var eventId = Interlocked.Increment(ref _nextEventId);
         return new GameEventEnvelope
         {
             event_id = eventId,
+            sequence = eventId,
+            protocol_version = ProtocolContract.Version,
+            correlation_id = correlationId,
+            run_id = runId,
+            combat_id = combatId,
             type = eventType,
             timestamp_utc = DateTime.UtcNow.ToString("O"),
             data = data
@@ -408,6 +424,16 @@ internal sealed class GameEventSubscription : IDisposable
 internal sealed class GameEventEnvelope
 {
     public long event_id { get; init; }
+
+    public long sequence { get; init; }
+
+    public string protocol_version { get; init; } = ProtocolContract.Version;
+
+    public string? correlation_id { get; init; }
+
+    public string? run_id { get; init; }
+
+    public string? combat_id { get; init; }
 
     public string type { get; init; } = string.Empty;
 

--- a/STS2AIAgent/Server/GameFactEventSource.cs
+++ b/STS2AIAgent/Server/GameFactEventSource.cs
@@ -1,0 +1,636 @@
+using System.Runtime.CompilerServices;
+using MegaCrit.Sts2.Core.Combat;
+using MegaCrit.Sts2.Core.Combat.History;
+using MegaCrit.Sts2.Core.Combat.History.Entries;
+using MegaCrit.Sts2.Core.Context;
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Entities.Creatures;
+using MegaCrit.Sts2.Core.GameActions.Multiplayer;
+using MegaCrit.Sts2.Core.Logging;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Rooms;
+using MegaCrit.Sts2.Core.Runs;
+using STS2AIAgent.Game;
+
+namespace STS2AIAgent.Server;
+
+internal sealed class GameFactEventSource
+{
+    private const string LogPrefix = "[STS2AIAgent.GameFactEventSource]";
+    private static readonly Lazy<GameFactEventSource> LazyInstance = new(() => new GameFactEventSource());
+
+    private readonly object _gate = new();
+    private ConditionalWeakTable<CardPlay, CardActionAccumulator> _cardActions = new();
+    private readonly Dictionary<string, string> _pendingAiCardCorrelations = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, string> _observedAiCardCorrelations = new(StringComparer.Ordinal);
+    private readonly HashSet<CombatRoom> _wonRooms = new(ReferenceEqualityComparer.Instance);
+    private CombatFactContext? _combat;
+    private int _historyCursor;
+    private long _nextCorrelationId;
+    private bool _started;
+
+    public static GameFactEventSource Instance => LazyInstance.Value;
+
+    public void Start()
+    {
+        lock (_gate)
+        {
+            if (_started)
+            {
+                return;
+            }
+
+            _started = true;
+            var manager = CombatManager.Instance;
+            manager.CombatSetUp += OnCombatSetUp;
+            manager.CombatBegan += OnCombatBegan;
+            manager.TurnStarted += OnTurnStarted;
+            manager.CombatWon += OnCombatWon;
+            manager.CombatEnded += OnCombatEnded;
+            manager.History.Changed += OnHistoryChanged;
+            _historyCursor = manager.History.Entries.Count();
+        }
+
+        Log.Info($"{LogPrefix} Subscribed to authoritative combat lifecycle and history events.");
+    }
+
+    public void Stop()
+    {
+        lock (_gate)
+        {
+            if (!_started)
+            {
+                return;
+            }
+
+            _started = false;
+            var manager = CombatManager.Instance;
+            manager.CombatSetUp -= OnCombatSetUp;
+            manager.CombatBegan -= OnCombatBegan;
+            manager.TurnStarted -= OnTurnStarted;
+            manager.CombatWon -= OnCombatWon;
+            manager.CombatEnded -= OnCombatEnded;
+            manager.History.Changed -= OnHistoryChanged;
+            _historyCursor = 0;
+            _combat = null;
+            _wonRooms.Clear();
+            _pendingAiCardCorrelations.Clear();
+            _observedAiCardCorrelations.Clear();
+            _cardActions = new ConditionalWeakTable<CardPlay, CardActionAccumulator>();
+        }
+    }
+
+    public void RecordDamage(DamageFact fact)
+    {
+        CombatFactContext? combat;
+        CardActionAccumulator? action = null;
+        string correlationId;
+        lock (_gate)
+        {
+            if (!_started)
+            {
+                return;
+            }
+
+            combat = _combat ?? TryBuildCurrentCombatContext();
+            if (fact.CardPlay != null)
+            {
+                _cardActions.TryGetValue(fact.CardPlay, out action);
+            }
+
+            correlationId = action?.CorrelationId ?? NextCorrelationId(combat?.CombatId, "effect");
+            action?.AddDamage(fact.Results);
+        }
+
+        var source = fact.EffectSource ?? fact.CardSource;
+        var dealer = fact.Dealer ?? ResolveSourceOwner(source);
+        var targets = fact.Results.Select(result => new
+        {
+            target = BuildCreatureRef(result.Receiver),
+            blocked_damage = result.BlockedDamage,
+            hp_loss = result.UnblockedDamage,
+            overkill_damage = result.OverkillDamage,
+            total_damage = result.TotalDamage,
+            was_block_broken = result.WasBlockBroken,
+            was_fully_blocked = result.WasFullyBlocked,
+            was_target_killed = result.WasTargetKilled
+        }).ToArray();
+
+        GameEventService.Instance.Publish(
+            "damage_resolved",
+            new
+            {
+                action_type = fact.CardPlay == null ? "effect" : "card_play",
+                requested_amount = fact.RequestedAmount,
+                value_props = fact.Props,
+                source_attribution = source == null ? "unavailable" : "exact",
+                source = BuildModelRef(source),
+                actor = BuildCreatureRef(dealer),
+                targets,
+                total_blocked_damage = targets.Sum(target => target.blocked_damage),
+                total_hp_loss = targets.Sum(target => target.hp_loss),
+                total_overkill_damage = targets.Sum(target => target.overkill_damage)
+            },
+            correlationId,
+            combat?.RunId,
+            combat?.CombatId);
+    }
+
+    public void RecordAiDecision(AiDecisionFact fact)
+    {
+        CombatFactContext? combat;
+        var correlationId = $"decision_{SanitizeId(fact.RequestId)}";
+        lock (_gate)
+        {
+            if (!_started)
+            {
+                return;
+            }
+
+            combat = _combat;
+            if (!string.IsNullOrWhiteSpace(fact.Option?.CardInstanceId))
+            {
+                if (_observedAiCardCorrelations.Remove(fact.Option.CardInstanceId, out var observedCorrelation))
+                {
+                    correlationId = observedCorrelation;
+                }
+                else
+                {
+                    _pendingAiCardCorrelations[fact.Option.CardInstanceId] = correlationId;
+                }
+            }
+        }
+
+        GameEventService.Instance.Publish(
+            "ai_decision",
+            new
+            {
+                request_id = fact.RequestId,
+                snapshot_id = fact.SnapshotId,
+                actor_id = fact.ActorId,
+                actor_role = "ai_teammate",
+                chosen_action_id = fact.ChosenActionId,
+                ranked_action_ids = fact.RankedActionIds,
+                reason = fact.Reason,
+                chosen_action = fact.Option == null ? null : new
+                {
+                    action_id = fact.Option.ActionId,
+                    action_type = fact.Option.ActionType,
+                    description = fact.Option.Description,
+                    label = fact.Option.Label,
+                    summary = fact.Option.Summary,
+                    card_id = fact.Option.CardId,
+                    card_instance_id = fact.Option.CardInstanceId,
+                    target_id = fact.Option.TargetId,
+                    target_label = fact.Option.TargetLabel,
+                    energy_cost = fact.Option.EnergyCost,
+                    priority_tags = fact.Option.PriorityTags,
+                    metadata = fact.Option.Metadata
+                },
+                provenance = "optional_ai_teammate_decision_backend"
+            },
+            correlationId,
+            combat?.RunId,
+            combat?.CombatId);
+    }
+
+    private void OnCombatSetUp(CombatState state)
+    {
+        lock (_gate)
+        {
+            _combat = BuildCombatContext(state);
+            _historyCursor = CombatManager.Instance.History.Entries.Count();
+            _cardActions = new ConditionalWeakTable<CardPlay, CardActionAccumulator>();
+            _pendingAiCardCorrelations.Clear();
+            _observedAiCardCorrelations.Clear();
+        }
+    }
+
+    private void OnCombatBegan(CombatState state)
+    {
+        CombatFactContext combat;
+        lock (_gate)
+        {
+            combat = _combat ?? BuildCombatContext(state);
+            _combat = combat;
+        }
+
+        GameEventService.Instance.Publish(
+            "combat_started",
+            new
+            {
+                run_id = combat.RunId,
+                combat_id = combat.CombatId,
+                turn = state.RoundNumber,
+                encounter = new
+                {
+                    encounter_id = combat.EncounterId,
+                    encounter_type = combat.EncounterType
+                }
+            },
+            combat.CombatId,
+            combat.RunId,
+            combat.CombatId);
+    }
+
+    private void OnTurnStarted(CombatState state)
+    {
+        CombatFactContext combat;
+        int? previousTurn;
+        lock (_gate)
+        {
+            combat = _combat ?? BuildCombatContext(state);
+            previousTurn = combat.LastTurn;
+            combat.LastTurn = state.RoundNumber;
+            _combat = combat;
+        }
+
+        GameEventService.Instance.Publish(
+            "combat_turn_changed",
+            new
+            {
+                run_id = combat.RunId,
+                combat_id = combat.CombatId,
+                from = previousTurn,
+                to = state.RoundNumber,
+                side = state.CurrentSide.ToString().ToLowerInvariant()
+            },
+            $"{combat.CombatId}_turn_{state.RoundNumber}",
+            combat.RunId,
+            combat.CombatId);
+    }
+
+    private void OnCombatWon(CombatRoom room)
+    {
+        lock (_gate)
+        {
+            _wonRooms.Add(room);
+        }
+    }
+
+    private void OnCombatEnded(CombatRoom room)
+    {
+        CombatFactContext combat;
+        bool victory;
+        lock (_gate)
+        {
+            combat = _combat ?? BuildCombatContext(room.CombatState);
+            victory = _wonRooms.Remove(room);
+            _combat = null;
+            _historyCursor = 0;
+            _cardActions = new ConditionalWeakTable<CardPlay, CardActionAccumulator>();
+            _pendingAiCardCorrelations.Clear();
+            _observedAiCardCorrelations.Clear();
+        }
+
+        GameEventService.Instance.Publish(
+            "combat_ended",
+            new
+            {
+                run_id = combat.RunId,
+                combat_id = combat.CombatId,
+                outcome = victory ? "victory" : "defeat",
+                victory,
+                outcome_source = victory
+                    ? "combat_manager.combat_won"
+                    : "combat_manager.combat_ended_without_combat_won",
+                encounter = new
+                {
+                    encounter_id = room.Encounter.Id.Entry,
+                    encounter_type = ResolveEncounterType(room.RoomType)
+                }
+            },
+            combat.CombatId,
+            combat.RunId,
+            combat.CombatId);
+    }
+
+    private void OnHistoryChanged()
+    {
+        CombatHistoryEntry[] appended;
+        lock (_gate)
+        {
+            if (!_started)
+            {
+                return;
+            }
+
+            var entries = CombatManager.Instance.History.Entries.ToArray();
+            if (entries.Length < _historyCursor)
+            {
+                _historyCursor = 0;
+            }
+
+            appended = entries.Skip(_historyCursor).ToArray();
+            _historyCursor = entries.Length;
+        }
+
+        foreach (var entry in appended)
+        {
+            switch (entry)
+            {
+                case CardPlayStartedEntry started:
+                    RecordCardPlayStarted(started.CardPlay);
+                    break;
+                case CardPlayFinishedEntry finished:
+                    RecordCardPlayFinished(finished.CardPlay);
+                    break;
+            }
+        }
+    }
+
+    private void RecordCardPlayStarted(CardPlay cardPlay)
+    {
+        CombatFactContext? combat;
+        CardActionAccumulator action;
+        lock (_gate)
+        {
+            combat = _combat ?? TryBuildCurrentCombatContext();
+            var cardInstanceId = GetCardInstanceId(cardPlay.Card);
+            var correlationId = cardInstanceId != null &&
+                                !LocalContext.IsMe(cardPlay.Player.Creature) &&
+                                _pendingAiCardCorrelations.Remove(cardInstanceId, out var decisionCorrelation)
+                ? decisionCorrelation
+                : NextCorrelationId(combat?.CombatId, "card");
+            if (cardInstanceId != null && !LocalContext.IsMe(cardPlay.Player.Creature))
+            {
+                _observedAiCardCorrelations[cardInstanceId] = correlationId;
+            }
+            action = new CardActionAccumulator(correlationId);
+            _cardActions.Remove(cardPlay);
+            _cardActions.Add(cardPlay, action);
+        }
+
+        GameEventService.Instance.Publish(
+            "action_started",
+            new
+            {
+                action_type = "card_play",
+                actor = BuildCreatureRef(cardPlay.Player.Creature),
+                source = BuildModelRef(cardPlay.Card),
+                target = BuildCreatureRef(cardPlay.Target),
+                card = new
+                {
+                    card_id = cardPlay.Card.Id.Entry,
+                    card_instance_id = GetCardInstanceId(cardPlay.Card),
+                    name = cardPlay.Card.Title,
+                    upgraded = cardPlay.Card.IsUpgraded,
+                    auto_play = cardPlay.IsAutoPlay,
+                    play_index = cardPlay.PlayIndex,
+                    play_count = cardPlay.PlayCount
+                }
+            },
+            action.CorrelationId,
+            combat?.RunId,
+            combat?.CombatId);
+    }
+
+    private void RecordCardPlayFinished(CardPlay cardPlay)
+    {
+        CombatFactContext? combat;
+        CardActionAccumulator? action;
+        lock (_gate)
+        {
+            combat = _combat;
+            _cardActions.TryGetValue(cardPlay, out action);
+            _cardActions.Remove(cardPlay);
+            var cardInstanceId = GetCardInstanceId(cardPlay.Card);
+            if (cardInstanceId != null && !LocalContext.IsMe(cardPlay.Player.Creature))
+            {
+                _observedAiCardCorrelations.Remove(cardInstanceId);
+            }
+        }
+
+        var correlationId = action?.CorrelationId ?? NextCorrelationId(combat?.CombatId, "card");
+        var totals = action?.Snapshot() ?? Array.Empty<CardTargetDamageTotal>();
+        GameEventService.Instance.Publish(
+            "action_finished",
+            new
+            {
+                action_type = "card_play",
+                actor = BuildCreatureRef(cardPlay.Player.Creature),
+                source = BuildModelRef(cardPlay.Card),
+                target = BuildCreatureRef(cardPlay.Target),
+                card = new
+                {
+                    card_id = cardPlay.Card.Id.Entry,
+                    card_instance_id = GetCardInstanceId(cardPlay.Card),
+                    name = cardPlay.Card.Title,
+                    upgraded = cardPlay.Card.IsUpgraded,
+                    auto_play = cardPlay.IsAutoPlay,
+                    play_index = cardPlay.PlayIndex,
+                    play_count = cardPlay.PlayCount
+                },
+                damage = new
+                {
+                    targets = totals,
+                    total_blocked_damage = totals.Sum(total => total.blocked_damage),
+                    total_hp_loss = totals.Sum(total => total.hp_loss),
+                    total_overkill_damage = totals.Sum(total => total.overkill_damage),
+                    hit_count = totals.Sum(total => total.hit_count)
+                }
+            },
+            correlationId,
+            combat?.RunId,
+            combat?.CombatId);
+    }
+
+    private string NextCorrelationId(string? combatId, string kind)
+    {
+        var sequence = Interlocked.Increment(ref _nextCorrelationId);
+        return $"{combatId ?? "session"}_{kind}_{sequence}";
+    }
+
+    private static CombatFactContext BuildCombatContext(CombatState state)
+    {
+        var runId = (state.RunState as RunState)?.Rng.StringSeed ?? "run_unknown";
+        var encounterId = state.Encounter?.Id.Entry ?? "encounter_unknown";
+        var combatId = CombatManager.Instance.CurrentCombatId is { } id
+            ? $"combat_{id.Value}"
+            : $"combat_{SanitizeId(encounterId)}";
+        return new CombatFactContext(
+            runId,
+            combatId,
+            encounterId,
+            ResolveEncounterType(state.Encounter?.RoomType ?? RoomType.Unassigned),
+            state.RoundNumber);
+    }
+
+    private static CombatFactContext? TryBuildCurrentCombatContext()
+    {
+        var state = CombatManager.Instance.DebugOnlyGetState();
+        return state == null ? null : BuildCombatContext(state);
+    }
+
+    internal static string ResolveEncounterType(RoomType roomType) => roomType switch
+    {
+        RoomType.Monster => "normal",
+        RoomType.Elite => "elite",
+        RoomType.Boss => "boss",
+        _ => roomType.ToString().ToLowerInvariant()
+    };
+
+    private static object? BuildModelRef(AbstractModel? source)
+    {
+        if (source == null)
+        {
+            return null;
+        }
+
+        return new
+        {
+            source_type = ResolveModelType(source),
+            source_id = source.Id.Entry,
+            source_name = ResolveModelName(source),
+            card_instance_id = source is CardModel sourceCard
+                ? GetCardInstanceId(sourceCard)
+                : null
+        };
+    }
+
+    private static string ResolveModelType(AbstractModel model) => model switch
+    {
+        CardModel => "card",
+        PowerModel => "power",
+        RelicModel => "relic",
+        PotionModel => "potion",
+        OrbModel => "orb",
+        MonsterModel => "monster",
+        _ => "unknown"
+    };
+
+    private static string ResolveModelName(AbstractModel model)
+    {
+        try
+        {
+            return model switch
+            {
+                CardModel card => card.Title,
+                PowerModel power => power.Title.GetFormattedText(),
+                RelicModel relic => relic.Title.GetFormattedText(),
+                PotionModel potion => potion.Title.GetFormattedText(),
+                OrbModel orb => orb.Title.GetFormattedText(),
+                MonsterModel monster => monster.Title.GetFormattedText(),
+                _ => model.Id.Entry
+            };
+        }
+        catch
+        {
+            return model.Id.Entry;
+        }
+    }
+
+    private static Creature? ResolveSourceOwner(AbstractModel? source)
+    {
+        try
+        {
+            return source switch
+            {
+                CardModel card => card.Owner.Creature,
+                PowerModel power => power.Owner,
+                RelicModel relic => relic.Owner.Creature,
+                PotionModel potion => potion.Owner.Creature,
+                OrbModel orb => orb.Owner.Creature,
+                MonsterModel monster => monster.Creature,
+                _ => null
+            };
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static object? BuildCreatureRef(Creature? creature)
+    {
+        if (creature == null)
+        {
+            return null;
+        }
+
+        return new
+        {
+            entity_id = creature.Player != null
+                ? $"player_{creature.Player.NetId}"
+                : creature.CombatId is { } combatId
+                    ? $"creature_{combatId}"
+                    : $"creature_{SanitizeId(creature.ModelId.Entry)}",
+            entity_type = creature.Player != null ? "player" : "enemy",
+            model_id = creature.ModelId.Entry,
+            name = creature.Name,
+            player_id = creature.Player?.NetId.ToString(),
+            is_local = creature.Player != null && LocalContext.IsMe(creature)
+        };
+    }
+
+    private static string? GetCardInstanceId(CardModel card) =>
+        NetCombatCardDb.Instance.TryGetCardId(card, out var id) ? $"combat_{id}" : null;
+
+    private static string SanitizeId(string value)
+    {
+        var chars = value.Select(character => char.IsLetterOrDigit(character) || character is '-' or '_'
+            ? character
+            : '_').ToArray();
+        return new string(chars);
+    }
+
+    private sealed class CombatFactContext(
+        string runId,
+        string combatId,
+        string encounterId,
+        string encounterType,
+        int? lastTurn)
+    {
+        public string RunId { get; } = runId;
+        public string CombatId { get; } = combatId;
+        public string EncounterId { get; } = encounterId;
+        public string EncounterType { get; } = encounterType;
+        public int? LastTurn { get; set; } = lastTurn;
+    }
+
+    private sealed class CardActionAccumulator(string correlationId)
+    {
+        private readonly Dictionary<string, CardTargetDamageTotal> _totals = new(StringComparer.Ordinal);
+        public string CorrelationId { get; } = correlationId;
+
+        public void AddDamage(IEnumerable<DamageResult> results)
+        {
+            foreach (var result in results)
+            {
+                var targetId = result.Receiver.Player != null
+                    ? $"player_{result.Receiver.Player.NetId}"
+                    : result.Receiver.CombatId is { } combatId
+                        ? $"creature_{combatId}"
+                        : $"creature_{SanitizeId(result.Receiver.ModelId.Entry)}";
+                if (!_totals.TryGetValue(targetId, out var total))
+                {
+                    total = new CardTargetDamageTotal
+                    {
+                        target_id = targetId,
+                        target_name = result.Receiver.Name
+                    };
+                    _totals[targetId] = total;
+                }
+
+                total.blocked_damage += result.BlockedDamage;
+                total.hp_loss += result.UnblockedDamage;
+                total.overkill_damage += result.OverkillDamage;
+                total.hit_count += 1;
+            }
+        }
+
+        public CardTargetDamageTotal[] Snapshot() => _totals.Values
+            .OrderBy(static total => total.target_id, StringComparer.Ordinal)
+            .ToArray();
+    }
+}
+
+internal sealed class CardTargetDamageTotal
+{
+    public string target_id { get; init; } = string.Empty;
+    public string target_name { get; init; } = string.Empty;
+    public int blocked_damage { get; set; }
+    public int hp_loss { get; set; }
+    public int overkill_damage { get; set; }
+    public int hit_count { get; set; }
+}

--- a/STS2AIAgent/Server/ProtocolContract.cs
+++ b/STS2AIAgent/Server/ProtocolContract.cs
@@ -1,0 +1,9 @@
+namespace STS2AIAgent.Server;
+
+internal static class ProtocolContract
+{
+    public const string Version = "2026-08-31-v2";
+    public const int StateVersion = 12;
+    public const int AgentViewVersion = 7;
+    public const string SchemaDraft = "https://json-schema.org/draft/2020-12/schema";
+}

--- a/STS2AIAgent/Server/ProtocolSchemaService.cs
+++ b/STS2AIAgent/Server/ProtocolSchemaService.cs
@@ -1,0 +1,38 @@
+using System.Reflection;
+using System.Text.Json;
+
+namespace STS2AIAgent.Server;
+
+internal static class ProtocolSchemaService
+{
+    private const string ResourcePrefix = "STS2AIAgent.Schemas.2026-08-31-v2.";
+
+    private static readonly IReadOnlyDictionary<string, string> Resources =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["health"] = ResourcePrefix + "health.schema.json",
+            ["state"] = ResourcePrefix + "state.schema.json",
+            ["event"] = ResourcePrefix + "event.schema.json",
+            ["data-collection"] = ResourcePrefix + "data-collection.schema.json"
+        };
+
+    public static string[] Names { get; } = Resources.Keys.OrderBy(static name => name, StringComparer.Ordinal).ToArray();
+
+    public static bool TryGet(string rawName, out JsonElement schema)
+    {
+        var name = rawName.EndsWith(".schema.json", StringComparison.OrdinalIgnoreCase)
+            ? rawName[..^".schema.json".Length]
+            : rawName;
+        if (!Resources.TryGetValue(name, out var resourceName))
+        {
+            schema = default;
+            return false;
+        }
+
+        using var stream = typeof(ProtocolSchemaService).Assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidDataException($"Embedded protocol schema is missing: {resourceName}");
+        using var document = JsonDocument.Parse(stream);
+        schema = document.RootElement.Clone();
+        return true;
+    }
+}

--- a/STS2AIAgent/Server/Router.cs
+++ b/STS2AIAgent/Server/Router.cs
@@ -12,7 +12,6 @@ namespace STS2AIAgent.Server;
 internal static class Router
 {
     private const string ServiceName = "sts2-ai-agent";
-    private const string ProtocolVersion = "2026-03-11-v1";
     private const string ModVersion = "0.9.1";
     private const string LogPrefix = "[STS2AIAgent.Router]";
 
@@ -42,7 +41,8 @@ internal static class Router
                     {
                         service = ServiceName,
                         mod_version = ModVersion,
-                        protocol_version = ProtocolVersion,
+                        protocol_version = ProtocolContract.Version,
+                        schema_version = ProtocolContract.Version,
                         game_version = ReleaseInfoManager.Instance.ReleaseInfo?.Version ?? "unknown",
                         status = "ready",
                         api_host = HttpServer.Instance.Host,
@@ -77,6 +77,46 @@ internal static class Router
                     ok = true,
                     request_id = requestId,
                     data = payload
+                });
+                statusCode = 200;
+                return;
+            }
+
+            if (request.HttpMethod.Equals("GET", StringComparison.OrdinalIgnoreCase) &&
+                request.Url?.AbsolutePath == "/schemas")
+            {
+                await WriteJsonAsync(response, 200, new
+                {
+                    ok = true,
+                    request_id = requestId,
+                    data = new
+                    {
+                        protocol_version = ProtocolContract.Version,
+                        json_schema_draft = ProtocolContract.SchemaDraft,
+                        schemas = ProtocolSchemaService.Names
+                    }
+                });
+                statusCode = 200;
+                return;
+            }
+
+            if (request.HttpMethod.Equals("GET", StringComparison.OrdinalIgnoreCase) &&
+                request.Url?.AbsolutePath is string schemaPath &&
+                schemaPath.StartsWith("/schemas/", StringComparison.OrdinalIgnoreCase))
+            {
+                var schemaName = schemaPath.Substring("/schemas/".Length);
+                if (!ProtocolSchemaService.TryGet(schemaName, out var schema))
+                {
+                    statusCode = 404;
+                    await WriteErrorAsync(response, 404, "schema_not_found", $"Unknown protocol schema: {schemaName}", requestId);
+                    return;
+                }
+
+                await WriteJsonAsync(response, 200, new
+                {
+                    ok = true,
+                    request_id = requestId,
+                    data = schema
                 });
                 statusCode = 200;
                 return;

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,7 +1,9 @@
 # STS2 AI Agent Mod — HTTP API
 
-状态：可实现
-协议版本：`2026-03-10-v0`
+状态：已实现
+协议版本：`2026-08-31-v2`
+
+逐动作事件、关联 ID 与正式 JSON Schema 见 [fact-events-v2.md](./fact-events-v2.md)。
 
 ---
 
@@ -98,9 +100,10 @@
   "request_id": "req_20260310_120000_1234",
   "data": {
     "service": "sts2-ai-agent",
-    "mod_version": "0.4.0",
-    "protocol_version": "2026-03-11-v1",
-    "game_version": "v0.98.2",
+    "mod_version": "0.9.1",
+    "protocol_version": "2026-08-31-v2",
+    "schema_version": "2026-08-31-v2",
+    "game_version": "v0.111.0",
     "status": "ready"
   }
 }
@@ -116,7 +119,7 @@
 
 | 字段 | 类型 | 说明 |
 | --- | --- | --- |
-| `state_version` | number | 状态模型版本（当前固定为 11） |
+| `state_version` | number | 状态模型版本（当前固定为 12） |
 | `run_id` | string | 本局运行标识（种子字符串） |
 | `screen` | string | 当前逻辑界面（见 Screen 枚举） |
 | `in_combat` | boolean | 是否处于战斗流程 |

--- a/docs/fact-events-v2.md
+++ b/docs/fact-events-v2.md
@@ -1,0 +1,166 @@
+# Protocol v2: authoritative fact events and schemas
+
+Protocol `2026-08-31-v2` adds an authoritative event layer for clients that need to reconstruct combat without inferring actions from polled snapshots. State version is `12`; compact agent-view version is `7`.
+
+## Published schemas
+
+All schemas use JSON Schema Draft 2020-12 and ship as embedded resources in the mod.
+
+| Endpoint | Schema |
+| --- | --- |
+| `GET /health` | `GET /schemas/health` |
+| `GET /state` response data | `GET /schemas/state` |
+| each `GET /events/stream` SSE data object | `GET /schemas/event` |
+| each `/data/{collection}` response data array | `GET /schemas/data-collection` |
+
+`GET /schemas` lists the published names. The state schema enumerates every supported `screen` and conditionally requires its scene payload.
+
+## Event envelope
+
+Every event has a monotonic sequence and association fields:
+
+```json
+{
+  "event_id": 42,
+  "sequence": 42,
+  "protocol_version": "2026-08-31-v2",
+  "correlation_id": "combat_4_card_12",
+  "run_id": "ABC123",
+  "combat_id": "combat_4",
+  "type": "action_finished",
+  "timestamp_utc": "2026-08-31T10:00:00Z",
+  "data": {}
+}
+```
+
+Legacy state-change events can have null association fields. Authoritative combat lifecycle, card, damage, and AI-decision events carry them.
+`stream_ready` is a per-subscription cursor: its `sequence` repeats the latest published sequence, and every subsequent fact on that connection has a greater value.
+
+## Card action lifecycle
+
+Each card play emits:
+
+1. `action_started` from `CombatHistory.CardPlayStartedEntry`;
+2. one or more `damage_resolved` events from the deepest `CreatureCmd.Damage` overload;
+3. `action_finished` from `CombatHistory.CardPlayFinishedEntry`.
+
+All three stages share one `correlation_id`. `action_finished.damage` aggregates all hits and targets for that card without losing the individual `damage_resolved` records.
+
+```json
+{
+  "type": "action_finished",
+  "correlation_id": "combat_4_card_12",
+  "data": {
+    "action_type": "card_play",
+    "actor": {
+      "entity_id": "player_2",
+      "entity_type": "player",
+      "model_id": "SILENT",
+      "name": "Silent",
+      "player_id": "2",
+      "is_local": false
+    },
+    "source": {
+      "source_type": "card",
+      "source_id": "POISON_STAB",
+      "source_name": "Poisoned Stab",
+      "card_instance_id": "combat_17"
+    },
+    "target": {
+      "entity_id": "creature_8",
+      "entity_type": "enemy",
+      "model_id": "CULTIST",
+      "name": "Cultist",
+      "player_id": null,
+      "is_local": false
+    },
+    "card": {
+      "card_id": "POISON_STAB",
+      "card_instance_id": "combat_17",
+      "name": "Poisoned Stab",
+      "upgraded": false,
+      "auto_play": false,
+      "play_index": 1,
+      "play_count": 1
+    },
+    "damage": {
+      "targets": [
+        {
+          "target_id": "creature_8",
+          "target_name": "Cultist",
+          "blocked_damage": 3,
+          "hp_loss": 6,
+          "overkill_damage": 0,
+          "hit_count": 1
+        }
+      ],
+      "total_blocked_damage": 3,
+      "total_hp_loss": 6,
+      "total_overkill_damage": 0,
+      "hit_count": 1
+    }
+  }
+}
+```
+
+`hp_loss` is the actual HP removed after block. Requested amount, blocked damage, and overkill remain separate.
+
+## Exact damage source attribution
+
+`damage_resolved.source.source_type` is one of `card`, `power`, `relic`, `potion`, `orb`, `monster`, or `unknown`. The instrumentation scopes the real model method that calls `CreatureCmd.Damage`; it does not infer a source from adjacent snapshots or a retained player-choice context. If no callsite or explicit card source proves ownership, `source_attribution` is `unavailable` and `source` is null.
+
+This distinction allows a client to keep poison ticks, power callbacks, relic effects, potion effects, orb effects, monster effects, and direct card damage separate even when they change the same target HP in immediate succession.
+
+## Optional AI teammate telemetry
+
+When the optional `sts2AITeammate` assembly is present, the mod patches its `DecideAsync(AiDecisionRequest, ...)` backend without adding a static dependency. `ai_decision` contains the chosen action, ranking, exact card instance, target, and reason already retained by that mod.
+
+```json
+{
+  "type": "ai_decision",
+  "correlation_id": "decision_req_7",
+  "data": {
+    "request_id": "req-7",
+    "snapshot_id": "snapshot-3",
+    "actor_id": "2",
+    "actor_role": "ai_teammate",
+    "chosen_action_id": "play_card_combat_17_target_creature_8",
+    "ranked_action_ids": ["play_card_combat_17_target_creature_8", "end_turn_player_2"],
+    "reason": "Remove the attacking target first.",
+    "chosen_action": {
+      "card_id": "POISON_STAB",
+      "card_instance_id": "combat_17",
+      "target_id": "creature_8",
+      "target_label": "Cultist",
+      "energy_cost": 1
+    },
+    "provenance": "optional_ai_teammate_decision_backend"
+  }
+}
+```
+
+When the chosen card is executed, its exact `card_instance_id` lets the decision, card lifecycle, and damage records reuse the same correlation ID. The base mod continues to work when the optional assembly is absent.
+
+## Encounter and outcome facts
+
+Combat state and lifecycle events expose `encounter_id` plus `encounter_type`. Combat values are `normal`, `elite`, or `boss`, sourced from `Encounter.RoomType`.
+
+`combat_ended` always includes `outcome`, `victory`, and `outcome_source`. A victory is recorded only after the game's `CombatManager.CombatWon` event. `CombatEnded` without that event is recorded as defeat, so clients no longer need to treat “combat ended” as proof of a win.
+
+## Complete multiplayer inventories
+
+Every `combat.players[]` entry now includes powers, orbs, hand, draw/discard/exhaust/play piles, full run deck, relics, and potions. Every `run.players[]` entry includes the full deck, relics, potions, gold, maximum energy, and base orb slots. `is_local` remains the ownership boundary.
+
+## Static data collections
+
+The existing read-only exports remain available at:
+
+- `/data/cards`
+- `/data/relics`
+- `/data/monsters`
+- `/data/potions`
+- `/data/events`
+- `/data/powers`
+- `/data/characters`
+
+Use the raw records for forward-compatible fields and `data-collection.schema.json` for the stable minimum shape.


### PR DESCRIPTION
## Summary

- add protocol `2026-08-31-v2` with monotonic/correlated authoritative combat events
- capture card start/finish from `CombatHistory` and actual damage results from the deepest `CreatureCmd.Damage` overload
- attribute damage to the real card/power/relic/potion/orb/monster model callsite, returning `unavailable` instead of guessing
- expose exact `normal`/`elite`/`boss` encounter facts and `victory`/`defeat` outcomes (victory requires `CombatWon`)
- optionally capture the workshop AI teammate's chosen action, card instance, target, ranking, and reason without creating a hard dependency
- expose complete per-player combat/run inventories
- publish embedded Draft 2020-12 schemas through `GET /schemas` and `GET /schemas/{name}`

## Why

Snapshot polling cannot distinguish rapid consecutive actions, multi-hit damage, or poison/power/card sources that modify the same HP value. `CombatEnded` also does not prove victory. This adds a fact layer at the game's authoritative lifecycle and damage-settlement points while retaining the existing read-only state/data APIs.

## Verification

- Release mod build against the installed STS2 v0.111.0 assemblies: 0 warnings, 0 errors
- 53/53 tests passed with the actual game assemblies and `sts2AITeammate` 0.1.2 DLL; the runtime checks verify the concrete damage sink, PoisonPower state machine patch, and optional DecideAsync patch
- 51/51 portable tests passed with no proprietary game assemblies present, so the normal test project remains buildable in CI
- all four embedded schema documents parse successfully

## Validation boundary

I did not drive the game UI or claim a full live multiplayer combat run. The callsites and optional assembly were verified against the actual installed binaries; an end-to-end combat, reconnect, and cold/hot-start pass should still be performed before release.

## Summary by Sourcery

Introduce protocol v2 authoritative fact events, complete multiplayer state, and published JSON schemas for reliable game-state reconstruction.

New Features:
- Add authoritative combat and optional AI decision events with monotonic sequencing, correlation identifiers, exact damage outcomes, source attribution, encounter tiers, and explicit combat results.
- Expose complete combat and run inventories for every multiplayer player.
- Publish embedded Draft 2020-12 protocol schemas through schema discovery and retrieval endpoints.

Bug Fixes:
- Distinguish actual combat victories from combat termination by requiring the authoritative combat-won signal.
- Preserve complete event timelines for subscribers instead of silently dropping events when consumers lag.

Enhancements:
- Upgrade the protocol to 2026-08-31-v2 with expanded state and agent-view versions and shared event metadata.
- Document the new fact-event protocol, schemas, inventory data, and API contract.

Documentation:
- Document protocol v2 fact events, schema endpoints, attribution semantics, combat outcomes, optional AI telemetry, and multiplayer inventory payloads.
- Update API and project README documentation for the new protocol and capabilities.

Tests:
- Add schema coverage tests for the published catalog, state scenes, event types, and correlation rules.
- Add runtime instrumentation tests against the installed game assemblies and optional AI teammate assembly.