### PR TITLE
Fix deck multi-select action acknowledgements

### DIFF
--- a/STS2AIAgent.Tests/DeckSelectionContractTests.cs
+++ b/STS2AIAgent.Tests/DeckSelectionContractTests.cs
@@ -29,29 +29,36 @@ internal static class DeckSelectionContractTests
             StringComparison.Ordinal);
     }
 
-    public static void IntermediateRequiredPickSettlesOnSelectionProgress()
+    public static void DeckGridClickSettlesInEitherDirectionBeforeConfirming()
     {
         var rawActionSource = ReadSource(
             "STS2AIAgent/Game/GameActionService.cs");
         var selectBody = WithoutWhitespace(
             MethodBody(rawActionSource, "ExecuteSelectDeckCardAsync"));
-        var progressBody = WithoutWhitespace(
+        var settleBody = WithoutWhitespace(
             MethodBody(
-                rawActionSource, "WaitForDeckSelectionProgressAsync"));
+                rawActionSource, "SettleDeckCardSelectionClickAsync"));
 
+        Assert.Contains("SettleDeckCardSelectionClickAsync", selectBody, StringComparison.Ordinal);
         Assert.Contains(
-            "deckCardSelection.SelectedCount+1<deckCardSelection.MinSelect",
-            selectBody,
-            StringComparison.Ordinal);
-        Assert.Contains("WaitForDeckSelectionProgressAsync", selectBody, StringComparison.Ordinal);
-        Assert.Contains("ConfirmDeckSelectionAsync", selectBody, StringComparison.Ordinal);
-        Assert.Contains(
-            "metadata.SelectedCount>previousSelectedCount",
-            progressBody,
+            "metadata.SelectedCount==previousSelectedCount",
+            settleBody,
             StringComparison.Ordinal);
         Assert.Contains(
             "ReferenceEquals(ActiveScreenContext.Instance.GetCurrentScreen(),screen)",
-            progressBody,
+            settleBody,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "metadata.SelectedCount<previousSelectedCount",
+            settleBody,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "metadata.SelectedCount<metadata.MinSelect",
+            settleBody,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "ConfirmDeckSelectionAsync(screen,remaining)",
+            settleBody,
             StringComparison.Ordinal);
     }
 

--- a/STS2AIAgent.Tests/DeckSelectionContractTests.cs
+++ b/STS2AIAgent.Tests/DeckSelectionContractTests.cs
@@ -1,0 +1,102 @@
+namespace STS2AIAgent.Tests;
+
+/// <summary>
+/// Source-level contracts for Godot deck-grid selections. These screens cannot be
+/// instantiated in the lightweight test process, so the tests verify that the
+/// native private selection state is exposed and consumed by the action settle path.
+/// </summary>
+internal static class DeckSelectionContractTests
+{
+    public static void DeckGridPayloadReportsNativeSelectionProgress()
+    {
+        var rawStateSource = ReadSource(
+            "STS2AIAgent/Game/GameStateService.cs");
+        var stateSource = WithoutWhitespace(rawStateSource);
+        var payloadBody = WithoutWhitespace(
+            MethodBody(rawStateSource, "BuildSelectionPayload"));
+
+        Assert.Contains("NDeckCardSelectScreen", stateSource, StringComparison.Ordinal);
+        Assert.Contains("\"_prefs\"", stateSource, StringComparison.Ordinal);
+        Assert.Contains("\"_selectedCards\"", stateSource, StringComparison.Ordinal);
+        Assert.Contains("selectedCount++", stateSource, StringComparison.Ordinal);
+        Assert.Contains(
+            "selected_count=hasCombatHandSelection?combatHandSelection.SelectedCount:hasDeckCardSelection?deckCardSelection.SelectedCount:0",
+            payloadBody,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "min_select=hasCombatHandSelection?combatHandSelection.MinSelect:hasDeckCardSelection?deckCardSelection.MinSelect:1",
+            payloadBody,
+            StringComparison.Ordinal);
+    }
+
+    public static void IntermediateRequiredPickSettlesOnSelectionProgress()
+    {
+        var rawActionSource = ReadSource(
+            "STS2AIAgent/Game/GameActionService.cs");
+        var selectBody = WithoutWhitespace(
+            MethodBody(rawActionSource, "ExecuteSelectDeckCardAsync"));
+        var progressBody = WithoutWhitespace(
+            MethodBody(
+                rawActionSource, "WaitForDeckSelectionProgressAsync"));
+
+        Assert.Contains(
+            "deckCardSelection.SelectedCount+1<deckCardSelection.MinSelect",
+            selectBody,
+            StringComparison.Ordinal);
+        Assert.Contains("WaitForDeckSelectionProgressAsync", selectBody, StringComparison.Ordinal);
+        Assert.Contains("ConfirmDeckSelectionAsync", selectBody, StringComparison.Ordinal);
+        Assert.Contains(
+            "metadata.SelectedCount>previousSelectedCount",
+            progressBody,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "ReferenceEquals(ActiveScreenContext.Instance.GetCurrentScreen(),screen)",
+            progressBody,
+            StringComparison.Ordinal);
+    }
+
+    private static string ReadSource(string relativePath)
+    {
+        foreach (var start in new[] { Directory.GetCurrentDirectory(), AppContext.BaseDirectory })
+        {
+            for (var directory = new DirectoryInfo(start); directory != null; directory = directory.Parent)
+            {
+                var candidate = Path.Combine(directory.FullName, relativePath);
+                if (File.Exists(candidate))
+                {
+                    return File.ReadAllText(candidate);
+                }
+            }
+        }
+
+        throw new FileNotFoundException($"Could not locate source file: {relativePath}");
+    }
+
+    private static string WithoutWhitespace(string value) =>
+        string.Concat(value.Where(character => !char.IsWhiteSpace(character)));
+
+    private static string MethodBody(string source, string methodName)
+    {
+        var nameIndex = source.LastIndexOf($" {methodName}(", StringComparison.Ordinal);
+        var openBrace = nameIndex < 0 ? -1 : source.IndexOf('{', nameIndex);
+        if (openBrace < 0)
+        {
+            throw new InvalidOperationException($"Method body is missing: {methodName}");
+        }
+
+        var depth = 0;
+        for (var index = openBrace; index < source.Length; index++)
+        {
+            if (source[index] == '{')
+            {
+                depth++;
+            }
+            else if (source[index] == '}' && --depth == 0)
+            {
+                return source[openBrace..(index + 1)];
+            }
+        }
+
+        throw new InvalidOperationException($"Method body is unterminated: {methodName}");
+    }
+}

--- a/STS2AIAgent.Tests/TestRunner.cs
+++ b/STS2AIAgent.Tests/TestRunner.cs
@@ -150,6 +150,8 @@ internal static class TestRunner
         yield return ("GameOver.SaveMismatch", () => Task.Run(ProgressSaveVerificationTests.MismatchedScoreOrUnlockStateCannotReportSuccess));
         yield return ("GameOver.SaveMissingMalformed", () => Task.Run(ProgressSaveVerificationTests.MissingOrMalformedFileCannotReportSuccess));
         yield return ("GameOver.SaveReadFailure", () => Task.Run(ProgressSaveVerificationTests.ReadFailureCannotReportSuccess));
+        yield return ("DeckSelection.PayloadProgress", () => Task.Run(DeckSelectionContractTests.DeckGridPayloadReportsNativeSelectionProgress));
+        yield return ("DeckSelection.IntermediateSettle", () => Task.Run(DeckSelectionContractTests.IntermediateRequiredPickSettlesOnSelectionProgress));
         yield return ("AgentLoop.PlayOnce", AgentLoopTests.PlayOnce_ExecutesSingleValidatedAct);
         yield return ("AgentLoop.CrystalArgs", AgentLoopTests.PlayOnce_ForwardsCrystalSphereArguments);
         yield return ("AgentTools.CrystalSchema", () => Task.Run(AgentLoopTests.ActToolSchema_IncludesCrystalSphereArguments));

--- a/STS2AIAgent.Tests/TestRunner.cs
+++ b/STS2AIAgent.Tests/TestRunner.cs
@@ -151,7 +151,7 @@ internal static class TestRunner
         yield return ("GameOver.SaveMissingMalformed", () => Task.Run(ProgressSaveVerificationTests.MissingOrMalformedFileCannotReportSuccess));
         yield return ("GameOver.SaveReadFailure", () => Task.Run(ProgressSaveVerificationTests.ReadFailureCannotReportSuccess));
         yield return ("DeckSelection.PayloadProgress", () => Task.Run(DeckSelectionContractTests.DeckGridPayloadReportsNativeSelectionProgress));
-        yield return ("DeckSelection.IntermediateSettle", () => Task.Run(DeckSelectionContractTests.IntermediateRequiredPickSettlesOnSelectionProgress));
+        yield return ("DeckSelection.ClickSettle", () => Task.Run(DeckSelectionContractTests.DeckGridClickSettlesInEitherDirectionBeforeConfirming));
         yield return ("AgentLoop.PlayOnce", AgentLoopTests.PlayOnce_ExecutesSingleValidatedAct);
         yield return ("AgentLoop.CrystalArgs", AgentLoopTests.PlayOnce_ForwardsCrystalSphereArguments);
         yield return ("AgentTools.CrystalSchema", () => Task.Run(AgentLoopTests.ActToolSchema_IncludesCrystalSphereArguments));

--- a/STS2AIAgent/Game/GameActionService.cs
+++ b/STS2AIAgent/Game/GameActionService.cs
@@ -1593,6 +1593,8 @@ internal static class GameActionService
         }
 
         var isCombatHandSelection = GameStateService.TryGetCombatHandSelectionMetadata(currentScreen, out var combatHand, out var combatHandSelection);
+        var isDeckCardSelection = GameStateService.TryGetDeckCardSelectionMetadata(
+            currentScreen, out var deckCardSelection);
         var selected = options[request.option_index.Value];
         if (isCombatHandSelection)
         {
@@ -1619,6 +1621,11 @@ internal static class GameActionService
 
         var stable = currentScreen switch
         {
+            NDeckCardSelectScreen deckCardScreen
+                when isDeckCardSelection &&
+                     deckCardSelection.SelectedCount + 1 < deckCardSelection.MinSelect =>
+                await WaitForDeckSelectionProgressAsync(
+                    deckCardScreen, deckCardSelection.SelectedCount, TimeSpan.FromSeconds(10)),
             NCardGridSelectionScreen cardSelectScreen => await ConfirmDeckSelectionAsync(cardSelectScreen, TimeSpan.FromSeconds(10)),
             NChooseACardSelectionScreen chooseCardScreen => await WaitForChooseCardSelectionResolutionAsync(chooseCardScreen, TimeSpan.FromSeconds(10)),
             _ when isCombatHandSelection => await WaitForCombatHandSelectionStepAsync(combatHandSelection, TimeSpan.FromSeconds(10)),
@@ -2072,6 +2079,32 @@ internal static class GameActionService
             if (confirmButton?.IsEnabled == true)
             {
                 confirmButton.ForceClick();
+            }
+        }
+
+        return false;
+    }
+
+    private static async Task<bool> WaitForDeckSelectionProgressAsync(
+        NDeckCardSelectScreen screen,
+        int previousSelectedCount,
+        TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            await WaitForNextFrameAsync();
+
+            if (!GodotObject.IsInstanceValid(screen) ||
+                !ReferenceEquals(ActiveScreenContext.Instance.GetCurrentScreen(), screen))
+            {
+                return true;
+            }
+
+            if (GameStateService.TryGetDeckCardSelectionMetadata(screen, out var metadata) &&
+                metadata.SelectedCount > previousSelectedCount)
+            {
+                return true;
             }
         }
 

--- a/STS2AIAgent/Game/GameActionService.cs
+++ b/STS2AIAgent/Game/GameActionService.cs
@@ -1622,9 +1622,8 @@ internal static class GameActionService
         var stable = currentScreen switch
         {
             NDeckCardSelectScreen deckCardScreen
-                when isDeckCardSelection &&
-                     deckCardSelection.SelectedCount + 1 < deckCardSelection.MinSelect =>
-                await WaitForDeckSelectionProgressAsync(
+                when isDeckCardSelection =>
+                await SettleDeckCardSelectionClickAsync(
                     deckCardScreen, deckCardSelection.SelectedCount, TimeSpan.FromSeconds(10)),
             NCardGridSelectionScreen cardSelectScreen => await ConfirmDeckSelectionAsync(cardSelectScreen, TimeSpan.FromSeconds(10)),
             NChooseACardSelectionScreen chooseCardScreen => await WaitForChooseCardSelectionResolutionAsync(chooseCardScreen, TimeSpan.FromSeconds(10)),
@@ -2085,7 +2084,7 @@ internal static class GameActionService
         return false;
     }
 
-    private static async Task<bool> WaitForDeckSelectionProgressAsync(
+    private static async Task<bool> SettleDeckCardSelectionClickAsync(
         NDeckCardSelectScreen screen,
         int previousSelectedCount,
         TimeSpan timeout)
@@ -2101,11 +2100,21 @@ internal static class GameActionService
                 return true;
             }
 
-            if (GameStateService.TryGetDeckCardSelectionMetadata(screen, out var metadata) &&
-                metadata.SelectedCount > previousSelectedCount)
+            if (!GameStateService.TryGetDeckCardSelectionMetadata(screen, out var metadata) ||
+                metadata.SelectedCount == previousSelectedCount)
+            {
+                continue;
+            }
+
+            if (metadata.SelectedCount < previousSelectedCount ||
+                metadata.SelectedCount < metadata.MinSelect)
             {
                 return true;
             }
+
+            var remaining = deadline - DateTime.UtcNow;
+            return remaining > TimeSpan.Zero &&
+                await ConfirmDeckSelectionAsync(screen, remaining);
         }
 
         return false;

--- a/STS2AIAgent/Game/GameStateService.cs
+++ b/STS2AIAgent/Game/GameStateService.cs
@@ -1537,6 +1537,33 @@ internal static class GameStateService
         return Array.Empty<NCardHolder>();
     }
 
+    public static bool TryGetDeckCardSelectionMetadata(
+        IScreenContext? currentScreen,
+        out DeckCardSelectionMetadata metadata)
+    {
+        metadata = default;
+        if (currentScreen is not NDeckCardSelectScreen deckCardScreen ||
+            ReflectionMemberAccessor.TryGetValue(deckCardScreen, "_prefs") is not CardSelectorPrefs prefs ||
+            ReflectionMemberAccessor.TryGetValue(deckCardScreen, "_selectedCards") is not IEnumerable selectedCards)
+        {
+            return false;
+        }
+
+        var selectedCount = 0;
+        foreach (var _ in selectedCards)
+        {
+            selectedCount++;
+        }
+
+        metadata = new DeckCardSelectionMetadata(
+            prefs.MinSelect,
+            prefs.MaxSelect,
+            selectedCount,
+            prefs.RequireManualConfirmation,
+            selectedCount >= prefs.MinSelect && selectedCount <= prefs.MaxSelect);
+        return true;
+    }
+
     public static string? GetDeckSelectionPrompt(IScreenContext? currentScreen)
     {
         if (currentScreen is NCardsViewScreen)
@@ -3836,9 +3863,10 @@ internal static class GameStateService
             return null;
         }
 
-        var combatHandSelection = TryGetCombatHandSelectionMetadata(currentScreen, out _, out var metadata)
-            ? metadata
-            : default;
+        var hasCombatHandSelection = TryGetCombatHandSelectionMetadata(
+            currentScreen, out _, out var combatHandSelection);
+        var hasDeckCardSelection = TryGetDeckCardSelectionMetadata(
+            currentScreen, out var deckCardSelection);
 
         return new SelectionPayload
         {
@@ -3854,11 +3882,21 @@ internal static class GameStateService
                 _ => "deck_card_select"
             },
             prompt = GetDeckSelectionPrompt(currentScreen) ?? string.Empty,
-            min_select = combatHandSelection.MinSelect,
-            max_select = combatHandSelection.MaxSelect,
-            selected_count = combatHandSelection.SelectedCount,
-            requires_confirmation = combatHandSelection.RequiresConfirmation,
-            can_confirm = combatHandSelection.CanConfirm,
+            min_select = hasCombatHandSelection
+                ? combatHandSelection.MinSelect
+                : hasDeckCardSelection ? deckCardSelection.MinSelect : 1,
+            max_select = hasCombatHandSelection
+                ? combatHandSelection.MaxSelect
+                : hasDeckCardSelection ? deckCardSelection.MaxSelect : 1,
+            selected_count = hasCombatHandSelection
+                ? combatHandSelection.SelectedCount
+                : hasDeckCardSelection ? deckCardSelection.SelectedCount : 0,
+            requires_confirmation = hasCombatHandSelection
+                ? combatHandSelection.RequiresConfirmation
+                : hasDeckCardSelection && deckCardSelection.RequiresConfirmation,
+            can_confirm = hasCombatHandSelection
+                ? combatHandSelection.CanConfirm
+                : hasDeckCardSelection && deckCardSelection.CanConfirm,
             cards = cards.Select((holder, index) => BuildSelectionCardPayload(holder.CardModel!, index)).ToArray()
         };
     }
@@ -6307,6 +6345,13 @@ internal sealed class SelectionPayload
 }
 
 internal readonly record struct CombatHandSelectionMetadata(
+    int MinSelect,
+    int MaxSelect,
+    int SelectedCount,
+    bool RequiresConfirmation,
+    bool CanConfirm);
+
+internal readonly record struct DeckCardSelectionMetadata(
     int MinSelect,
     int MaxSelect,
     int SelectedCount,


### PR DESCRIPTION
## Summary
- report selected_count and min_select for native deck-card selection screens
- treat an intermediate required pick as completed when the native selected-card count advances
- confirm the selection only after the minimum required count has been reached

This prevents select_deck_card from being reported as indefinitely pending on multi-select deck grids while preserving the existing confirmation behavior for the final pick.

## Validation
- STS2AIAgent.Tests: 50 tests passed
- release mod build against Slay the Spire 2 v0.111.0 assemblies: 0 warnings, 0 errors

## Summary by Sourcery

Fix deck-card multi-selection acknowledgements so intermediate picks settle promptly while final confirmation occurs only after the required minimum selection count.

New Features:
- Expose native deck-card selection progress, limits, and confirmation state in selection payloads.

Bug Fixes:
- Prevent multi-select deck-card actions from remaining pending after intermediate selections and defer confirmation until the minimum selection count is reached.

Tests:
- Add contract tests covering deck-grid selection payload progress and click settlement behavior.