### PR TITLE
Fix HttpServer startup on Windows excluded port ranges

### DIFF
--- a/STS2AIAgent.Tests/LoopbackListenerTests.cs
+++ b/STS2AIAgent.Tests/LoopbackListenerTests.cs
@@ -1,0 +1,96 @@
+using System.Net;
+using STS2AIAgent.Server;
+
+namespace STS2AIAgent.Tests;
+
+internal static class LoopbackListenerTests
+{
+    public static void ExcludedRangeUsesDynamicPort()
+    {
+        var attempted = new List<int>();
+        var selected = LoopbackListener.Select(8080, true, port =>
+        {
+            attempted.Add(port);
+            if (port < 49000) throw new HttpListenerException(32);
+            return "listening";
+        }, () => 49000, () => throw new Exception("Automatic selection should not sleep."));
+        Assert.Equal(49000, selected.Port);
+        Assert.Equal(LoopbackListener.NearbyPortCount + 1, attempted.Count);
+        Assert.Equal("listening", selected.Listener);
+    }
+
+    public static void BindRaceReselectsDynamicPort()
+    {
+        var allocated = 49000;
+        var selected = LoopbackListener.Select(65535, true, port =>
+        {
+            if (port != 49002) throw new HttpListenerException(183);
+            return port;
+        }, () => ++allocated, () => { });
+        Assert.Equal(49002, selected.Port);
+    }
+
+    public static void ExplicitPortNeverChanges()
+    {
+        var attempts = 0;
+        var waits = 0;
+        var error = Expect<InvalidOperationException>(() => LoopbackListener.Select<int>(8080, false, port =>
+        {
+            Assert.Equal(8080, port);
+            attempts++;
+            throw new HttpListenerException(183);
+        }, () => throw new Exception("Explicit port cannot fall back."), () => waits++));
+        Assert.Equal(LoopbackListener.ExplicitPortAttempts, attempts);
+        Assert.Equal(attempts - 1, waits);
+        Assert.Contains("STS2_API_PORT", error.Message);
+    }
+
+    public static void ExplicitReservedPortFailsClearly()
+    {
+        var error = Expect<InvalidOperationException>(() => LoopbackListener.Select<int>(8080, false,
+            _ => throw new HttpListenerException(32),
+            () => throw new Exception("Unexpected fallback"), () => throw new Exception("Unexpected retry")));
+        Assert.Contains("8080", error.Message);
+        Assert.True(error.InnerException is HttpListenerException);
+    }
+
+    public static void ExhaustionIsBounded()
+    {
+        var attempts = 0;
+        Expect<InvalidOperationException>(() => LoopbackListener.Select<int>(8080, true, _ =>
+        {
+            attempts++;
+            throw new HttpListenerException(5);
+        }, () => 49000, () => { }));
+        Assert.Equal(LoopbackListener.NearbyPortCount + LoopbackListener.DynamicPortAttempts, attempts);
+    }
+
+    public static void UnexpectedFailureIsNotHidden()
+    {
+        var error = Expect<HttpListenerException>(() => LoopbackListener.Select<int>(8080, true,
+            _ => throw new HttpListenerException(87),
+            () => throw new Exception("Unexpected fallback"), () => { }));
+        Assert.Equal(87, error.NativeErrorCode);
+    }
+
+    public static async Task RealLoopbackListenerResponds()
+    {
+        var started = LoopbackListener.Start(49080, allowFallback: true);
+        using var listener = started.Listener;
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        using var http = new HttpClient();
+        var request = http.GetAsync($"http://127.0.0.1:{started.Port}/health", timeout.Token);
+        var context = await listener.GetContextAsync().WaitAsync(timeout.Token);
+        context.Response.StatusCode = 204;
+        context.Response.Close();
+        using var response = await request;
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    private static T Expect<T>(Action action) where T : Exception
+    {
+        try { action(); }
+        catch (T error) { return error; }
+        throw new Exception($"Expected {typeof(T).Name}.");
+    }
+}

--- a/STS2AIAgent.Tests/STS2AIAgent.Tests.csproj
+++ b/STS2AIAgent.Tests/STS2AIAgent.Tests.csproj
@@ -24,5 +24,6 @@
     <Compile Include="..\STS2AIAgent\Game\CrystalSphereSettlePolicy.cs" Link="Game\CrystalSphereSettlePolicy.cs" />
     <Compile Include="..\STS2AIAgent\Game\ProgressSaveVerification.cs" Link="Game\ProgressSaveVerification.cs" />
     <Compile Include="..\STS2AIAgent\Game\EventOptionLocalization.cs" Link="Game\EventOptionLocalization.cs" />
+    <Compile Include="..\STS2AIAgent\Server\LoopbackListener.cs" Link="Server\LoopbackListener.cs" />
   </ItemGroup>
 </Project>

--- a/STS2AIAgent.Tests/TestRunner.cs
+++ b/STS2AIAgent.Tests/TestRunner.cs
@@ -179,5 +179,12 @@ internal static class TestRunner
         yield return ("EventOptionLocalization.DynamicVars", () => Task.Run(EventOptionLocalizationTests.AddsEventVariablesBeforeFormatting));
         yield return ("EventOptionLocalization.Null", () => Task.Run(EventOptionLocalizationTests.MissingLocStringReturnsEmpty));
         yield return ("EventOptionLocalization.Signature", () => Task.Run(EventOptionLocalizationTests.FormatsSignatureFieldsWithEventVariables));
+        yield return ("LoopbackListener.ExcludedRangeUsesDynamicPort", () => Task.Run(LoopbackListenerTests.ExcludedRangeUsesDynamicPort));
+        yield return ("LoopbackListener.BindRaceReselectsDynamicPort", () => Task.Run(LoopbackListenerTests.BindRaceReselectsDynamicPort));
+        yield return ("LoopbackListener.ExplicitPortNeverChanges", () => Task.Run(LoopbackListenerTests.ExplicitPortNeverChanges));
+        yield return ("LoopbackListener.ExplicitReservedPortFailsClearly", () => Task.Run(LoopbackListenerTests.ExplicitReservedPortFailsClearly));
+        yield return ("LoopbackListener.ExhaustionIsBounded", () => Task.Run(LoopbackListenerTests.ExhaustionIsBounded));
+        yield return ("LoopbackListener.UnexpectedFailureIsNotHidden", () => Task.Run(LoopbackListenerTests.UnexpectedFailureIsNotHidden));
+        yield return ("LoopbackListener.RealLoopbackListenerResponds", LoopbackListenerTests.RealLoopbackListenerResponds);
     }
 }

--- a/STS2AIAgent/Server/HttpServer.cs
+++ b/STS2AIAgent/Server/HttpServer.cs
@@ -1,5 +1,4 @@
 using System.Net;
-using System.Net.Sockets;
 using System.Threading;
 using MegaCrit.Sts2.Core.Logging;
 
@@ -9,10 +8,7 @@ public sealed class HttpServer
 {
     private const string DefaultHost = "127.0.0.1";
     private const int DefaultPort = 8080;
-    private const int AutoIncrementSpan = 32;
     private const string LogPrefix = "[STS2AIAgent.HttpServer]";
-    private const int StartRetryCount = 20;
-    private static readonly TimeSpan StartRetryDelay = TimeSpan.FromMilliseconds(250);
 
     private static readonly Lazy<HttpServer> LazyInstance = new(() => new HttpServer());
 
@@ -47,7 +43,7 @@ public sealed class HttpServer
 
             var preferredPort = ResolvePreferredPort();
             var allowIncrement = !IsExplicitPortConfigured();
-            var started = StartListener(preferredPort, allowIncrement);
+            var started = LoopbackListener.Start(preferredPort, allowIncrement);
             _listener = started.Listener;
             Port = started.Port;
             PortWasAutoIncremented = started.Port != preferredPort;
@@ -62,25 +58,9 @@ public sealed class HttpServer
     public static int FindFreePort(int startPort)
     {
         var port = startPort is > 0 and <= 65535 ? startPort : DefaultPort;
-        for (var candidate = port; candidate <= Math.Min(65535, port + AutoIncrementSpan); candidate++)
-        {
-            TcpListener? listener = null;
-            try
-            {
-                listener = new TcpListener(IPAddress.Loopback, candidate);
-                listener.Start();
-                return candidate;
-            }
-            catch (SocketException)
-            {
-            }
-            finally
-            {
-                listener?.Stop();
-            }
-        }
-
-        throw new InvalidOperationException($"No free loopback port found in {startPort}..{startPort + AutoIncrementSpan}.");
+        var selected = LoopbackListener.Start(port, allowFallback: true);
+        selected.Listener.Close();
+        return selected.Port;
     }
 
     public void Stop()
@@ -181,54 +161,6 @@ public sealed class HttpServer
         }
     }
 
-    private static (HttpListener Listener, int Port) StartListener(int preferredPort, bool allowIncrement)
-    {
-        HttpListenerException? lastConflict = null;
-        var maxPort = allowIncrement
-            ? Math.Min(65535, preferredPort + AutoIncrementSpan)
-            : preferredPort;
-
-        for (var port = preferredPort; port <= maxPort; port++)
-        {
-            var prefix = $"http://{DefaultHost}:{port}/";
-            var attempts = allowIncrement ? 2 : StartRetryCount;
-            for (var attempt = 1; attempt <= attempts; attempt++)
-            {
-                var listener = new HttpListener();
-                listener.Prefixes.Add(prefix);
-
-                try
-                {
-                    listener.Start();
-                    if (port != preferredPort)
-                    {
-                        Log.Info($"{LogPrefix} Preferred port {preferredPort} was busy; bound {prefix}");
-                    }
-
-                    return (listener, port);
-                }
-                catch (HttpListenerException ex) when (IsPrefixConflict(ex))
-                {
-                    listener.Close();
-                    lastConflict = ex;
-                    if (attempt < attempts)
-                    {
-                        Log.Warn($"{LogPrefix} Prefix still busy, retrying start ({attempt}/{attempts - 1})...");
-                        Thread.Sleep(StartRetryDelay);
-                    }
-                }
-            }
-        }
-
-        if (lastConflict != null)
-        {
-            throw lastConflict;
-        }
-
-        throw new InvalidOperationException(
-            $"Failed to bind STS2 AI Agent HTTP API starting at port {preferredPort}.");
-    }
-
     private static bool IsExplicitPortConfigured()
     {
         var rawPort = Environment.GetEnvironmentVariable("STS2_API_PORT");
@@ -248,12 +180,5 @@ public sealed class HttpServer
         }
 
         return DefaultPort;
-    }
-
-    private static bool IsPrefixConflict(HttpListenerException ex)
-    {
-        return ex.ErrorCode == 183 ||
-            ex.NativeErrorCode == 183 ||
-            ex.Message.Contains("conflicts with an existing registration", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/STS2AIAgent/Server/LoopbackListener.cs
+++ b/STS2AIAgent/Server/LoopbackListener.cs
@@ -1,0 +1,139 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace STS2AIAgent.Server;
+
+// Keep port selection independent of Godot so startup failures can be reproduced
+// without launching a game. A successful TCP probe alone does not prove that
+// HTTP.sys can bind the port; the final decision always belongs to HttpListener.
+internal static class LoopbackListener
+{
+    internal const int NearbyPortCount = 33;
+    internal const int DynamicPortAttempts = 16;
+    internal const int ExplicitPortAttempts = 20;
+
+    public static (HttpListener Listener, int Port) Start(int preferredPort, bool allowFallback)
+    {
+        return Select(
+            preferredPort,
+            allowFallback,
+            Bind,
+            AllocateDynamicPort,
+            () => Thread.Sleep(TimeSpan.FromMilliseconds(250)));
+    }
+
+    internal static (T Listener, int Port) Select<T>(
+        int preferredPort,
+        bool allowFallback,
+        Func<int, T> bind,
+        Func<int> allocateDynamicPort,
+        Action waitBeforeRetry)
+    {
+        if (preferredPort is < 1 or > 65535)
+        {
+            throw new ArgumentOutOfRangeException(nameof(preferredPort));
+        }
+
+        HttpListenerException? lastFailure = null;
+        var nearbyCount = allowFallback ? Math.Min(NearbyPortCount, 65536 - preferredPort) : 1;
+        for (var offset = 0; offset < nearbyCount; offset++)
+        {
+            var port = preferredPort + offset;
+            var attempts = allowFallback ? 1 : ExplicitPortAttempts;
+            for (var attempt = 0; attempt < attempts; attempt++)
+            {
+                try
+                {
+                    return (bind(port), port);
+                }
+                catch (HttpListenerException ex) when (
+                    allowFallback ? IsUnavailablePort(ex) : IsRegistrationConflict(ex))
+                {
+                    lastFailure = ex;
+                    if (attempt + 1 < attempts)
+                    {
+                        waitBeforeRetry();
+                    }
+                }
+                catch (HttpListenerException ex) when (!allowFallback && IsUnavailablePort(ex))
+                {
+                    throw new InvalidOperationException(
+                        $"Configured loopback HTTP port {preferredPort} is unavailable. Change STS2_API_PORT or free that port.", ex);
+                }
+            }
+        }
+
+        if (allowFallback)
+        {
+            // Windows may reserve the entire nearby range. Let the OS nominate
+            // a dynamic loopback port, then retry the real HTTP bind a bounded
+            // number of times in case another process wins the release/bind race.
+            for (var attempt = 0; attempt < DynamicPortAttempts; attempt++)
+            {
+                var port = allocateDynamicPort();
+                if (port is < 1 or > 65535)
+                {
+                    throw new InvalidOperationException("The OS returned an invalid loopback port.");
+                }
+
+                try
+                {
+                    return (bind(port), port);
+                }
+                catch (HttpListenerException ex) when (IsUnavailablePort(ex))
+                {
+                    lastFailure = ex;
+                }
+            }
+        }
+
+        throw new InvalidOperationException(
+            allowFallback
+                ? $"Unable to bind a loopback HTTP port starting at {preferredPort}, including dynamically selected ports."
+                : $"Configured loopback HTTP port {preferredPort} is unavailable. Change STS2_API_PORT or free that port.",
+            lastFailure);
+    }
+
+    private static HttpListener Bind(int port)
+    {
+        var listener = new HttpListener();
+        try
+        {
+            listener.Prefixes.Add($"http://127.0.0.1:{port}/");
+            listener.Start();
+            return listener;
+        }
+        catch
+        {
+            listener.Close();
+            throw;
+        }
+    }
+
+    private static int AllocateDynamicPort()
+    {
+        var probe = new TcpListener(IPAddress.Loopback, 0);
+        try
+        {
+            probe.Start();
+            return ((IPEndPoint)probe.LocalEndpoint).Port;
+        }
+        finally
+        {
+            probe.Stop();
+        }
+    }
+
+    internal static bool IsUnavailablePort(HttpListenerException ex)
+    {
+        // HTTP.sys excluded/reserved ranges can report sharing violation (32)
+        // or access denied (5), even when no ordinary TCP listener owns the port.
+        return ex.NativeErrorCode is 5 or 32 or 183 or 10013 or 10048 || IsRegistrationConflict(ex);
+    }
+
+    private static bool IsRegistrationConflict(HttpListenerException ex)
+    {
+        return ex.NativeErrorCode == 183 ||
+            ex.Message.Contains("conflicts with an existing registration", StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce LoopbackListener to handle loopback HTTP port binding and fallback when Windows excluded/reserved port ranges block default ports.
- Treat native error codes 5, 32, 183, 10013, 10048 as unavailable ports in HttpListenerException.
- When STS2_API_PORT is unconfigured, try nearby ports first (preferredPort .. preferredPort + 32), then fall back to OS-nominated ephemeral loopback ports via TcpListener(IPAddress.Loopback, 0) with bounded retry for the release-to-bind race.
- When STS2_API_PORT is explicitly configured, remain strictly deterministic and fail fast with a clear error message if the port is unavailable.
- Update HttpServer.Start and HttpServer.FindFreePort to use LoopbackListener.
- Add dedicated unit tests in LoopbackListenerTests covering dynamic fallback, bind race resolution, explicit port strictness, exhaustion bounding, and real loopback HTTP responses.

Fixes #55

## Validation
- dotnet run --project STS2AIAgent.Tests/STS2AIAgent.Tests.csproj -c Release (75 tests passed, 0 failures)
- dotnet build STS2AIAgent/STS2AIAgent.csproj -c Release (0 warnings, 0 errors)
- uv run --with pytest pytest tests/ -v in mcp_server (48 passed, 61 subtests passed)

## Summary by Sourcery

Make loopback HTTP server startup resilient to Windows port reservations while preserving strict behavior for explicitly configured ports.

New Features:
- Add resilient loopback HTTP port selection that falls back to nearby or OS-assigned ports when automatic configuration encounters unavailable Windows ranges.

Bug Fixes:
- Fix HttpServer startup failures caused by Windows excluded or reserved loopback port ranges.

Enhancements:
- Keep explicitly configured STS2_API_PORT bindings deterministic, retrying conflicts and reporting clear failures without fallback.
- Recognize relevant Windows and HTTP.sys error codes as unavailable ports and bound dynamic-port retry attempts.
- Route HttpServer startup and free-port discovery through the shared loopback listener implementation.

Tests:
- Add coverage for dynamic fallback, bind races, explicit-port behavior, bounded exhaustion, unexpected errors, and real loopback HTTP responses.