### PR TITLE
feat(coop): offline companion instance isolation and configurable settings path

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ In the overlay:
 4. **AI teammate**: invite an AI companion from the main menu. You control your character while the model joins and plays in a second game window. Inviting saves the current model settings; repeated clicks do not launch another companion process.
 5. **Connect**: start the optional HTTP MCP server with one click and copy the API / MCP URLs for Cursor, Claude, Codex, or a custom client.
 
-Settings are stored in `%AppData%/STS2AIAgent/settings.json` and are shared by both local instances.
+Settings default to `%AppData%/STS2AIAgent/settings.json`. When launching a local companion via the in-game UI, the launcher automatically isolates configuration by deriving and provisioning a companion-specific file (`settings.companion.json` seeded from the main instance) so concurrent settings writes never collide. You can also explicitly assign an isolated configuration file path to any instance by setting the `STS2_AGENT_SETTINGS_PATH` environment variable to an absolute path (or `STS2_COMPANION_SETTINGS_PATH` for the launcher companion override).
 
 Vision is optional extra context. Auto-play works with text-only models: compact `agent_view`, `get_game_state` / `get_available_actions` / `get_game_data_*` / `wait_until_actionable` / `act`. If you assign a vision-capable play model or a vision sidecar, screenshots are attached as supporting context only.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -53,7 +53,7 @@ Slay the Spire 2/
 4. **AI 队友**：在主菜单邀请 AI 一起爬塔。你操作自己的角色，模型在第二个游戏窗口中自动加入大厅并游玩。邀请前会保存当前模型设置；重复点击不会再启动一个队友进程。
 5. **接入**：一键启动 HTTP MCP，复制 API / MCP 地址，给 Cursor、Claude、Codex 或自写客户端用。
 
-配置保存在 `%AppData%/STS2AIAgent/settings.json`，两个本地实例共用。
+配置默认保存在 `%AppData%/STS2AIAgent/settings.json`。通过游戏内 UI 启动本地 AI 队友时，启动器会自动为队友派生并同步初始化独立的配置文件（`settings.companion.json`），避免双实例并发写入冲突。若需为特定实例自定义配置文件位置，可设置环境变量 `STS2_AGENT_SETTINGS_PATH` 为绝对路径（亦可通过 `STS2_COMPANION_SETTINGS_PATH` 显式指定队友配置）。
 
 视觉是可选的额外上下文。纯文本模型可以直接游玩：compact `agent_view` + `get_game_state` / `get_available_actions` / `get_game_data_*` / `wait_until_actionable` / `act`。如果给游玩模型勾了「视觉」，或另外配了外挂视觉模型，截图才会作为辅助信息附上。
 

--- a/STS2AIAgent.Tests/CompanionStartupTests.cs
+++ b/STS2AIAgent.Tests/CompanionStartupTests.cs
@@ -13,20 +13,55 @@ internal static class CompanionStartupTests
         Assert.Equal("--windowed", CoopLaunchPolicy.CompanionArguments(null, "901"));
         Assert.Equal("--windowed --force-steam off --clientId 902", CoopLaunchPolicy.CompanionArguments("off", "901"));
         Assert.Equal("--windowed --force-steam off", CoopLaunchPolicy.CompanionArguments("off", null));
+
+        Expect<InvalidOperationException>(() => CoopLaunchPolicy.CompanionArguments("off", ulong.MaxValue.ToString()));
+
+        Assert.True(CoopLaunchPolicy.TryGetCompanionArguments("off", "901", out var args, out var err));
+        Assert.Equal("--windowed --force-steam off --clientId 902", args);
+        Assert.True(err == null);
+
+        Assert.False(CoopLaunchPolicy.TryGetCompanionArguments("off", ulong.MaxValue.ToString(), out var badArgs, out var badErr));
+        Assert.Equal(string.Empty, badArgs);
+        Assert.True(badErr != null && badErr.Contains("adjacent companion ID"));
     }
 
     public static void SettingsPathCanBeIsolated()
     {
         var previous = Environment.GetEnvironmentVariable("STS2_AGENT_SETTINGS_PATH");
+        var tempDir = Path.Combine(Path.GetTempPath(), "sts2-coop-test-" + Guid.NewGuid().ToString("N"));
         try
         {
-            var isolated = Path.Combine(Path.GetTempPath(), "sts2-coop-test", "settings.json");
+            Directory.CreateDirectory(tempDir);
+            var isolated = Path.Combine(tempDir, "settings.json");
             Environment.SetEnvironmentVariable("STS2_AGENT_SETTINGS_PATH", isolated);
             Assert.Equal(Path.GetFullPath(isolated), new SettingsStore().Path);
             Environment.SetEnvironmentVariable("STS2_AGENT_SETTINGS_PATH", "relative.json");
             Expect<InvalidOperationException>(() => new SettingsStore());
+
+            var derived = CoopLaunchPolicy.CompanionSettingsPath(isolated);
+            Assert.Equal(Path.Combine(tempDir, "settings.companion.json"), derived);
+
+            var explicitCustom = Path.Combine(tempDir, "custom.companion.json");
+            Assert.Equal(explicitCustom, CoopLaunchPolicy.CompanionSettingsPath(isolated, explicitCustom));
+            Expect<InvalidOperationException>(() => CoopLaunchPolicy.CompanionSettingsPath(isolated, "relative.companion.json"));
+            Expect<ArgumentException>(() => CoopLaunchPolicy.CompanionSettingsPath(""));
+
+            File.WriteAllText(isolated, "{\"main\":true}");
+            Assert.False(File.Exists(derived));
+            CoopLaunchPolicy.SeedCompanionSettings(isolated, derived);
+            Assert.True(File.Exists(derived));
+            Assert.Equal("{\"main\":true}", File.ReadAllText(derived));
+
+            File.WriteAllText(derived, "{\"companion\":true}");
+            File.WriteAllText(isolated, "{\"main\":updated}");
+            CoopLaunchPolicy.SeedCompanionSettings(isolated, derived);
+            Assert.Equal("{\"companion\":true}", File.ReadAllText(derived));
         }
-        finally { Environment.SetEnvironmentVariable("STS2_AGENT_SETTINGS_PATH", previous); }
+        finally
+        {
+            Environment.SetEnvironmentVariable("STS2_AGENT_SETTINGS_PATH", previous);
+            try { if (Directory.Exists(tempDir)) Directory.Delete(tempDir, true); } catch { }
+        }
     }
 
     public static void ExcludedRangeUsesDynamicPort()

--- a/STS2AIAgent.Tests/CompanionStartupTests.cs
+++ b/STS2AIAgent.Tests/CompanionStartupTests.cs
@@ -8,6 +8,27 @@ namespace STS2AIAgent.Tests;
 
 internal static class CompanionStartupTests
 {
+    public static void OfflineLaunchKeepsAccountsIsolated()
+    {
+        Assert.Equal("--windowed", CoopLaunchPolicy.CompanionArguments(null, "901"));
+        Assert.Equal("--windowed --force-steam off --clientId 902", CoopLaunchPolicy.CompanionArguments("off", "901"));
+        Assert.Equal("--windowed --force-steam off", CoopLaunchPolicy.CompanionArguments("off", null));
+    }
+
+    public static void SettingsPathCanBeIsolated()
+    {
+        var previous = Environment.GetEnvironmentVariable("STS2_AGENT_SETTINGS_PATH");
+        try
+        {
+            var isolated = Path.Combine(Path.GetTempPath(), "sts2-coop-test", "settings.json");
+            Environment.SetEnvironmentVariable("STS2_AGENT_SETTINGS_PATH", isolated);
+            Assert.Equal(Path.GetFullPath(isolated), new SettingsStore().Path);
+            Environment.SetEnvironmentVariable("STS2_AGENT_SETTINGS_PATH", "relative.json");
+            Expect<InvalidOperationException>(() => new SettingsStore());
+        }
+        finally { Environment.SetEnvironmentVariable("STS2_AGENT_SETTINGS_PATH", previous); }
+    }
+
     public static void ExcludedRangeUsesDynamicPort()
     {
         var attempted = new List<int>();

--- a/STS2AIAgent.Tests/TestRunner.cs
+++ b/STS2AIAgent.Tests/TestRunner.cs
@@ -132,6 +132,8 @@ internal static class TestRunner
         yield return ("TeamChat.SessionAuthorization", () => Task.Run(TeamConversationTests.SessionTokensAreRequiredAndDistinct));
         yield return ("TeamChat.Transport", TeamConversationTests.TransportChecksIdentityAndSendsBoundedBody);
         yield return ("TeamChat.ReusedPort", TeamConversationTests.ReusedPortDoesNotReceiveMessage);
+        yield return ("CoopStartup.OfflineIsolation", () => Task.Run(CompanionStartupTests.OfflineLaunchKeepsAccountsIsolated));
+        yield return ("CoopStartup.SettingsIsolation", () => Task.Run(CompanionStartupTests.SettingsPathCanBeIsolated));
         yield return ("CoopStartup.ExcludedRange", () => Task.Run(CompanionStartupTests.ExcludedRangeUsesDynamicPort));
         yield return ("CoopStartup.BindRace", () => Task.Run(CompanionStartupTests.BindRaceReselectsDynamicPort));
         yield return ("CoopStartup.ExplicitPort", () => Task.Run(CompanionStartupTests.ExplicitPortNeverChanges));

--- a/STS2AIAgent/Config/SettingsStore.cs
+++ b/STS2AIAgent/Config/SettingsStore.cs
@@ -25,6 +25,14 @@ internal sealed class SettingsStore
 
     public static string DefaultPath()
     {
+        var configured = Environment.GetEnvironmentVariable("STS2_AGENT_SETTINGS_PATH");
+        if (!string.IsNullOrWhiteSpace(configured))
+        {
+            if (!System.IO.Path.IsPathFullyQualified(configured))
+                throw new InvalidOperationException("STS2_AGENT_SETTINGS_PATH must be an absolute file path.");
+            return System.IO.Path.GetFullPath(configured);
+        }
+
         var root = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
         if (string.IsNullOrWhiteSpace(root))
         {

--- a/STS2AIAgent/Multiplayer/CoopLaunchPolicy.cs
+++ b/STS2AIAgent/Multiplayer/CoopLaunchPolicy.cs
@@ -4,6 +4,18 @@ namespace STS2AIAgent.Multiplayer;
 
 internal static class CoopLaunchPolicy
 {
+    public static string CompanionArguments(string? forceSteam, string? clientId)
+    {
+        if (!string.Equals(forceSteam, "off", StringComparison.OrdinalIgnoreCase)) return "--windowed";
+        var arguments = "--windowed --force-steam off";
+        if (ulong.TryParse(clientId, out var id))
+        {
+            if (id == ulong.MaxValue) throw new InvalidOperationException("Offline clientId leaves no adjacent companion ID.");
+            arguments += " --clientId " + (id + 1).ToString(System.Globalization.CultureInfo.InvariantCulture);
+        }
+        return arguments;
+    }
+
     public static string? GetError(bool isCompanion, bool autoPlayRunning, string screen, ResolvedModel? model)
     {
         if (isCompanion) return "当前窗口已是 AI 队友。请在你的主窗口邀请队友。";

--- a/STS2AIAgent/Multiplayer/CoopLaunchPolicy.cs
+++ b/STS2AIAgent/Multiplayer/CoopLaunchPolicy.cs
@@ -16,6 +16,57 @@ internal static class CoopLaunchPolicy
         return arguments;
     }
 
+    public static bool TryGetCompanionArguments(string? forceSteam, string? clientId, out string arguments, out string? error)
+    {
+        try
+        {
+            arguments = CompanionArguments(forceSteam, clientId);
+            error = null;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            arguments = string.Empty;
+            error = ex.Message;
+            return false;
+        }
+    }
+
+    public static string CompanionSettingsPath(string mainSettingsPath, string? explicitCompanionPath = null)
+    {
+        if (!string.IsNullOrWhiteSpace(explicitCompanionPath))
+        {
+            if (!System.IO.Path.IsPathFullyQualified(explicitCompanionPath))
+                throw new InvalidOperationException("Companion settings path must be an absolute file path.");
+            return System.IO.Path.GetFullPath(explicitCompanionPath);
+        }
+
+        if (string.IsNullOrWhiteSpace(mainSettingsPath))
+            throw new ArgumentException("Main settings path must not be empty.", nameof(mainSettingsPath));
+
+        var fullMain = System.IO.Path.GetFullPath(mainSettingsPath);
+        var dir = System.IO.Path.GetDirectoryName(fullMain) ?? string.Empty;
+        var nameWithoutExt = System.IO.Path.GetFileNameWithoutExtension(fullMain);
+        var ext = System.IO.Path.GetExtension(fullMain);
+        return System.IO.Path.Combine(dir, $"{nameWithoutExt}.companion{ext}");
+    }
+
+    public static void SeedCompanionSettings(string mainSettingsPath, string companionSettingsPath)
+    {
+        if (string.IsNullOrWhiteSpace(mainSettingsPath) || string.IsNullOrWhiteSpace(companionSettingsPath))
+            return;
+
+        if (string.Equals(System.IO.Path.GetFullPath(mainSettingsPath), System.IO.Path.GetFullPath(companionSettingsPath), StringComparison.OrdinalIgnoreCase))
+            return;
+
+        var dir = System.IO.Path.GetDirectoryName(companionSettingsPath);
+        if (!string.IsNullOrEmpty(dir))
+            System.IO.Directory.CreateDirectory(dir);
+
+        if (System.IO.File.Exists(mainSettingsPath) && !System.IO.File.Exists(companionSettingsPath))
+            System.IO.File.Copy(mainSettingsPath, companionSettingsPath, overwrite: false);
+    }
+
     public static string? GetError(bool isCompanion, bool autoPlayRunning, string screen, ResolvedModel? model)
     {
         if (isCompanion) return "当前窗口已是 AI 队友。请在你的主窗口邀请队友。";

--- a/STS2AIAgent/Multiplayer/LocalDualInstanceLauncher.cs
+++ b/STS2AIAgent/Multiplayer/LocalDualInstanceLauncher.cs
@@ -115,6 +115,36 @@ internal static class LocalDualInstanceLauncher
             return new DualLaunchResult { Ok = false, Message = "找不到空闲 API 端口：" + ex.Message };
         }
 
+        if (!CoopLaunchPolicy.TryGetCompanionArguments(
+                CommandLineHelper.GetValue("force-steam"),
+                CommandLineHelper.GetValue("clientId"),
+                out var companionArguments,
+                out var argumentError))
+        {
+            return new DualLaunchResult
+            {
+                Ok = false,
+                Message = "无法计算队友启动参数：" + argumentError
+            };
+        }
+
+        string companionSettingsPath;
+        try
+        {
+            var mainPath = SettingsStore.DefaultPath();
+            var explicitCompanion = System.Environment.GetEnvironmentVariable("STS2_COMPANION_SETTINGS_PATH");
+            companionSettingsPath = CoopLaunchPolicy.CompanionSettingsPath(mainPath, explicitCompanion);
+            CoopLaunchPolicy.SeedCompanionSettings(mainPath, companionSettingsPath);
+        }
+        catch (Exception ex)
+        {
+            return new DualLaunchResult
+            {
+                Ok = false,
+                Message = "无法配置队友设置文件路径：" + ex.Message
+            };
+        }
+
         try
         {
             EnsureSteamAppIdFile(exe);
@@ -128,7 +158,7 @@ internal static class LocalDualInstanceLauncher
         {
             FileName = exe,
             WorkingDirectory = Path.GetDirectoryName(exe) ?? System.Environment.CurrentDirectory,
-            Arguments = CoopLaunchPolicy.CompanionArguments(CommandLineHelper.GetValue("force-steam"), CommandLineHelper.GetValue("clientId")),
+            Arguments = companionArguments,
             UseShellExecute = false
         };
 
@@ -136,6 +166,7 @@ internal static class LocalDualInstanceLauncher
         startInfo.Environment["STS2_AGENT_ROLE"] = InstanceRole.Companion;
         startInfo.Environment["STS2_MULTIPLAYER_HOST_IP"] = "127.0.0.1";
         startInfo.Environment["STS2_AGENT_AUTOPLAY"] = "1";
+        startInfo.Environment["STS2_AGENT_SETTINGS_PATH"] = companionSettingsPath;
         var sessionToken = CompanionConnection.CreateToken();
         startInfo.Environment[CompanionConnection.TokenEnvironment] = sessionToken;
 

--- a/STS2AIAgent/Multiplayer/LocalDualInstanceLauncher.cs
+++ b/STS2AIAgent/Multiplayer/LocalDualInstanceLauncher.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using Godot;
 using MegaCrit.Sts2.Core.Logging;
+using MegaCrit.Sts2.Core.Helpers;
 using STS2AIAgent.Config;
 using STS2AIAgent.Server;
 
@@ -127,7 +128,7 @@ internal static class LocalDualInstanceLauncher
         {
             FileName = exe,
             WorkingDirectory = Path.GetDirectoryName(exe) ?? System.Environment.CurrentDirectory,
-            Arguments = "--windowed",
+            Arguments = CoopLaunchPolicy.CompanionArguments(CommandLineHelper.GetValue("force-steam"), CommandLineHelper.GetValue("clientId")),
             UseShellExecute = false
         };
 


### PR DESCRIPTION
## Summary
Resolves account contention and settings overwrite issues when launching local co-op instances:
- Automatically assign adjacent offline clientId (--force-steam off --clientId {id + 1}) to avoid account collisions in offline mode.
- Support STS2_AGENT_SETTINGS_PATH environment variable for isolated settings.json configuration per game instance.
- Add comprehensive unit tests verifying parameter generation and settings path validation.

## Summary by Sourcery

Isolate offline companion instances by assigning distinct client IDs and settings files during local co-op launches.

New Features:
- Isolate local companion instances with dedicated settings files, supporting explicit paths through environment variables.
- Automatically assign an adjacent offline client ID when launching a companion instance.

Bug Fixes:
- Prevent account contention and concurrent settings overwrites between local co-op instances.

Documentation:
- Document companion settings isolation and configurable settings paths in English and Chinese README files.

Tests:
- Add coverage for offline companion client ID generation, settings path validation, derivation, and initialization.