### PR TITLE
feat: track token usage and enforce session budget guards

### DIFF
--- a/STS2AIAgent.Tests/LlmClientTests.cs
+++ b/STS2AIAgent.Tests/LlmClientTests.cs
@@ -149,6 +149,68 @@ internal static class OpenAiCompatibleClientTests
         Assert.Contains("play_card", completion.ToolCalls[0].ArgumentsJson);
     }
 
+    public static void ParseCompletion_ReadsUsage()
+    {
+        const string payload = """
+        {
+          "choices": [
+            {
+              "message": {
+                "role": "assistant",
+                "content": "ok"
+              }
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 120,
+            "completion_tokens": 30,
+            "total_tokens": 150
+          }
+        }
+        """;
+
+        var completion = OpenAiCompatibleClient.ParseCompletion(payload);
+        Assert.NotNull(completion.Usage);
+        Assert.Equal(120, completion.Usage!.PromptTokens);
+        Assert.Equal(30, completion.Usage.CompletionTokens);
+        Assert.Equal(150, completion.Usage.TotalTokens);
+    }
+
+    public static void ParseSse_ReadsUsageFromEndChunk()
+    {
+        const string payload = """
+        data: {"choices":[{"delta":{"content":"hello"}}]}
+
+        data: {"choices":[],"usage":{"prompt_tokens":50,"completion_tokens":10,"total_tokens":60}}
+
+        data: [DONE]
+        """;
+
+        var completion = OpenAiCompatibleClient.ParseSsePayload(payload);
+        Assert.Equal("hello", completion.Content);
+        Assert.NotNull(completion.Usage);
+        Assert.Equal(50, completion.Usage!.PromptTokens);
+        Assert.Equal(10, completion.Usage.CompletionTokens);
+        Assert.Equal(60, completion.Usage.TotalTokens);
+    }
+
+    public static void LlmUsage_CombineAndAdd()
+    {
+        var u1 = new LlmUsage { PromptTokens = 10, CompletionTokens = 5, TotalTokens = 15 };
+        var u2 = new LlmUsage { PromptTokens = 20, CompletionTokens = 8, TotalTokens = 28 };
+
+        var sum = u1 + u2;
+        Assert.Equal(30, sum.PromptTokens);
+        Assert.Equal(13, sum.CompletionTokens);
+        Assert.Equal(43, sum.TotalTokens);
+
+        var combinedWithNull = LlmUsage.Combine(u1, null);
+        Assert.Equal(15, combinedWithNull!.TotalTokens);
+
+        var combinedBoth = LlmUsage.Combine(u1, u2);
+        Assert.Equal(43, combinedBoth!.TotalTokens);
+    }
+
     private sealed class RecordingHandler : HttpMessageHandler
     {
         private readonly string _response;

--- a/STS2AIAgent.Tests/STS2AIAgent.Tests.csproj
+++ b/STS2AIAgent.Tests/STS2AIAgent.Tests.csproj
@@ -11,6 +11,7 @@
     <Compile Include="..\STS2AIAgent\Agent\AutoPlaySession.cs" Link="Agent\AutoPlaySession.cs" />
     <Compile Include="..\STS2AIAgent\Agent\AutoPlayRecovery.cs" Link="Agent\AutoPlayRecovery.cs" />
     <Compile Include="..\STS2AIAgent\Agent\CurrentRunBoundary.cs" Link="Agent\CurrentRunBoundary.cs" />
+    <Compile Include="..\STS2AIAgent\Agent\SessionBudgetGuard.cs" Link="Agent\SessionBudgetGuard.cs" />
     <Compile Include="..\STS2AIAgent\Server\LoopbackListener.cs" Link="Server\LoopbackListener.cs" />
     <Compile Include="..\STS2AIAgent\Multiplayer\CompanionHealth.cs" Link="Multiplayer\CompanionHealth.cs" />
     <Compile Include="..\STS2AIAgent\Multiplayer\CoopLaunchPolicy.cs" Link="Multiplayer\CoopLaunchPolicy.cs" />

--- a/STS2AIAgent.Tests/SessionBudgetGuardTests.cs
+++ b/STS2AIAgent.Tests/SessionBudgetGuardTests.cs
@@ -103,4 +103,89 @@ internal static class SessionBudgetGuardTests
             Assert.Equal(2, reported.Count);
         }
     }
+
+    public static void InitialCounters_ResumePreservesCumulativeUsage()
+    {
+        var guard = new SessionBudgetGuard(maxTokens: 1000, maxRequests: 3, initialTokens: 600, initialRequests: 2);
+        Assert.Equal(600, guard.ConsumedTokens);
+        Assert.Equal(2, guard.RequestCount);
+        Assert.Null(guard.CheckBudget());
+
+        var res = new AgentTurnResult
+        {
+            Acted = "play_card",
+            Usage = new LlmUsage { TotalTokens = 500 },
+            RequestsSpent = 1
+        };
+        var stop = guard.Observe(res);
+        Assert.NotNull(stop);
+        Assert.Equal(1100, guard.ConsumedTokens);
+        Assert.Equal(3, guard.RequestCount);
+    }
+
+    public static async Task InitialCounters_AlreadyExceeded_RunAsyncStopsImmediately()
+    {
+        var guard = new SessionBudgetGuard(maxRequests: 2, initialRequests: 2);
+        var calls = 0;
+        try
+        {
+            await AutoPlayRecovery.RunAsync(
+                turn: token =>
+                {
+                    calls++;
+                    return Task.FromResult(new AgentTurnResult { Acted = "play_card", RequestsSpent = 1 });
+                },
+                report: _ => { },
+                cancellationToken: CancellationToken.None,
+                delay: (ts, token) => Task.CompletedTask,
+                budgetGuard: guard);
+
+            Assert.True(false, "Expected AutoPlayStoppedException was not thrown.");
+        }
+        catch (AutoPlayStoppedException ex)
+        {
+            Assert.Contains("请求次数上限", ex.Message);
+            Assert.Equal(0, calls);
+        }
+    }
+
+    public static async Task InitialTokens_AlreadyExceeded_RunAsyncStopsImmediately()
+    {
+        var guard = new SessionBudgetGuard(maxTokens: 500, initialTokens: 600);
+        var calls = 0;
+        try
+        {
+            await AutoPlayRecovery.RunAsync(
+                turn: token =>
+                {
+                    calls++;
+                    return Task.FromResult(new AgentTurnResult { Acted = "play_card", RequestsSpent = 1 });
+                },
+                report: _ => { },
+                cancellationToken: CancellationToken.None,
+                delay: (ts, token) => Task.CompletedTask,
+                budgetGuard: guard);
+
+            Assert.True(false, "Expected AutoPlayStoppedException was not thrown.");
+        }
+        catch (AutoPlayStoppedException ex)
+        {
+            Assert.Contains("Token 预算上限", ex.Message);
+            Assert.Equal(0, calls);
+        }
+    }
+
+    public static void Settings_CreateBudgetGuard_CarriesInitialCounters()
+    {
+        var settings = new Config.AgentSettings
+        {
+            MaxSessionTokens = 2000,
+            MaxSessionRequests = 5
+        };
+        var guard = settings.CreateBudgetGuard(initialTokens: 350, initialRequests: 2);
+        Assert.Equal(2000, guard.MaxTokens);
+        Assert.Equal(5, guard.MaxRequests);
+        Assert.Equal(350, guard.ConsumedTokens);
+        Assert.Equal(2, guard.RequestCount);
+    }
 }

--- a/STS2AIAgent.Tests/SessionBudgetGuardTests.cs
+++ b/STS2AIAgent.Tests/SessionBudgetGuardTests.cs
@@ -1,0 +1,106 @@
+namespace STS2AIAgent.Tests;
+
+using STS2AIAgent.Agent;
+using STS2AIAgent.Llm;
+
+internal static class SessionBudgetGuardTests
+{
+    public static void NoLimit_NeverStops()
+    {
+        var guard = new SessionBudgetGuard();
+        Assert.False(guard.HasLimit);
+
+        var stop1 = guard.Record(5000, 10);
+        Assert.Null(stop1);
+        Assert.Equal(5000, guard.ConsumedTokens);
+        Assert.Equal(10, guard.RequestCount);
+
+        var result = new AgentTurnResult
+        {
+            Acted = "play_card",
+            Usage = new LlmUsage { PromptTokens = 100, CompletionTokens = 20, TotalTokens = 120 },
+            RequestsSpent = 1
+        };
+        var stop2 = guard.Observe(result);
+        Assert.Null(stop2);
+        Assert.Equal(5120, guard.ConsumedTokens);
+        Assert.Equal(11, guard.RequestCount);
+    }
+
+    public static void MaxTokens_StopsWhenExceeded()
+    {
+        var guard = new SessionBudgetGuard(maxTokens: 1000);
+        Assert.True(guard.HasLimit);
+
+        var res1 = new AgentTurnResult
+        {
+            Acted = "play_card",
+            Usage = new LlmUsage { TotalTokens = 800 },
+            RequestsSpent = 1
+        };
+        Assert.Null(guard.Observe(res1));
+
+        var res2 = new AgentTurnResult
+        {
+            Acted = "end_turn",
+            Usage = new LlmUsage { TotalTokens = 250 },
+            RequestsSpent = 1
+        };
+        var stop = guard.Observe(res2);
+        Assert.NotNull(stop);
+        Assert.Contains("Token 预算上限", stop);
+        Assert.Contains("1,050/1,000", stop);
+    }
+
+    public static void MaxRequests_StopsEvenWithoutUsage()
+    {
+        var guard = new SessionBudgetGuard(maxRequests: 3);
+        Assert.True(guard.HasLimit);
+
+        var res1 = new AgentTurnResult { Acted = "choose_map_node", RequestsSpent = 1 };
+        Assert.Null(guard.Observe(res1));
+
+        var res2 = new AgentTurnResult { Acted = "play_card", RequestsSpent = 1 };
+        Assert.Null(guard.Observe(res2));
+
+        var res3 = new AgentTurnResult { Acted = "end_turn", RequestsSpent = 1 };
+        var stop = guard.Observe(res3);
+        Assert.NotNull(stop);
+        Assert.Contains("请求次数上限", stop);
+        Assert.Contains("3/3", stop);
+    }
+
+    public static async Task Recovery_AutoPlayStopsOnBudgetExceeded()
+    {
+        var guard = new SessionBudgetGuard(maxRequests: 2);
+        var calls = 0;
+        var reported = new List<AgentTurnResult>();
+
+        try
+        {
+            await AutoPlayRecovery.RunAsync(
+                turn: token =>
+                {
+                    calls++;
+                    return Task.FromResult(new AgentTurnResult
+                    {
+                        Acted = "play_card",
+                        RequestsSpent = 1,
+                        Usage = new LlmUsage { TotalTokens = 50 }
+                    });
+                },
+                report: res => reported.Add(res),
+                cancellationToken: CancellationToken.None,
+                delay: (ts, token) => Task.CompletedTask,
+                budgetGuard: guard);
+
+            Assert.True(false, "Expected AutoPlayStoppedException was not thrown.");
+        }
+        catch (AutoPlayStoppedException ex)
+        {
+            Assert.Contains("请求次数上限", ex.Message);
+            Assert.Equal(2, calls);
+            Assert.Equal(2, reported.Count);
+        }
+    }
+}

--- a/STS2AIAgent.Tests/TestRunner.cs
+++ b/STS2AIAgent.Tests/TestRunner.cs
@@ -164,6 +164,10 @@ internal static class TestRunner
         yield return ("Budget.MaxTokens", () => Task.Run(SessionBudgetGuardTests.MaxTokens_StopsWhenExceeded));
         yield return ("Budget.MaxRequests", () => Task.Run(SessionBudgetGuardTests.MaxRequests_StopsEvenWithoutUsage));
         yield return ("Budget.RecoveryStops", SessionBudgetGuardTests.Recovery_AutoPlayStopsOnBudgetExceeded);
+        yield return ("Budget.ResumePreservesCumulativeUsage", () => Task.Run(SessionBudgetGuardTests.InitialCounters_ResumePreservesCumulativeUsage));
+        yield return ("Budget.ExceededRequestsStopsImmediately", SessionBudgetGuardTests.InitialCounters_AlreadyExceeded_RunAsyncStopsImmediately);
+        yield return ("Budget.ExceededTokensStopsImmediately", SessionBudgetGuardTests.InitialTokens_AlreadyExceeded_RunAsyncStopsImmediately);
+        yield return ("Budget.SettingsCarriesInitialCounters", () => Task.Run(SessionBudgetGuardTests.Settings_CreateBudgetGuard_CarriesInitialCounters));
         yield return ("GameData.DetectScene", () => Task.Run(GameDataFilterTests.DetectScene_MatchesGuidedMcpRules));
         yield return ("GameData.ProjectRelevant", () => Task.Run(GameDataFilterTests.ProjectRelevant_KeepsCombatCardFields));
         yield return ("PlayIntent.Detect", () => Task.Run(PlayIntentTests.DetectsPlayPhrasesAndIgnoresQuestions));

--- a/STS2AIAgent.Tests/TestRunner.cs
+++ b/STS2AIAgent.Tests/TestRunner.cs
@@ -157,6 +157,13 @@ internal static class TestRunner
         yield return ("OpenAI.PostBody", OpenAiCompatibleClientTests.CompleteAsync_PostsOpenAiCompatibleBody);
         yield return ("OpenAI.DeepSeekExtraBody", OpenAiCompatibleClientTests.CompleteAsync_PostsDeepSeekThinkingInExtraBody);
         yield return ("OpenAI.ParseSse", () => Task.Run(OpenAiCompatibleClientTests.ParseSse_AccumulatesContentAndToolCalls));
+        yield return ("OpenAI.ParseCompletionUsage", () => Task.Run(OpenAiCompatibleClientTests.ParseCompletion_ReadsUsage));
+        yield return ("OpenAI.ParseSseUsage", () => Task.Run(OpenAiCompatibleClientTests.ParseSse_ReadsUsageFromEndChunk));
+        yield return ("OpenAI.LlmUsageMath", () => Task.Run(OpenAiCompatibleClientTests.LlmUsage_CombineAndAdd));
+        yield return ("Budget.NoLimit", () => Task.Run(SessionBudgetGuardTests.NoLimit_NeverStops));
+        yield return ("Budget.MaxTokens", () => Task.Run(SessionBudgetGuardTests.MaxTokens_StopsWhenExceeded));
+        yield return ("Budget.MaxRequests", () => Task.Run(SessionBudgetGuardTests.MaxRequests_StopsEvenWithoutUsage));
+        yield return ("Budget.RecoveryStops", SessionBudgetGuardTests.Recovery_AutoPlayStopsOnBudgetExceeded);
         yield return ("GameData.DetectScene", () => Task.Run(GameDataFilterTests.DetectScene_MatchesGuidedMcpRules));
         yield return ("GameData.ProjectRelevant", () => Task.Run(GameDataFilterTests.ProjectRelevant_KeepsCombatCardFields));
         yield return ("PlayIntent.Detect", () => Task.Run(PlayIntentTests.DetectsPlayPhrasesAndIgnoresQuestions));

--- a/STS2AIAgent/Agent/AgentLoop.cs
+++ b/STS2AIAgent/Agent/AgentLoop.cs
@@ -72,7 +72,9 @@ internal sealed class AgentLoop
             tools,
             allowAct,
             stopAfterAct: false,
-            cancellationToken);
+            cancellationToken,
+            initialUsage: visionNote.Usage,
+            initialRequests: visionNote.RequestsSpent);
     }
 
     public async Task<AgentTurnResult> PlayOnceAsync(CancellationToken cancellationToken, Action<string>? checkState = null)
@@ -87,7 +89,8 @@ internal sealed class AgentLoop
             {
                 Error = "Timed out waiting for an actionable state.",
                 WaitingForGame = true,
-                ToolRounds = 0
+                ToolRounds = 0,
+                RequestsSpent = 0
             };
         }
 
@@ -127,7 +130,9 @@ internal sealed class AgentLoop
             allowAct: true,
             stopAfterAct: true,
             cancellationToken,
-            checkState);
+            checkState,
+            initialUsage: visionNote.Usage,
+            initialRequests: visionNote.RequestsSpent);
     }
 
     public async Task<string> TestConnectionAsync(CancellationToken cancellationToken)
@@ -145,7 +150,9 @@ internal sealed class AgentLoop
         bool allowAct,
         bool stopAfterAct,
         CancellationToken cancellationToken,
-        Action<string>? checkState = null)
+        Action<string>? checkState = null,
+        LlmUsage? initialUsage = null,
+        int initialRequests = 0)
     {
         var client = _factory.Create(resolved.Endpoint);
         string? lastText = null;
@@ -154,6 +161,8 @@ internal sealed class AgentLoop
         string? actResult = null;
         string? lastActError = null;
         var rounds = 0;
+        var accumulatedUsage = initialUsage;
+        var requestsSpent = initialRequests;
 
         for (var round = 0; round < MaxToolRounds; round++)
         {
@@ -171,7 +180,12 @@ internal sealed class AgentLoop
             LlmCompletion completion;
             try
             {
+                requestsSpent++;
                 completion = await client.CompleteAsync(request, cancellationToken);
+                if (completion.Usage != null)
+                {
+                    accumulatedUsage = LlmUsage.Combine(accumulatedUsage, completion.Usage);
+                }
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -187,7 +201,9 @@ internal sealed class AgentLoop
                     ActResultJson = actResult,
                     Error = ex.Message,
                     RequiresConfiguration = ex is LlmException { StatusCode: >= 400 and < 500 and not 408 and not 429 },
-                    ToolRounds = rounds
+                    ToolRounds = rounds,
+                    Usage = accumulatedUsage,
+                    RequestsSpent = requestsSpent
                 };
             }
 
@@ -214,7 +230,9 @@ internal sealed class AgentLoop
                                 Reasoning = lastReasoning,
                                 Acted = acted,
                                 ActResultJson = actResult,
-                                ToolRounds = rounds
+                                ToolRounds = rounds,
+                                Usage = accumulatedUsage,
+                                RequestsSpent = requestsSpent
                             };
                         }
                     }
@@ -235,7 +253,9 @@ internal sealed class AgentLoop
                     Acted = acted,
                     ActResultJson = actResult,
                     Error = acted == null ? lastActError : null,
-                    ToolRounds = rounds
+                    ToolRounds = rounds,
+                    Usage = accumulatedUsage,
+                    RequestsSpent = requestsSpent
                 };
             }
 
@@ -272,7 +292,9 @@ internal sealed class AgentLoop
                                 Reasoning = lastReasoning,
                                 Acted = acted,
                                 ActResultJson = actResult,
-                                ToolRounds = rounds
+                                ToolRounds = rounds,
+                                Usage = accumulatedUsage,
+                                RequestsSpent = requestsSpent
                             };
                         }
                     }
@@ -298,11 +320,13 @@ internal sealed class AgentLoop
             Error = acted == null && lastActError != null
                 ? lastActError
                 : "Reached the tool-call round limit without a final answer.",
-            ToolRounds = rounds
+            ToolRounds = rounds,
+            Usage = accumulatedUsage,
+            RequestsSpent = requestsSpent
         };
     }
 
-    private async Task<(string? Caption, byte[]? Jpeg, bool AttachToPrimary)> TryDescribeOrAttachVisionAsync(
+    private async Task<(string? Caption, byte[]? Jpeg, bool AttachToPrimary, LlmUsage? Usage, int RequestsSpent)> TryDescribeOrAttachVisionAsync(
         ResolvedModel primary,
         AgentSettings settings,
         bool attachRequested,
@@ -310,13 +334,13 @@ internal sealed class AgentLoop
     {
         if (!attachRequested)
         {
-            return (null, null, false);
+            return (null, null, false, null, 0);
         }
 
         var vision = settings.TryResolveVisionModel();
         if (!primary.Model.SupportsVision && vision == null)
         {
-            return (null, null, false);
+            return (null, null, false, null, 0);
         }
 
         byte[]? jpeg;
@@ -331,17 +355,17 @@ internal sealed class AgentLoop
 
         if (jpeg == null || jpeg.Length == 0)
         {
-            return (null, null, false);
+            return (null, null, false, null, 0);
         }
 
         if (primary.Model.SupportsVision)
         {
-            return (null, jpeg, true);
+            return (null, jpeg, true, null, 0);
         }
 
         if (vision == null)
         {
-            return (null, null, false);
+            return (null, null, false, null, 0);
         }
 
         try
@@ -362,11 +386,11 @@ internal sealed class AgentLoop
             var caption = string.IsNullOrWhiteSpace(completion.Content)
                 ? "Vision model returned an empty description."
                 : "Vision observation:\n" + completion.Content;
-            return (caption, jpeg, false);
+            return (caption, jpeg, false, completion.Usage, 1);
         }
         catch (Exception ex)
         {
-            return ("Vision model failed: " + ex.Message, jpeg, false);
+            return ("Vision model failed: " + ex.Message, jpeg, false, null, 1);
         }
     }
 

--- a/STS2AIAgent/Agent/AgentRuntime.cs
+++ b/STS2AIAgent/Agent/AgentRuntime.cs
@@ -213,6 +213,14 @@ internal sealed class AgentRuntime
             var reply = result.AssistantText;
             if (reply.Length > TeamConversation.MaxMessageLength) reply = reply[..TeamConversation.MaxMessageLength];
             _teamConversation.Add("assistant", reply);
+            lock (_gate)
+            {
+                if (result.Usage != null)
+                {
+                    _sessionUsage = LlmUsage.Combine(_sessionUsage, result.Usage) ?? LlmUsage.Empty;
+                }
+                _sessionRequests += result.RequestsSpent > 0 ? result.RequestsSpent : 1;
+            }
             RaiseChanged();
             return reply;
         }
@@ -416,6 +424,20 @@ internal sealed class AgentRuntime
             return;
         }
 
+        string? budgetBlocked = null;
+        lock (_gate)
+        {
+            var guard = _settings.CreateBudgetGuard(_sessionUsage.TotalTokens, _sessionRequests);
+            budgetBlocked = guard.CheckBudget();
+        }
+
+        if (budgetBlocked != null)
+        {
+            AddHistory("user", text);
+            AddHistory("assistant", budgetBlocked);
+            return;
+        }
+
         var prior = History;
         AddHistory("user", text);
         SetStatus("正在请求模型…");
@@ -447,7 +469,7 @@ internal sealed class AgentRuntime
                 {
                     _sessionUsage = LlmUsage.Combine(_sessionUsage, result.Usage) ?? LlmUsage.Empty;
                 }
-                _sessionRequests += result.RequestsSpent;
+                _sessionRequests += result.RequestsSpent > 0 ? result.RequestsSpent : 1;
             }
 
             var reply = result.Error != null
@@ -622,7 +644,7 @@ internal sealed class AgentRuntime
         SessionBudgetGuard? budgetGuard;
         lock (_gate)
         {
-            budgetGuard = _settings.CreateBudgetGuard();
+            budgetGuard = _settings.CreateBudgetGuard(_sessionUsage.TotalTokens, _sessionRequests);
         }
 
         try
@@ -712,7 +734,7 @@ internal sealed class AgentRuntime
             {
                 _sessionUsage = LlmUsage.Combine(_sessionUsage, result.Usage) ?? LlmUsage.Empty;
             }
-            _sessionRequests += result.RequestsSpent;
+            _sessionRequests += result.RequestsSpent > 0 ? result.RequestsSpent : (result.WaitingForGame ? 0 : 1);
         }
 
         if (!string.IsNullOrWhiteSpace(result.Acted))

--- a/STS2AIAgent/Agent/AgentRuntime.cs
+++ b/STS2AIAgent/Agent/AgentRuntime.cs
@@ -40,6 +40,8 @@ internal sealed class AgentRuntime
     private string _mcpStatus = "MCP 未启动。外部 Agent 可走下方接入说明。";
     private string? _mcpUrl;
     private Process? _mcpProcess;
+    private LlmUsage _sessionUsage = LlmUsage.Empty;
+    private int _sessionRequests;
 
     public static AgentRuntime Instance => LazyInstance.Value;
 
@@ -132,6 +134,26 @@ internal sealed class AgentRuntime
     public string LastAction => _lastAction;
 
     public string LastThought => _lastThought;
+
+    public LlmUsage SessionUsage
+    {
+        get { lock (_gate) return _sessionUsage; }
+    }
+
+    public int SessionRequests
+    {
+        get { lock (_gate) return _sessionRequests; }
+    }
+
+    public void ResetSessionStats()
+    {
+        lock (_gate)
+        {
+            _sessionUsage = LlmUsage.Empty;
+            _sessionRequests = 0;
+        }
+        RaiseChanged();
+    }
 
     public string DualStatus => _dualStatus;
     public bool DualLaunching => _dualLaunching;
@@ -419,6 +441,15 @@ internal sealed class AgentRuntime
                 _turnGate.Release();
             }
 
+            lock (_gate)
+            {
+                if (result.Usage != null)
+                {
+                    _sessionUsage = LlmUsage.Combine(_sessionUsage, result.Usage) ?? LlmUsage.Empty;
+                }
+                _sessionRequests += result.RequestsSpent;
+            }
+
             var reply = result.Error != null
                 ? result.Error
                 : string.IsNullOrWhiteSpace(result.AssistantText) ? "(无文本回复)" : result.AssistantText;
@@ -588,6 +619,12 @@ internal sealed class AgentRuntime
     private async Task AutoPlayLoopAsync(CancellationToken cancellationToken)
     {
         var boundary = new CurrentRunBoundary();
+        SessionBudgetGuard? budgetGuard;
+        lock (_gate)
+        {
+            budgetGuard = _settings.CreateBudgetGuard();
+        }
+
         try
         {
             await AutoPlayRecovery.RunAsync(async token =>
@@ -602,7 +639,7 @@ internal sealed class AgentRuntime
                     _turnGate.Release();
                 }
 
-            }, ApplyPlayResult, cancellationToken);
+            }, ApplyPlayResult, cancellationToken, delay: null, budgetGuard: budgetGuard);
         }
         finally { RaiseChanged(); }
     }
@@ -669,6 +706,15 @@ internal sealed class AgentRuntime
 
     private void ApplyPlayResult(AgentTurnResult result)
     {
+        lock (_gate)
+        {
+            if (result.Usage != null)
+            {
+                _sessionUsage = LlmUsage.Combine(_sessionUsage, result.Usage) ?? LlmUsage.Empty;
+            }
+            _sessionRequests += result.RequestsSpent;
+        }
+
         if (!string.IsNullOrWhiteSpace(result.Acted))
         {
             _lastAction = result.Acted;

--- a/STS2AIAgent/Agent/AutoPlayRecovery.cs
+++ b/STS2AIAgent/Agent/AutoPlayRecovery.cs
@@ -32,7 +32,8 @@ internal sealed class AutoPlayRecovery
         Func<CancellationToken, Task<AgentTurnResult>> turn,
         Action<AgentTurnResult> report,
         CancellationToken cancellationToken,
-        Func<TimeSpan, CancellationToken, Task>? delay = null)
+        Func<TimeSpan, CancellationToken, Task>? delay = null,
+        SessionBudgetGuard? budgetGuard = null)
     {
         var recovery = new AutoPlayRecovery();
         delay ??= Task.Delay;
@@ -46,6 +47,11 @@ internal sealed class AutoPlayRecovery
             catch (Exception ex) { result = new AgentTurnResult { Error = ex.Message }; }
             cancellationToken.ThrowIfCancellationRequested();
             report(result);
+            if (budgetGuard != null)
+            {
+                var budgetReason = budgetGuard.Observe(result);
+                if (budgetReason != null) throw new AutoPlayStoppedException(budgetReason);
+            }
             var next = recovery.Observe(result);
             if (next.StopReason != null) throw new AutoPlayStoppedException(next.StopReason);
             if (next.Delay > TimeSpan.Zero) await delay(next.Delay, cancellationToken);

--- a/STS2AIAgent/Agent/AutoPlayRecovery.cs
+++ b/STS2AIAgent/Agent/AutoPlayRecovery.cs
@@ -37,6 +37,14 @@ internal sealed class AutoPlayRecovery
     {
         var recovery = new AutoPlayRecovery();
         delay ??= Task.Delay;
+        if (budgetGuard != null)
+        {
+            var initialExceeded = budgetGuard.CheckBudget();
+            if (initialExceeded != null)
+            {
+                throw new AutoPlayStoppedException(initialExceeded);
+            }
+        }
         while (true)
         {
             cancellationToken.ThrowIfCancellationRequested();

--- a/STS2AIAgent/Agent/IGameBridge.cs
+++ b/STS2AIAgent/Agent/IGameBridge.cs
@@ -1,3 +1,5 @@
+using STS2AIAgent.Llm;
+
 namespace STS2AIAgent.Agent;
 
 internal interface IGameBridge
@@ -50,6 +52,10 @@ internal sealed class AgentTurnResult
     public bool RequiresConfiguration { get; init; }
 
     public int ToolRounds { get; init; }
+
+    public LlmUsage? Usage { get; init; }
+
+    public int RequestsSpent { get; init; }
 }
 
 internal sealed class ChatTurn

--- a/STS2AIAgent/Agent/SessionBudgetGuard.cs
+++ b/STS2AIAgent/Agent/SessionBudgetGuard.cs
@@ -12,13 +12,30 @@ internal sealed class SessionBudgetGuard
 
     public int RequestCount { get; private set; }
 
-    public SessionBudgetGuard(int? maxTokens = null, int? maxRequests = null)
+    public SessionBudgetGuard(int? maxTokens = null, int? maxRequests = null, int initialTokens = 0, int initialRequests = 0)
     {
         MaxTokens = maxTokens is > 0 ? maxTokens : null;
         MaxRequests = maxRequests is > 0 ? maxRequests : null;
+        ConsumedTokens = Math.Max(0, initialTokens);
+        RequestCount = Math.Max(0, initialRequests);
     }
 
     public bool HasLimit => MaxTokens.HasValue || MaxRequests.HasValue;
+
+    public string? CheckBudget()
+    {
+        if (MaxRequests.HasValue && RequestCount >= MaxRequests.Value)
+        {
+            return $"已达到会话请求次数上限（{RequestCount}/{MaxRequests.Value} 次），已自动停止游玩。";
+        }
+
+        if (MaxTokens.HasValue && ConsumedTokens >= MaxTokens.Value)
+        {
+            return $"已达到会话 Token 预算上限（{ConsumedTokens:N0}/{MaxTokens.Value:N0} tokens），已自动停止游玩。";
+        }
+
+        return null;
+    }
 
     public string? Observe(AgentTurnResult result)
     {
@@ -31,17 +48,6 @@ internal sealed class SessionBudgetGuard
     {
         ConsumedTokens += tokensAdded;
         RequestCount += requestsAdded;
-
-        if (MaxRequests.HasValue && RequestCount >= MaxRequests.Value)
-        {
-            return $"已达到会话请求次数上限（{RequestCount}/{MaxRequests.Value} 次），已自动停止游玩。";
-        }
-
-        if (MaxTokens.HasValue && ConsumedTokens >= MaxTokens.Value)
-        {
-            return $"已达到会话 Token 预算上限（{ConsumedTokens:N0}/{MaxTokens.Value:N0} tokens），已自动停止游玩。";
-        }
-
-        return null;
+        return CheckBudget();
     }
 }

--- a/STS2AIAgent/Agent/SessionBudgetGuard.cs
+++ b/STS2AIAgent/Agent/SessionBudgetGuard.cs
@@ -1,0 +1,47 @@
+namespace STS2AIAgent.Agent;
+
+using STS2AIAgent.Llm;
+
+internal sealed class SessionBudgetGuard
+{
+    public int? MaxTokens { get; }
+
+    public int? MaxRequests { get; }
+
+    public int ConsumedTokens { get; private set; }
+
+    public int RequestCount { get; private set; }
+
+    public SessionBudgetGuard(int? maxTokens = null, int? maxRequests = null)
+    {
+        MaxTokens = maxTokens is > 0 ? maxTokens : null;
+        MaxRequests = maxRequests is > 0 ? maxRequests : null;
+    }
+
+    public bool HasLimit => MaxTokens.HasValue || MaxRequests.HasValue;
+
+    public string? Observe(AgentTurnResult result)
+    {
+        var tokens = result.Usage?.TotalTokens ?? 0;
+        var requests = result.RequestsSpent > 0 ? result.RequestsSpent : (result.WaitingForGame ? 0 : 1);
+        return Record(tokens, requests);
+    }
+
+    public string? Record(int tokensAdded, int requestsAdded)
+    {
+        ConsumedTokens += tokensAdded;
+        RequestCount += requestsAdded;
+
+        if (MaxRequests.HasValue && RequestCount >= MaxRequests.Value)
+        {
+            return $"已达到会话请求次数上限（{RequestCount}/{MaxRequests.Value} 次），已自动停止游玩。";
+        }
+
+        if (MaxTokens.HasValue && ConsumedTokens >= MaxTokens.Value)
+        {
+            return $"已达到会话 Token 预算上限（{ConsumedTokens:N0}/{MaxTokens.Value:N0} tokens），已自动停止游玩。";
+        }
+
+        return null;
+    }
+}

--- a/STS2AIAgent/Config/AgentSettings.cs
+++ b/STS2AIAgent/Config/AgentSettings.cs
@@ -34,9 +34,9 @@ internal sealed class AgentSettings
 
     public int? MaxSessionRequests { get; set; }
 
-    public STS2AIAgent.Agent.SessionBudgetGuard CreateBudgetGuard()
+    public STS2AIAgent.Agent.SessionBudgetGuard CreateBudgetGuard(int initialTokens = 0, int initialRequests = 0)
     {
-        return new STS2AIAgent.Agent.SessionBudgetGuard(MaxSessionTokens, MaxSessionRequests);
+        return new STS2AIAgent.Agent.SessionBudgetGuard(MaxSessionTokens, MaxSessionRequests, initialTokens, initialRequests);
     }
 
     public LlmModelConfig? FindModel(string? modelId)

--- a/STS2AIAgent/Config/AgentSettings.cs
+++ b/STS2AIAgent/Config/AgentSettings.cs
@@ -30,6 +30,15 @@ internal sealed class AgentSettings
 
     public int McpPort { get; set; } = 8765;
 
+    public int? MaxSessionTokens { get; set; }
+
+    public int? MaxSessionRequests { get; set; }
+
+    public STS2AIAgent.Agent.SessionBudgetGuard CreateBudgetGuard()
+    {
+        return new STS2AIAgent.Agent.SessionBudgetGuard(MaxSessionTokens, MaxSessionRequests);
+    }
+
     public LlmModelConfig? FindModel(string? modelId)
     {
         if (string.IsNullOrWhiteSpace(modelId))
@@ -168,6 +177,16 @@ internal sealed class AgentSettings
         }
 
         McpServerPath = McpServerPath?.Trim() ?? string.Empty;
+
+        if (MaxSessionTokens is <= 0)
+        {
+            MaxSessionTokens = null;
+        }
+
+        if (MaxSessionRequests is <= 0)
+        {
+            MaxSessionRequests = null;
+        }
     }
 
     private ResolvedModel ResolveRoleModel(string? modelId, bool required, string roleName)

--- a/STS2AIAgent/Llm/LlmTypes.cs
+++ b/STS2AIAgent/Llm/LlmTypes.cs
@@ -84,6 +84,38 @@ internal sealed class LlmToolCall
     public required string ArgumentsJson { get; init; }
 }
 
+internal sealed class LlmUsage
+{
+    public int PromptTokens { get; init; }
+
+    public int CompletionTokens { get; init; }
+
+    public int TotalTokens { get; init; }
+
+    public static LlmUsage Empty => new();
+
+    public static LlmUsage operator +(LlmUsage left, LlmUsage right)
+    {
+        return new LlmUsage
+        {
+            PromptTokens = left.PromptTokens + right.PromptTokens,
+            CompletionTokens = left.CompletionTokens + right.CompletionTokens,
+            TotalTokens = (left.TotalTokens > 0 || right.TotalTokens > 0)
+                ? (left.TotalTokens + right.TotalTokens)
+                : (left.PromptTokens + right.PromptTokens + left.CompletionTokens + right.CompletionTokens)
+        };
+    }
+
+    public static LlmUsage? Combine(LlmUsage? left, LlmUsage? right)
+    {
+        if (left == null) return right;
+        if (right == null) return left;
+        return left + right;
+    }
+
+    public override string ToString() => $"Total: {TotalTokens} (Prompt: {PromptTokens}, Completion: {CompletionTokens})";
+}
+
 internal sealed class LlmCompletion
 {
     public string? Content { get; init; }
@@ -91,6 +123,8 @@ internal sealed class LlmCompletion
     public string? Reasoning { get; init; }
 
     public IReadOnlyList<LlmToolCall> ToolCalls { get; init; } = Array.Empty<LlmToolCall>();
+
+    public LlmUsage? Usage { get; init; }
 }
 
 internal sealed class LlmException : Exception

--- a/STS2AIAgent/Llm/OpenAiCompatibleClient.cs
+++ b/STS2AIAgent/Llm/OpenAiCompatibleClient.cs
@@ -74,6 +74,10 @@ internal sealed class OpenAiCompatibleClient : ILlmClient
         if (request.Stream)
         {
             body["stream"] = true;
+            body["stream_options"] = new Dictionary<string, object?>
+            {
+                ["include_usage"] = true
+            };
         }
 
         return await SendCompletionAsync(body, request.Stream, cancellationToken);
@@ -123,6 +127,7 @@ internal sealed class OpenAiCompatibleClient : ILlmClient
         catch (LlmException ex) when (stream && ShouldRetryWithoutStream(ex))
         {
             body["stream"] = false;
+            body.Remove("stream_options");
             return await SendOnceAsync(body, stream: false, cancellationToken);
         }
     }
@@ -185,6 +190,7 @@ internal sealed class OpenAiCompatibleClient : ILlmClient
         var content = new StringBuilder();
         var reasoning = new StringBuilder();
         var toolCalls = new SortedDictionary<int, SseToolCall>();
+        LlmUsage? usage = null;
 
         foreach (var rawLine in payload.Split('\n'))
         {
@@ -212,6 +218,11 @@ internal sealed class OpenAiCompatibleClient : ILlmClient
 
             using (document)
             {
+                if (ReadUsage(document.RootElement) is { } chunkUsage)
+                {
+                    usage = chunkUsage;
+                }
+
                 if (!document.RootElement.TryGetProperty("choices", out var choices) ||
                     choices.ValueKind != JsonValueKind.Array ||
                     choices.GetArrayLength() == 0)
@@ -260,7 +271,8 @@ internal sealed class OpenAiCompatibleClient : ILlmClient
                 Id = call.Id ?? string.Empty,
                 Name = call.Name ?? string.Empty,
                 ArgumentsJson = call.Arguments.Length == 0 ? "{}" : call.Arguments.ToString()
-            }).Where(call => !string.IsNullOrWhiteSpace(call.Id) && !string.IsNullOrWhiteSpace(call.Name)).ToArray()
+            }).Where(call => !string.IsNullOrWhiteSpace(call.Id) && !string.IsNullOrWhiteSpace(call.Name)).ToArray(),
+            Usage = usage
         };
     }
 
@@ -359,11 +371,13 @@ internal sealed class OpenAiCompatibleClient : ILlmClient
         var content = ReadContent(message);
         var reasoning = ReadOptionalString(message, "reasoning_content") ?? ReadOptionalString(message, "reasoning");
         var toolCalls = ReadToolCalls(message);
+        var usage = ReadUsage(root);
         return new LlmCompletion
         {
             Content = content,
             Reasoning = reasoning,
-            ToolCalls = toolCalls
+            ToolCalls = toolCalls,
+            Usage = usage
         };
     }
 
@@ -439,6 +453,39 @@ internal sealed class OpenAiCompatibleClient : ILlmClient
         }
 
         return content;
+    }
+
+    internal static LlmUsage? ReadUsage(JsonElement root)
+    {
+        if (!root.TryGetProperty("usage", out var usageElement) || usageElement.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        var prompt = ReadIntProperty(usageElement, "prompt_tokens");
+        var completion = ReadIntProperty(usageElement, "completion_tokens");
+        var total = ReadIntProperty(usageElement, "total_tokens");
+
+        if (prompt == 0 && completion == 0 && total == 0)
+        {
+            return null;
+        }
+
+        return new LlmUsage
+        {
+            PromptTokens = prompt,
+            CompletionTokens = completion,
+            TotalTokens = total > 0 ? total : (prompt + completion)
+        };
+    }
+
+    private static int ReadIntProperty(JsonElement element, string propertyName)
+    {
+        if (element.TryGetProperty(propertyName, out var prop) && prop.TryGetInt32(out var val))
+        {
+            return val;
+        }
+        return 0;
     }
 
     private static string FormatError(int statusCode, string payload)

--- a/STS2AIAgent/Ui/AgentOverlayHost.cs
+++ b/STS2AIAgent/Ui/AgentOverlayHost.cs
@@ -37,6 +37,9 @@ internal sealed class AgentOverlayHost
     private Label? _playScreen;
     private Label? _playAction;
     private Label? _playThought;
+    private Label? _playUsage;
+    private LineEdit? _maxTokensEdit;
+    private LineEdit? _maxRequestsEdit;
     private Label? _apiLabel;
     private Label? _dualStatus;
     private Button? _dualLaunchButton;
@@ -368,6 +371,8 @@ internal sealed class AgentOverlayHost
         page.AddChild(_playScreen);
         page.AddChild(_playAction);
         page.AddChild(_playThought);
+        _playUsage = UiFactory.Label("Token 消耗：-", 13, muted: true);
+        page.AddChild(_playUsage);
         page.AddChild(UiFactory.Row(_playToggle, _stepButton));
         page.AddChild(UiFactory.Label("自动游玩走 compact 状态和工具，与 MCP 相同，不需要视觉即可打完全部流程。对话默认只读；勾选「允许代打」或明确说「帮我打」才会执行动作。", 12, muted: true));
         return page;
@@ -475,6 +480,11 @@ internal sealed class AgentOverlayHost
         _settingsBody.AddChild(UiFactory.Label("视觉可选。不勾选「视觉」、不配外挂视觉时，仍用 compact 状态与工具打完全部内容。", 11, muted: true));
         _hotkeyEdit = UiFactory.Line(settings.Hotkey, "F8");
         _settingsBody.AddChild(Labeled("开关热键", _hotkeyEdit));
+        _maxTokensEdit = UiFactory.Line(settings.MaxSessionTokens?.ToString() ?? "", "不限（留空或0）");
+        _maxRequestsEdit = UiFactory.Line(settings.MaxSessionRequests?.ToString() ?? "", "不限（留空或0）");
+        _settingsBody.AddChild(Labeled("会话 Token 上限", _maxTokensEdit));
+        _settingsBody.AddChild(Labeled("会话请求上限", _maxRequestsEdit));
+        _settingsBody.AddChild(UiFactory.Label("预算护栏：达到上限时优雅停止自动游玩并提示，避免意外耗尽额度。", 11, muted: true));
         _settingsBody.AddChild(UiFactory.Button("重置窗口位置", ResetPlacement));
         _settingsBody.AddChild(UiFactory.Label("拖动标题栏可移动窗口，位置会保存。", 11, muted: true));
         _settingsBody.AddChild(UiFactory.Label("配置文件：" + AgentRuntime.Instance.SettingsPath, 11, muted: true));
@@ -676,6 +686,23 @@ internal sealed class AgentOverlayHost
         current.AttachStateInChat = _attachState?.ButtonPressed ?? true;
         current.AttachScreenshotInChat = _attachShot?.ButtonPressed ?? false;
         current.McpServerPath = _mcpPathEdit?.Text.Trim() ?? current.McpServerPath;
+        if (int.TryParse(_maxTokensEdit?.Text.Trim(), out var maxTokens) && maxTokens > 0)
+        {
+            current.MaxSessionTokens = maxTokens;
+        }
+        else
+        {
+            current.MaxSessionTokens = null;
+        }
+
+        if (int.TryParse(_maxRequestsEdit?.Text.Trim(), out var maxReqs) && maxReqs > 0)
+        {
+            current.MaxSessionRequests = maxReqs;
+        }
+        else
+        {
+            current.MaxSessionRequests = null;
+        }
         return current;
     }
 
@@ -714,7 +741,9 @@ internal sealed class AgentOverlayHost
             OverlayLeft = source.OverlayLeft,
             OverlayTop = source.OverlayTop,
             McpServerPath = source.McpServerPath,
-            McpPort = source.McpPort
+            McpPort = source.McpPort,
+            MaxSessionTokens = source.MaxSessionTokens,
+            MaxSessionRequests = source.MaxSessionRequests
         };
     }
 
@@ -855,6 +884,13 @@ internal sealed class AgentOverlayHost
         if (_playThought != null)
         {
             _playThought.Text = "思考：" + Trim(AgentRuntime.Instance.LastThought, 240);
+        }
+
+        if (_playUsage != null)
+        {
+            var usage = AgentRuntime.Instance.SessionUsage;
+            var reqs = AgentRuntime.Instance.SessionRequests;
+            _playUsage.Text = $"Token 消耗：{usage.TotalTokens:N0} (Prompt: {usage.PromptTokens:N0}, Completion: {usage.CompletionTokens:N0}) | 请求：{reqs} 次";
         }
 
         if (_playToggle != null)


### PR DESCRIPTION
## Summary

Implements Item 8 / P1 & core maturity metrics from `PRODUCT_PLAN_CURRENT.md`: Token usage tracking and hard session budget guards.

### Key Changes
1. **LLM Usage Parsing & Aggregation (`LlmTypes.cs`, `OpenAiCompatibleClient.cs`)**:
   - Added `LlmUsage` with prompt/completion/total tokens, null-safe `Combine`, and operator `+`.
   - Exposed `Usage` on `LlmCompletion`.
   - In `OpenAiCompatibleClient`: parsed usage from non-streaming JSON and streaming SSE chunks; included `stream_options: {"include_usage": true}` on streaming and safely removed on fallback retry.
2. **Turn-Level Tracking across Multi-Round Tools & Vision (`IGameBridge.cs`, `AgentLoop.cs`)**:
   - Added `Usage` and `RequestsSpent` to `AgentTurnResult`.
   - Aggregated usage and model request count across all tool rounds and secondary vision model calls in `AgentLoop`.
3. **Session Budget Guard (`SessionBudgetGuard.cs`, `AutoPlayRecovery.cs`, `AgentRuntime.cs`)**:
   - Created standalone, Godot-independent `SessionBudgetGuard` supporting configurable `MaxSessionTokens` and `MaxSessionRequests`.
   - Stops gracefully with `AutoPlayStoppedException` when limits are hit, providing transparent UI feedback.
   - When upstream endpoints omit usage, `MaxSessionRequests` provides a deterministic fallback ceiling.
   - Maintained cumulative session usage and request counters in `AgentRuntime`.
4. **Game Overlay Integration (`AgentSettings.cs`, `AgentOverlayHost.cs`)**:
   - Displayed live session token consumption (`Total (Prompt / Completion) | Requests`) in play view.
   - Added token and request budget limit configuration inputs to the settings page.
5. **Testing**:
   - Added `SessionBudgetGuardTests` (4 tests) and `OpenAiCompatibleClientTests` usage extraction tests (3 tests).
   - All 116 C# unit tests PASS.
   - All 48 Python MCP tests PASS.

## Summary by Sourcery

Add end-to-end LLM usage accounting and configurable session budget guards to prevent runaway token consumption and requests.

New Features:
- Track prompt, completion, and total token usage from both streaming and non-streaming LLM responses.
- Display cumulative session usage and request counts in the play view.
- Allow users to configure per-session token and request limits.

Bug Fixes:
- Prevent streaming-only options from being sent when retrying a request without streaming support.

Enhancements:
- Aggregate usage and request counts across tool rounds, vision calls, chat interactions, and autoplay sessions.
- Enforce configurable session budgets with graceful autoplay and chat blocking, including request-count fallback when providers omit usage.
- Preserve cumulative usage and request counters when creating budget guards for resumed sessions.

Tests:
- Add coverage for LLM usage extraction, usage aggregation, budget enforcement, autoplay recovery, and resumed-session limits.