### PR TITLE
docs: revamp README for usability with quickstart and developer guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,182 +1,243 @@
 # STS2 AI Agent
 
+<div align="center">
+
 https://github.com/user-attachments/assets/89353468-a299-4315-9516-e520bcbfbd4b
 
-中文版说明请见 [README.zh-CN.md](./README.zh-CN.md).
+**In-Game AI Companion & Autonomous Gameplay Mod for Slay the Spire 2**
 
-`STS2 AI Agent` is a Slay the Spire 2 mod with an in-game AI overlay. After you install the mod, you can configure model endpoints, chat, set per-model thinking intensity, let the model play, optionally attach vision, and launch a local second instance for co-op with the model.
+[中文说明 (README.zh-CN)](./README.zh-CN.md) • [Product Plan](./PRODUCT_PLAN_CURRENT.md) • [Co-op Delivery Tracker](./COOP_DELIVERY.md) • [API Docs](./docs/api.md) • [MCP Tools Guide](./mcp_server/README.md)
 
-The local HTTP API and MCP server remain available for developers and external clients.
+</div>
 
-- `STS2AIAgent`: in-game overlay + local HTTP API (`http://127.0.0.1:8080` by default)
-- `mcp_server`: optional MCP wrapper around that API
+---
 
-Detailed MCP tool documentation lives in [mcp_server/README.md](./mcp_server/README.md). The in-game play loop follows the same state-first rules as [skills/sts2-mcp-player/SKILL.md](./skills/sts2-mcp-player/SKILL.md).
+## 🌟 Key Highlights
 
-## Quick Start (Players)
+- 🎮 **In-Game Overlay UI**: Press **F8** at any time to open the configuration and control window directly inside the game—no external browser required.
+- 🤖 **Any OpenAI-Compatible Model**: Works seamlessly with official OpenAI, DeepSeek, SiliconFlow, OpenRouter, Ollama, LM Studio, vLLM, and more. Features per-model configurable thinking intensity.
+- 🃏 **Autonomous Auto-Play**: Text-only models can complete full runs (combat, card drafting, shops, events, pathing, capstones). Optional vision model support for screenshot context.
+- 👥 **Local Co-op AI Teammate**: One-click launch from the main menu spins up an isolated second game instance. You play your character; the AI teammate plays its own character in co-op mode.
+- 💬 **Live Team Conversation**: Talk to your AI teammate in natural language from the human window (e.g., "focus the right cultist", "let's take the shop path"). The AI replies and uses recent context in subsequent decisions.
+- 🛡️ **Session Budget Guards & Fault Recovery**: Accurate Token accounting with hard cutoff thresholds prevents runaway API bills. Autoplay automatically breaks after 3 consecutive failures with exponential backoff; halts when leaving the run.
+- 🔌 **Developer-Ready**: Built-in local HTTP API (`:8080`) and FastMCP server (`:8765`) allow external AI agents (Cursor, Claude Desktop, Codex) to interface directly with the game.
 
-### 1. Install The Mod
+---
 
-After downloading and extracting the release package, copy these files into your game's `mods/` directory:
+## 🚀 3-Minute Quick Start (Players)
+
+### Step 1: Install The Mod
+1. Download the latest release `.zip` from [GitHub Releases](https://github.com/CharTyr/STS2-Agent/releases).
+2. Extract the files into your game's `mods/` directory (create the folder if it does not exist):
+   ```text
+   STS2AIAgent.dll
+   STS2AIAgent.pck
+   mod_id.json
+   ```
+   > 💡 **Default Steam Directory**: `C:\Program Files (x86)\Steam\steamapps\common\Slay the Spire 2\mods\`
+
+### Step 2: Launch The Game & Open The Overlay
+1. Start *Slay the Spire 2* normally.
+2. Press **`F8`** (configurable) or click the grey **`AI`** tab on the right edge of the screen to open the Agent window.
+
+### Step 3: Configure Your LLM Endpoint
+1. In the overlay, navigate to the **Settings** tab.
+2. Click **Add Endpoint**:
+   - **Name**: e.g., `SiliconFlow` or `DeepSeek`
+   - **Base URL**: e.g., `https://api.siliconflow.cn/v1` or `https://api.deepseek.com/v1`
+   - **API Key**: Enter your API key (leave blank or enter dummy string for local Ollama/LM Studio).
+3. Select your added endpoint and assign models for **Chat Model** and **Play Model** (e.g., `deepseek-chat`).
+4. (Optional) Adjust the thinking intensity (**Off / Low / Medium / High**).
+5. *Cost Protection*: The built-in `SessionBudgetGuard` is active by default. You can adjust `Max Tokens` and `Max Requests` in Settings to protect your wallet.
+
+### Step 4: Play!
+
+#### Option A: Auto-Play
+- Start a standard single-player run.
+- Switch to the **Play** tab and click **Start Auto-Play** (or **Step Once**).
+- The model evaluates live state and dispatches cards, rewards, and route decisions autonomously.
+
+#### Option B: Co-op With An AI Teammate (Recommended!)
+- Go to the game's **Main Menu**.
+- Switch to the **AI Teammate** tab and click **Invite AI Teammate**.
+- A second game window will launch automatically and join the co-op lobby. You play your character; the AI controls its character!
+- Use the **Team Conversation** tab to coordinate strategy with your teammate in plain English or Chinese.
+
+---
+
+## 🎮 Core Features
+
+### 1. Autonomous Gameplay (Auto-Play)
+- **Compact State Engine**: Highly compressed, actionable representation covering cards, energy, intents, relics, HP, and potion slots. Text-only models can clear full runs.
+- **Optional Vision Augmentation**: When using a vision-capable model, screenshots are captured on demand to provide rich visual context.
+- **Real-Time Counters**: The overlay displays prompt, completion, total tokens, and request counts live.
+
+### 2. Dual-Instance Local Co-op
+- **Zero-Collision Isolation**: Propagates `--force-steam off` and increments `clientId` in offline mode. Automatically derives and clones `settings.companion.json` so both instances never write over each other's configurations or save slots.
+- **Team Conversation**:
+  - Chat directly with the AI teammate during multiplayer runs.
+  - Teammate replies using its play model, and recent discussions inform subsequent play decisions.
+  - Read-only safety: The chat interface never plays cards for the human or unpauses a paused companion.
+
+### 3. Interactive In-Game Advisor
+- Use the **Chat** tab to ask strategic advice.
+- Enable "Attach State" to pass full live game context (deck, relics, route) to the model for tactical guidance.
+
+---
+
+## 🛡️ Reliability & Safety Guards
+
+| Mechanism | Description | Player Benefit |
+|---|---|---|
+| **Session Budget Guard (`SessionBudgetGuard`)** | Accurate accounting across JSON and streaming SSE; hard configurable caps | Immediate cutoff with visual alerts when budget is reached—no runaway bills |
+| **Autoplay Circuit Breaker (`AutoPlayRecovery`)** | Automatic halt after 3 consecutive failures with 2s/4s exponential backoff | Prevents spin loops on unrecognized game dialogs or invalid choices |
+| **Immediate Config Error Exit** | Halts immediately upon receiving HTTP 401, 403, or 404 responses | Stops wasted token calls when API keys expire or are mistyped |
+| **Run Boundary Protection (`CurrentRunBoundary`)** | Scoped strictly to the active run's unique `runId` | Exiting a run, surrendering, or returning to lobby immediately stops autoplay |
+| **Process & Settings Isolation (`CoopLaunchPolicy`)** | Dedicated companion settings file and safe `clientId` stepping | Complete segregation between main and companion instances |
+
+---
+
+## 🛠️ Advanced Users & Developers Guide
+
+### System Architecture
 
 ```text
-STS2AIAgent.dll
-STS2AIAgent.pck
-mod_id.json
+┌───────────────────────────────────────────────────────────┐
+│                    Slay the Spire 2                       │
+│  ┌─────────────────────────────────────────────────────┐  │
+│  │             STS2AIAgent (C# Mod)                    │  │
+│  │  - Godot In-Game Overlay UI (F8)                    │  │
+│  │  - OpenAI-compatible Client & Budget Guard          │  │
+│  │  - Autoplay Decision Loop & Recovery Controller     │  │
+│  │  - GameThread Action / State Synchronizer           │  │
+│  │  - Local Dual-Instance Process Launcher             │  │
+│  └───────────────────────┬─────────────────────────────┘  │
+└──────────────────────────┼────────────────────────────────┘
+                           │ Local HTTP API (:8080)
+                           ▼
+┌───────────────────────────────────────────────────────────┐
+│              mcp_server (Python FastMCP)                  │
+│  - stdio / HTTP (:8765) Adapters                          │
+│  - Tool Profiles: guided / layered / full                 │
+│  - Bundled Metadata Lookups (Cards/Relics/Monsters/Events)│
+└──────────────────────────┬────────────────────────────────┘
+                           │ MCP Protocol
+                           ▼
+        External Agents (Cursor / Claude Desktop / Codex)
 ```
 
-The default Steam install path is usually:
+### Local HTTP API
 
-```text
-C:\Program Files (x86)\Steam\steamapps\common\Slay the Spire 2
-```
+The mod runs an embedded HTTP server on `http://127.0.0.1:8080` (with dynamic fallback on port contention):
 
-Your final layout should look like this:
+- `GET /health`: Health check, returns `api_port`, `instance_role`, and process PID.
+- `GET /state`: Full raw game state JSON.
+- `GET /actions/available`: Currently available legal actions and schema.
+- `GET /events/stream`: Real-time SSE stream for game events.
+- `POST /action`: Dispatch an action (e.g., `play_card`, `choose_map_node`, `proceed`).
 
-```text
-Slay the Spire 2/
-  mods/
-    STS2AIAgent.dll
-    STS2AIAgent.pck
-    mod_id.json
-```
+### FastMCP Server Integration
 
-### 2. Open The In-Game Agent Window
+To connect external agent IDEs (e.g. Cursor, Claude Desktop, Codex):
 
-Launch the game normally. Press **F8** (configurable) or the **AI** tab on the right edge.
+1. **Prerequisites**: Python 3.11+ and [uv](https://astral.sh/uv).
+2. **Run Server**:
+   - In-game: Click the one-click launch button on the **Connect** tab.
+   - Or run script:
+     ```powershell
+     # Windows (HTTP Mode, default http://127.0.0.1:8765/mcp)
+     powershell -ExecutionPolicy Bypass -File ".\scripts\start-mcp-network.ps1"
+     ```
+3. **Configure External Client** (e.g. `claude_desktop_config.json`):
+   ```json
+   {
+     "mcpServers": {
+       "sts2-ai-agent": {
+         "url": "http://127.0.0.1:8765/mcp"
+       }
+     }
+   }
+   ```
+4. **Tool Profiles**:
+   - `guided` (Default): Streamlined autonomous play tools (`health_check`, `get_game_state`, `get_available_actions`, `act`, `get_game_data_*`, `wait_until_actionable`).
+   - `layered`: Handoff and knowledge tracking tools for multi-agent planner/combat tiers.
+   - `full`: Complete legacy per-action tool surface.
 
-In the overlay:
+---
 
-1. **Settings**: add one or more OpenAI-compatible endpoints (OpenAI, DeepSeek, SiliconFlow, OpenRouter, Ollama, LM Studio, …), add models, then pick the conversation model. Optionally pick a play model and a vision model. Each model has its own thinking intensity (Off / Low / Medium / High).
-2. **Chat**: talk to the model. Enable “attach current state” or “attach screenshot” as needed.
-3. **Play**: start auto-play or step once. This uses compact live state and tools, the same contract as MCP. Vision is optional and not required to finish a run.
-4. **AI teammate**: invite an AI companion from the main menu. You control your character while the model joins and plays in a second game window. Inviting saves the current model settings; repeated clicks do not launch another companion process.
-5. **Connect**: start the optional HTTP MCP server with one click and copy the API / MCP URLs for Cursor, Claude, Codex, or a custom client.
+## 🧪 Building From Source & Automated Testing
 
-Settings default to `%AppData%/STS2AIAgent/settings.json`. When launching a local companion via the in-game UI, the launcher automatically isolates configuration by deriving and provisioning a companion-specific file (`settings.companion.json` seeded from the main instance) so concurrent settings writes never collide. You can also explicitly assign an isolated configuration file path to any instance by setting the `STS2_AGENT_SETTINGS_PATH` environment variable to an absolute path (or `STS2_COMPANION_SETTINGS_PATH` for the launcher companion override).
+All core logic can be verified **without running the game client**:
 
-Vision is optional extra context. Auto-play works with text-only models: compact `agent_view`, `get_game_state` / `get_available_actions` / `get_game_data_*` / `wait_until_actionable` / `act`. If you assign a vision-capable play model or a vision sidecar, screenshots are attached as supporting context only.
+### Build Mod
 
-Local dual-instance currently uses the game debug `multiplayer test` lobby. Steam may block a second process. The launcher does not kill your current game.
-
-After inviting a companion, use **AI teammate → Team conversation** in the human window to discuss targets, routes, or the teammate's choices. Replies use the companion's play model, and recent conversation informs future play decisions. Chat is read-only: it never plays the human's cards or resumes a paused companion. Messages wait for an in-progress action to finish and incur additional model requests.
-
-### 3. Optional: Confirm The HTTP API
-
-The overlay does not need a browser. Developers can still open:
-
-```text
-http://127.0.0.1:8080/health
-```
-
-`/health` reports `api_port`, `instance_role`, and `process_id`. If 8080 and nearby ports are unavailable, the mod tries dynamically allocated loopback ports. Use the actual address shown in the overlay. An explicit `STS2_API_PORT` stays fixed and fails clearly if unavailable.
-
-## Optional: MCP Server (Developers)
-
-MCP is not required for the in-game agent. The overlay **Connect** tab can start HTTP MCP (`http://127.0.0.1:8765/mcp`) if `uv` and the release `mcp_server` folder are present. You can also start it from these scripts:
-
-1. Install `Python 3.11+`
-2. Install `uv`
-
-Install `uv` on Windows:
+> ⚠️ **Close the game first** so the DLL file is not locked by the OS.
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://astral.sh/uv/install.ps1 | iex"
-```
-
-On macOS:
-
-```bash
-brew install uv
-```
-
-Then start the default `stdio` MCP server.
-
-Windows:
-
-```powershell
-powershell -ExecutionPolicy Bypass -File ".\scripts\start-mcp-stdio.ps1"
-```
-
-macOS / Linux:
-
-```bash
-./scripts/start-mcp-stdio.sh
-```
-
-If your client works better over HTTP:
-
-```powershell
-powershell -ExecutionPolicy Bypass -File ".\scripts\start-mcp-network.ps1"
-```
-
-Default MCP endpoint: `http://127.0.0.1:8765/mcp`
-
-## What The Project Can Do
-
-- In-game overlay: multi-endpoint / multi-model config, chat, per-model thinking intensity, auto-play, optional screenshot vision, local dual-instance co-op, one-click MCP for external agents
-- Reading live game state (compact `agent_view` now includes multiplayer lobby summaries)
-- Listing currently legal actions
-- Driving combat, rewards, shops, map routing, events, rest sites, chests, capstone selection, and bundle selection
-- Optional MCP over `stdio` or HTTP for external agents
-- Live game metadata for cards, relics, monsters, potions, and events via the Mod API
-
-See [mcp_server/README.md](./mcp_server/README.md) for the MCP tool surface.
-
-## FAQ
-
-### I installed the mod but there is no window
-
-Press **F8** or click the **AI** tab on the right edge. Confirm `STS2AIAgent.dll`, `STS2AIAgent.pck`, and `mod_id.json` are in the Steam game `mods/` directory.
-
-### `http://127.0.0.1:8080/health` Does Not Open
-
-Check these first:
-
-1. The game is actually running
-2. The three mod files are inside the game's `mods/` directory
-3. Check the actual API address in the overlay; port conflicts or Windows reserved ranges may require a different port
-4. You copied them into the Steam game directory, not the repository directory
-
-### The MCP Server Starts But Cannot Read Game State
-
-That usually means `mcp_server` is running, but the in-game mod is not connected. Confirm `/health` on the actual `api_port`.
-
-### Should I Enable Debug Actions?
-
-Usually no. Dual-instance from the overlay opens the debug multiplayer test scene internally and does not require you to expose `run_console_command` to MCP.
-
-## Building From Source
-
-Windows:
-
-```powershell
+# Windows
 powershell -ExecutionPolicy Bypass -File ".\scripts\build-mod.ps1" -Configuration Release
-```
 
-macOS / Linux:
-
-```bash
+# Linux / macOS
 ./scripts/build-mod.sh --configuration Release
 ```
 
-Core unit tests (no game required):
+### Run Tests
 
-```powershell
-dotnet run --project STS2AIAgent.Tests/STS2AIAgent.Tests.csproj
+- **C# Core Unit Tests (121 / 121 PASS)**:
+  ```powershell
+  dotnet run --project STS2AIAgent.Tests/STS2AIAgent.Tests.csproj
+  ```
+- **Python MCP Contract Tests (48 / 48 PASS)**:
+  ```powershell
+  cd mcp_server
+  uv run python -m unittest discover -s tests -v
+  ```
+- **Full Release Preflight Check**:
+  ```powershell
+  powershell -ExecutionPolicy Bypass -File ".\scripts\preflight-release.ps1"
+  ```
+
+---
+
+## ❓ FAQ
+
+### Q1: Pressing F8 does not open the overlay.
+1. Ensure `STS2AIAgent.dll`, `STS2AIAgent.pck`, and `mod_id.json` are inside `Slay the Spire 2/mods/`.
+2. Confirm files were copied into the Steam game installation directory, not the repository directory.
+3. Look for the grey **AI** tab on the right screen edge and click it directly.
+
+### Q2: Autoplay stopped unexpectedly. How do I resume?
+1. **Check Budget**: A notification will indicate if `MaxSessionTokens` or `MaxSessionRequests` was reached. Increase the limits in Settings or reset stats to continue.
+2. **Check API Status**: If your API key expired or network failed, the 3-failure circuit breaker safely halts the loop.
+3. **Check Game State**: Did you exit to the main menu? The run boundary protection stops autoplay upon leaving an active run.
+
+### Q3: Dual-instance companion window fails to start.
+1. Local co-op runs through the internal multiplayer test lobby.
+2. The launcher sets `--force-steam off` and steps `clientId` automatically. Check if third-party antivirus software blocked launching the child process.
+3. If ports are in use, the mod automatically selects an available fallback port.
+
+### Q4: Which models are recommended?
+- **Cloud Models**: DeepSeek-V3 / DeepSeek-R1, OpenAI GPT-4o / o3-mini, Claude 3.5 Sonnet.
+- **Local Models**: 7B~14B+ models with strong structured JSON tool-call abilities (e.g. Qwen2.5-7B/14B, Llama-3-8B) via Ollama or LM Studio.
+
+---
+
+## 📁 Repository Layout
+
+```text
+STS2-Agent/
+├── STS2AIAgent/          # C# In-Game Mod (Overlay UI, LLM Client, Decision Loop, Budget Guard)
+├── STS2AIAgent.Tests/    # Standalone C# Tests (121 tests, no game client required)
+├── mcp_server/           # FastMCP Server implementation and offline game data
+├── scripts/              # Build, packaging, startup, and preflight scripts
+├── skills/               # State-first gameplay skill specifications
+├── docs/                 # Developer reference and API documentation
+├── PRODUCT_PLAN_CURRENT.md # Official product plan & remote baseline assessment
+└── COOP_DELIVERY.md      # Co-op companion full delivery tracking
 ```
 
-More complete environment, path-discovery, and validation notes are in [build-and-env.md](./build-and-env.md).
-
-## Repository Layout
-
-- `STS2AIAgent/`: game mod source (overlay, LLM client, agent loop, HTTP API)
-- `STS2AIAgent.Tests/`: unit tests for settings, LLM JSON, and the agent loop
-- `mcp_server/`: optional MCP server source
-- `scripts/`: startup, build, and validation scripts
-- `docs/`: supporting documentation
-- `skills/`: companion skills for MCP clients
+---
 
 ## License
 
-This project is licensed under the GNU Affero General Public License v3.0 only (AGPL-3.0-only).
+This project is licensed under the [GNU Affero General Public License v3.0 (AGPL-3.0)](./LICENSE).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,182 +1,245 @@
 # STS2 AI Agent
 
+<div align="center">
+
 https://github.com/user-attachments/assets/89353468-a299-4315-9516-e520bcbfbd4b
 
-English README: [README.md](./README.md)
+**《杀戮尖塔 2》（Slay the Spire 2）游戏内 AI 助手与自主队友 Mod**
 
-`STS2 AI Agent` 是《Slay the Spire 2》的游戏内 AI Agent Mod。安装后即可在可视化窗口里配置模型端点、对话、按模型调整思考强度、让模型自动游玩。视觉是可选项：有视觉的模型可以看画面，没有视觉的模型也能靠 compact 状态和工具打完全部内容，也可以另配一个视觉模型当外挂。也可以从窗口拉起本地第二实例，和模型一起联机。
+[English README](./README.md) • [当前产品计划](./PRODUCT_PLAN_CURRENT.md) • [联机交付跟踪](./COOP_DELIVERY.md) • [API 文档](./docs/api.md) • [MCP 工具指南](./mcp_server/README.md)
 
-本地 HTTP API 与 MCP Server 仍然保留，给开发者和外部客户端用。
+</div>
 
-- `STS2AIAgent`：游戏内窗口 + 本地 HTTP API（默认 `http://127.0.0.1:8080`）
-- `mcp_server`：可选的 MCP 封装
+---
 
-MCP 工具说明见 [mcp_server/README.md](./mcp_server/README.md)。游戏内自动游玩沿用 [skills/sts2-mcp-player/SKILL.md](./skills/sts2-mcp-player/SKILL.md) 的状态优先规则。
+## 🌟 项目亮点
 
-## 快速开始（玩家）
+- 🎮 **游戏内悬浮窗界面**：在游戏内按 **F8** 即可随时唤起，无需切屏或打开浏览器。
+- 🤖 **支持任意主流大模型**：完美兼容 OpenAI、DeepSeek、硅基流动 (SiliconFlow)、OpenRouter、Ollama、LM Studio 等，支持按模型配置思考强度（Thinking Intensity）。
+- 🃏 **全自动自主游玩 (Auto-Play)**：纯文本模型即可完整打通战斗、选牌、商店、宝箱、路线抉择全流程；支持外挂视觉模型辅助。
+- 👥 **本地双开联机组队 (AI Teammate)**：一键在本地拉起副游戏窗口并自动组队，你操控自己的角色，AI 队友操作它的角色，共同爬塔。
+- 💬 **队伍实时自然语言交流**：在人类窗口直接向 AI 队友发战术指令（如“集火右怪”、“走商店路线”），AI 队友会回复并根据讨论调整出牌。
+- 🛡️ **会话成本硬护栏与异常熔断**：实时统计并限制 Token 消耗与请求数，防范失控扣费；连续 3 次异常自动安全熔断；离开对局自动刹车。
+- 🔌 **开发者友好**：内置本地 HTTP API (`:8080`) 与 FastMCP Server (`:8765`)，支持 Cursor、Claude Desktop、Codex 等外部 Agent 客户端一键接入。
 
-### 1. 安装 Mod
+---
 
-下载并解压 release 后，把下面这些文件复制到游戏目录 `mods/` 下：
+## 🚀 新手 3 分钟极速上手
+
+### 第 1 步：安装 Mod
+1. 前往 [GitHub Releases](https://github.com/CharTyr/STS2-Agent/releases) 下载最新的发布包（zip）。
+2. 解压后将以下三个文件复制到游戏的 `mods/` 文件夹中（若没有 `mods` 文件夹可新建）：
+   ```text
+   STS2AIAgent.dll
+   STS2AIAgent.pck
+   mod_id.json
+   ```
+   > 💡 **Steam 默认路径参考**：`C:\Program Files (x86)\Steam\steamapps\common\Slay the Spire 2\mods\`
+
+### 第 2 步：进入游戏并呼出界面
+1. 正常启动《杀戮尖塔 2》。
+2. 在任意游戏界面按下 **`F8`**（可在设置中修改），或点击屏幕右侧边缘灰色的 **`AI`** 标签，即可打开 Agent 控制悬浮窗。
+
+### 第 3 步：配置大模型（以 DeepSeek / 硅基流动 / 本地模型为例）
+1. 在悬浮窗顶部切换到 **「设置」** 页面。
+2. 点击 **「添加端点」**：
+   - **名称**：如 `SiliconFlow` 或 `DeepSeek`
+   - **Base URL**：例如 `https://api.siliconflow.cn/v1` 或 `https://api.deepseek.com/v1`
+   - **API Key**：填入你的模型 API 密钥（使用本地 Ollama/LM Studio 可留空或填任意值）
+3. 在下方选择你刚刚添加的端点，并在「对话模型」与「游玩模型」中选定对应模型（例如 `deepseek-chat` 或 `deepseek-ai/DeepSeek-V3`）。
+4. （可选）为模型设置思考强度（**Off / Low / Medium / High**）。
+5. *新手安心保障*：默认开启了「会话预算守卫」，在设置页面可看到 `Max Tokens` 与 `Max Requests`，防止产生意料外的模型调用费用。
+
+### 第 4 步：开始体验！
+
+#### 体验方式 A：单人自动代打
+- 开始一局正常的单人游戏。
+- 悬浮窗切换到 **「游玩」** 页面，点击 **「开始自动游玩」**（或点「单步执行」查看一步步决策）。
+- AI 会读取当前卡牌与场面，自动打出最优卡牌、选择奖励、规划路线。
+
+#### 体验方式 B：与 AI 队友双人联机（最推荐玩法！）
+- 回到游戏**主菜单**。
+- 悬浮窗切换到 **「AI 队友」** 页面，点击 **「邀请 AI 队友」**。
+- 系统会自动拉起第二个游戏实例并加入本地联机大厅！你控制主角色，AI 队友控制副角色。
+- 点击 **「队伍交流」** 标签，可以直接用文字和队友商量路线与集火策略。
+
+---
+
+## 🎮 核心玩法详解
+
+### 1. 自动游玩 (Auto-Play)
+- **纯文本模型全流程**：底层采用高压缩率且信息完备的 compact 状态（包含手牌、能量、怪物意图、遗物、血量等），无需具备视觉能力即可通关。
+- **可选视觉增强**：若配置了支持视觉的模型或外挂视觉模型，系统在需要时会自动截屏作为补充上下文辅助决策。
+- **实时看板**：游玩页面实时显示当前会话消耗的 Prompt Tokens、Completion Tokens、总 Token 数以及请求次数。
+
+### 2. 双人本地联机 (Co-op Companion)
+- **零干扰隔离启动**：离线模式下自动继承 `--force-steam off` 并分配增量 `clientId`；启动器自动为副实例派生并首次克隆独立的 `settings.companion.json` 配置文件。彻底杜绝两个实例共用存档或并发写入配置导致的踩踏与冲突。
+- **队伍交流机制 (Team Conversation)**：
+  - 在人类窗口直接向 AI 队友发起讨论（如：“这回合我全力防御，你来输出”、“下层我们走问号房”）。
+  - AI 队友使用游玩模型回复，并将近期的交流内容注入后续动作决策。
+  - 聊天为只读安全设计：绝不会擅自替人类玩家出牌，也不会替暂停状态的队友代打。
+
+### 3. AI 实时参谋 (Interactive Chat)
+- 切换到 **「对话」** 页面，可随时向模型请教游戏理解。
+- 勾选「附带当前状态」，大模型即可感知你当前的完整卡组、剩余生命与战局状态，提供针对性的构筑建议与出牌策略。
+
+---
+
+## 🛡️ 可靠性与安全护栏（玩得安心）
+
+| 安全机制 | 功能说明 | 对玩家的保障 |
+|---|---|---|
+| **会话预算硬护栏 (`SessionBudgetGuard`)** | 统一统计非流式与流式 SSE 使用量；支持设置 Token 与请求上限 | 超额时即刻硬性停止，并在 UI 上标红提示，彻底消除账单超支焦虑 |
+| **连续异常自动熔断 (`AutoPlayRecovery`)** | 连续 3 次空动作或决策异常时自动停止，并采用 2s / 4s 指数退避重试 | 遇到游戏未知卡死或模型输出不可行操作时自动刹车，不浪费费用 |
+| **不可重试错误即刻停止** | 识别 401（未授权）、403 等配置类 HTTP 错误时立即终止 | 避免 API 密钥填错后仍陷入无限死循环调用 |
+| **战局生命周期边界 (`CurrentRunBoundary`)** | 严格绑定当前对局 ID (`runId`) | 投降、通关、退出至主菜单或大厅时自动终止游玩，绝不跨局乱出牌 |
+| **双开环境安全隔离 (`CoopLaunchPolicy`)** | 自动隔离离线身份与副实例配置文件 | 双开不串存档、不覆盖设置，稳定流畅联机 |
+
+---
+
+## 🛠️ 高级用户与开发者指南
+
+### 系统架构
 
 ```text
-STS2AIAgent.dll
-STS2AIAgent.pck
-mod_id.json
+┌───────────────────────────────────────────────────────────┐
+│                    Slay the Spire 2                       │
+│  ┌─────────────────────────────────────────────────────┐  │
+│  │             STS2AIAgent (C# Mod)                    │  │
+│  │  - Godot In-Game Overlay UI (F8)                    │  │
+│  │  - OpenAI-compatible Client & Budget Guard          │  │
+│  │  - Autoplay Decision Loop & Recovery Controller     │  │
+│  │  - GameThread Action / State Synchronizer           │  │
+│  │  - Local Dual-Instance Process Launcher             │  │
+│  └───────────────────────┬─────────────────────────────┘  │
+└──────────────────────────┼────────────────────────────────┘
+                           │ 本地 HTTP API (:8080)
+                           ▼
+┌───────────────────────────────────────────────────────────┐
+│              mcp_server (Python FastMCP)                  │
+│  - stdio / HTTP (:8765) 适配器                             │
+│  - Tool Profiles: guided / layered / full                 │
+│  - 离线/内置游戏元数据检索 (Cards/Relics/Monsters/Events)   │
+└──────────────────────────┬────────────────────────────────┘
+                           │ MCP Protocol
+                           ▼
+        外部智能体 (Cursor / Claude Desktop / Codex)
 ```
 
-Steam 默认游戏目录通常是：
+### 开发者 HTTP API
 
-```text
-C:\Program Files (x86)\Steam\steamapps\common\Slay the Spire 2
-```
+Mod 默认在本地启动 HTTP 服务（默认端口 `8080`，遇冲突自动动态选择）：
 
-最终目录结构应当类似：
+- `GET /health`：服务健康检查，返回 `api_port`、`instance_role` 与进程 PID。
+- `GET /state`：获取完整原始游戏状态 JSON。
+- `GET /actions/available`：获取当前所有合法动作清单与参数 Schema。
+- `GET /events/stream`：订阅游戏状态转换的 SSE 长连接流。
+- `POST /action`：执行具体游戏动作（例如 `play_card`、`choose_map_node`、`proceed` 等）。
 
-```text
-Slay the Spire 2/
-  mods/
-    STS2AIAgent.dll
-    STS2AIAgent.pck
-    mod_id.json
-```
+### FastMCP 协议集成
 
-### 2. 打开游戏内 Agent 窗口
+若希望使用外部 AI 客户端（如 Cursor、Claude Desktop 等）直接接管游玩，可通过内置 FastMCP 服务连接：
 
-正常启动游戏。按 **F8**（可改）或点屏幕右侧的 **AI** 标签。
+1. **环境准备**：安装 Python 3.11+ 与 [uv](https://astral.sh/uv)。
+2. **启动服务**：
+   - 方式一：在游戏内悬浮窗 **「接入」** 页面点击一键启动。
+   - 方式二：通过脚本启动：
+     ```powershell
+     # Windows (HTTP 模式，默认 http://127.0.0.1:8765/mcp)
+     powershell -ExecutionPolicy Bypass -File ".\scripts\start-mcp-network.ps1"
+     ```
+3. **外部客户端配置**（以 `claude_desktop_config.json` 为例）：
+   ```json
+   {
+     "mcpServers": {
+       "sts2-ai-agent": {
+         "url": "http://127.0.0.1:8765/mcp"
+       }
+     }
+   }
+   ```
+4. **Tool Profile 说明**：
+   - `guided`（默认推荐）：提供精简的自主游玩接口 (`health_check`, `get_game_state`, `get_available_actions`, `act`, `get_game_data_*`, `wait_until_actionable`)。
+   - `layered`：面向主/副 Agent 分层协同，补充提供 Handoff 与战斗观察记录工具。
+   - `full`：全量暴露所有独立的 Legacy per-action 工具，适合细粒度测试。
 
-窗口里可以：
+---
 
-1. **设置**：添加多个 OpenAI 兼容端点（OpenAI / DeepSeek / 硅基流动 / OpenRouter / Ollama / LM Studio 等）和模型，选择主对话模型；可选游玩模型、外挂视觉模型。思考强度在每个模型上单独设置（Off / Low / Medium / High）。
-2. **对话**：和模型聊天。可勾选「附带当前状态」或「附带截图」。
-3. **游玩**：开始/暂停自动游玩，或单步。走 compact 状态和工具，与 MCP 相同；不需要视觉也能打完全部流程。
-4. **AI 队友**：在主菜单邀请 AI 一起爬塔。你操作自己的角色，模型在第二个游戏窗口中自动加入大厅并游玩。邀请前会保存当前模型设置；重复点击不会再启动一个队友进程。
-5. **接入**：一键启动 HTTP MCP，复制 API / MCP 地址，给 Cursor、Claude、Codex 或自写客户端用。
+## 🧪 源码构建与自动化测试
 
-配置默认保存在 `%AppData%/STS2AIAgent/settings.json`。通过游戏内 UI 启动本地 AI 队友时，启动器会自动为队友派生并同步初始化独立的配置文件（`settings.companion.json`），避免双实例并发写入冲突。若需为特定实例自定义配置文件位置，可设置环境变量 `STS2_AGENT_SETTINGS_PATH` 为绝对路径（亦可通过 `STS2_COMPANION_SETTINGS_PATH` 显式指定队友配置）。
+本项目拥有完善的端到端自动化单测套件，**所有核心逻辑均可脱离游戏客户端运行并验证**：
 
-视觉是可选的额外上下文。纯文本模型可以直接游玩：compact `agent_view` + `get_game_state` / `get_available_actions` / `get_game_data_*` / `wait_until_actionable` / `act`。如果给游玩模型勾了「视觉」，或另外配了外挂视觉模型，截图才会作为辅助信息附上。
+### 编译 Mod
 
-本地双开目前走游戏 debug 的 `multiplayer test` 大厅。Steam 可能阻止第二进程。启动器不会杀掉当前游戏。
-
-组队后可在主窗口 **AI 队友 → 队伍交流** 中商量目标、路线或询问队友的选择。回复来自队友使用的游玩模型；最近对话会进入后续游玩上下文。聊天只读，不会替人类玩家出牌，也不会恢复已暂停的队友。若队友正在行动，消息会等本次行动完成后处理。交流会产生额外模型请求。
-
-### 3. 可选：确认 HTTP API
-
-玩家不必打开浏览器。开发者仍可访问：
-
-```text
-http://127.0.0.1:8080/health
-```
-
-`/health` 会返回 `api_port`、`instance_role` 和 `process_id`。8080 及附近端口不可用时会尝试系统分配的动态端口；实际地址显示在窗口中。显式设置 `STS2_API_PORT` 时保持固定端口，失败会给出错误。
-
-## 可选：MCP Server（开发者）
-
-游戏内 Agent 不依赖 MCP。外部客户端可在 overlay **接入** 页一键启动 HTTP MCP，也可以继续用下面的脚本。
-
-1. 安装 `Python 3.11+`
-2. 安装 `uv`
-
-Windows 安装 `uv`：
+> ⚠️ **注意**：编译前必须**先关闭游戏**，否则 DLL 会被进程锁定无法写入。
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://astral.sh/uv/install.ps1 | iex"
-```
-
-macOS：
-
-```bash
-brew install uv
-```
-
-然后启动 `stdio` MCP。
-
-Windows：
-
-```powershell
-powershell -ExecutionPolicy Bypass -File ".\scripts\start-mcp-stdio.ps1"
-```
-
-macOS / Linux：
-
-```bash
-./scripts/start-mcp-stdio.sh
-```
-
-如果客户端更适合 HTTP：
-
-```powershell
-powershell -ExecutionPolicy Bypass -File ".\scripts\start-mcp-network.ps1"
-```
-
-默认 MCP 地址：`http://127.0.0.1:8765/mcp`
-
-## 这个项目现在能做什么
-
-- 游戏内窗口：多端点/多模型、对话、按模型思考强度、自动游玩、可选截图视觉、本地双开联机、一键启动 MCP 给外部 Agent
-- 读取游戏状态（compact `agent_view` 现含多人大厅摘要）
-- 获取当前可执行动作
-- 执行战斗、奖励、商店、地图、事件、休息点、宝箱、尖塔选择、Bundle 选择等操作
-- 可选 MCP（`stdio` 或 HTTP）给外部 Agent
-- 通过 Mod API 提供卡牌、遗物、敌人、药水、事件等实时元数据
-
-更细的 MCP 工具说明在 [mcp_server/README.md](./mcp_server/README.md)。
-
-## 常见问题
-
-### 装了 Mod 但看不到窗口
-
-按 **F8**，或点右侧 **AI** 标签。确认三个文件都在 Steam 游戏目录的 `mods/` 下。
-
-### `http://127.0.0.1:8080/health` 打不开
-
-优先检查：
-
-1. 游戏是否真的已经启动
-2. 三个 Mod 文件是否都在游戏 `mods/` 目录
-3. 窗口中显示的实际 API 地址；端口占用或 Windows 保留端口可能使其与 8080 不同
-4. 你放的是 Steam 游戏目录，不是仓库目录
-
-### MCP 能启动，但读不到游戏状态
-
-这通常表示 `mcp_server` 启动了，但游戏里的 Mod 没连上。请确认实际 `api_port` 上的 `/health`。
-
-### 要不要开 debug 动作
-
-正常使用不需要。窗口内双开会在内部打开 debug 多人大厅，不必把 `run_console_command` 暴露给 MCP。
-
-## 从源码构建
-
-Windows：
-
-```powershell
+# Windows
 powershell -ExecutionPolicy Bypass -File ".\scripts\build-mod.ps1" -Configuration Release
-```
 
-macOS / Linux：
-
-```bash
+# Linux / macOS
 ./scripts/build-mod.sh --configuration Release
 ```
+编译产物 `STS2AIAgent.dll` 与 `STS2AIAgent.pck` 会自动拷贝至游戏 `mods/` 目录。
 
-不依赖游戏的核心单测：
+### 运行自动化测试
 
-```powershell
-dotnet run --project STS2AIAgent.Tests/STS2AIAgent.Tests.csproj
+- **C# 核心单元测试（121 项全部通过）**：
+  ```powershell
+  dotnet run --project STS2AIAgent.Tests/STS2AIAgent.Tests.csproj
+  ```
+  涵盖会话预算守卫、自动恢复退避、战局边界拦截、离线双开隔离、网络端口自动后备、原生存档切换等。
+- **Python MCP 契约测试（48 项全部通过）**：
+  ```powershell
+  cd mcp_server
+  uv run python -m unittest discover -s tests -v
+  ```
+- **一键全量发布前预检**：
+  ```powershell
+  powershell -ExecutionPolicy Bypass -File ".\scripts\preflight-release.ps1"
+  ```
+
+---
+
+## ❓ 常见问题排查 (FAQ)
+
+### Q1: 进入游戏后按 F8 没有任何反应？
+1. 确认已将 `STS2AIAgent.dll`、`STS2AIAgent.pck` 和 `mod_id.json` 三个文件放进游戏的 `mods/` 文件夹。
+2. 确认复制到的是 Steam 游戏实际的安装目录，而不是从 Git 克隆的项目源码目录。
+3. 观察游戏主界面右侧屏幕边缘是否有半透明的灰色 **AI** 标签，若有可直接用鼠标点击展开。
+
+### Q2: 自动游玩突然停住了，怎么恢复？
+1. **检查是否达到预算上限**：悬浮窗中会显示明确的红字提示（如 `Session budget exceeded`）。若确认安全，可在「设置」中将 `Max Tokens` 或 `Max Requests` 调大，或重置统计后继续。
+2. **检查网络与 API Key**：若 API 额度不足或网络断开，恢复控制器在连续 3 次失败后会自动停止保护。
+3. **检查游戏状态**：是否退回了主菜单或联机大厅？战局边界保护会在离开战局时自动刹车。
+
+### Q3: 本地双开副窗口打不开或提示失败？
+1. 本地双开通过游戏内部的联机大厅进行对接。
+2. 启动器已自动配置 `--force-steam off` 与增量 `clientId`；部分杀毒软件可能会拦截子进程拉起，请加入信任列表。
+3. 若端口被占用，Mod 会自动寻找后续可用端口，请以悬浮窗显示的地址为准。
+
+### Q4: 推荐使用什么大模型？
+- **云端商业模型**：首选 DeepSeek-V3 / DeepSeek-R1、OpenAI GPT-4o / o3-mini、Claude 3.5 Sonnet。
+- **本地私有化模型**：使用 Ollama / LM Studio 部署 7B~14B 以上参数量、具备良好 JSON 工具调用能力的模型（如 Qwen2.5-7B/14B、Llama-3-8B 等）。
+
+---
+
+## 📁 仓库结构
+
+```text
+STS2-Agent/
+├── STS2AIAgent/          # C# 游戏内 Mod（Godot UI 悬浮窗、决策循环、预算守卫、HTTP 服务）
+├── STS2AIAgent.Tests/    # C# 核心单元测试（121 项，无游戏依赖）
+├── mcp_server/           # FastMCP Server 封装（Python）及离线游戏元数据
+├── scripts/              # 构建、部署、启动与全量预检脚本
+├── skills/               # 面向 MCP 外部 Agent 的策略 Skill 规范
+├── docs/                 # 开发设计文档与 API 接口参考
+├── PRODUCT_PLAN_CURRENT.md # 官方当前产品成熟度计划与基线评估
+└── COOP_DELIVERY.md      # AI 队友与联机双开交付全流程跟踪
 ```
 
-更完整的环境变量、路径探测和验证流程见 [build-and-env.md](./build-and-env.md)。
+---
 
-## 仓库结构
+## 开源协议
 
-- `STS2AIAgent/`：游戏 Mod 源码（窗口、LLM 客户端、Agent 循环、HTTP API）
-- `STS2AIAgent.Tests/`：设置、LLM JSON、Agent 循环单测
-- `mcp_server/`：可选 MCP Server 源码
-- `scripts/`：启动、构建、验证脚本
-- `docs/`：补充文档
-- `skills/`：给 MCP 客户端用的配套 Skill
-
-## License
-
-This project is licensed under the GNU Affero General Public License v3.0 only (AGPL-3.0-only).
+本项目采用 [GNU Affero General Public License v3.0 (AGPL-3.0)](./LICENSE) 协议开源。


### PR DESCRIPTION
## 概述

本 PR 全面重构并更新了中文与英文 README 文档（`README.zh-CN.md` 与 `README.md`），以**易用性与新手友好度**为核心方向，同时兼顾高级用户与开发者的架构理解需求。

---

## 主要改进

### 1. 面向新手与初次使用玩家（3 分钟极速上手）
- **清晰分步引导**：
  1. **安装**：说明如何下载 Release 并解压至 `mods/` 目录（附带默认路径与结构图）。
  2. **唤起**：指引游戏内按 **F8** 或点击屏幕边缘 **AI** 标签呼出悬浮窗。
  3. **配置**：详细以 DeepSeek、硅基流动、Ollama 等为例，说明如何填写端点、选择模型与调整思考强度。
  4. **两种核心玩法快速指引**：
     - 玩法 A：单人自动代打（进入对局 -> 点击开始自动游玩）。
     - 玩法 B：双人联机组队（主菜单 -> 点击邀请 AI 队友 -> 自动双开组队 + 队伍聊天沟通）。
- **新手成本安心提示**：说明内置会话预算守卫，消除失控扣费的后顾之忧。

### 2. 核心玩法与安全可靠性全景
- 细化自动游玩（纯文本全流程 + 可选视觉增强 + 实时用量看板）。
- 详述双人联机（账号与存档隔离、增量 `clientId`、派生 `settings.companion.json`、只读队伍战术交流）。
- 汇总可靠性设计清单：会话预算硬护栏、3 次连续异常指数退避熔断、战局生命周期边界保护、离线双开隔离。

### 3. 面向高级用户与开发者
- **系统架构全景图**（Godot Overlay -> C# Mod -> Local HTTP API :8080 -> FastMCP :8765 -> External Agents）。
- **开发者 HTTP API 端点清单**（`/health`, `/state`, `/actions/available`, `/events/stream`, `/action`）。
- **FastMCP 协议集成指南**（Cursor / Claude Desktop 配置文件范例、`guided` / `layered` / `full` Tool Profiles 说明）。
- **源码构建与自动化测试基准**（说明 121 项独立 C# 核心单测、48 项 Python MCP 测试与预检流程）。

---

## 验证
- 静态预检脚本 `scripts/preflight-release.ps1` 运行通过（Exit code 0）。
- 中英文文档结构严格对齐，链接格式有效。

## Summary by Sourcery

Improve the English and Chinese README documentation for new-player onboarding, core gameplay guidance, and developer integration.

Enhancements:
- Revamp the English and Chinese READMEs with a streamlined three-minute player quick start covering installation, overlay access, model configuration, and single-player or co-op usage.
- Expand user-facing documentation for autonomous gameplay, AI teammate co-op, team conversation, reliability safeguards, and troubleshooting.
- Add a consolidated developer guide documenting the system architecture, local HTTP API, FastMCP integration, tool profiles, repository layout, and source build workflows.

Documentation:
- Document automated validation workflows, including the C# and Python test suites and release preflight checks, in both language versions.