### PR TITLE
fix: close post-merge autoplay, budget, selection, and companion gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Fixed
+
+- Autoplay now rethrows run-boundary stops from `act` and re-checks compact state after `get_game_state` / `wait_until_actionable`, so leaving a run no longer burns extra model rounds.
+- Session request budgets are checked before each LLM round and shared with chat/teammate replies, not only after a finished autoplay turn.
+- Deck multi-select no longer confirms at `min_select`; cards report `selected`, and `confirm_selection` works on deck-grid screens.
+- Combat selection waits for action-queue readiness; settle timeouts return pending instead of a weaker `stable=true`.
+- Companion HTTP ports may fall back and are rediscovered by pid/port file; settings are recopied on every invite; offline launches always get a distinct `clientId`.
+- Companion bootstrap joins the host lobby and no longer runs `multiplayer test` itself.
+- Compact state now includes `native_profile_id` / `profiles[]`; the playbook tells the agent not to `switch_profile` unless asked.
+
 ### Added
 
 - Added session-scoped team chat from the human overlay to the launched AI companion. Team replies use the play model; recent conversation informs future play decisions without granting chat permission to execute actions.
@@ -16,7 +26,7 @@
 
 ### Validation
 
-- 63 core tests passed, including team-chat authorization, read-only behavior, context propagation, loopback HTTP and simulated excluded-range/bind-race cases; Release mod build passed. In-game co-op and visual verification remain pending for these changes.
+- Core tests cover run-boundary rethrow, in-flight request budgets, companion port-file discovery, settings reseed, and deck selected-card contracts. Live co-op and in-game selection still need a game session.
 
 ## v0.9.2 - 2026-08-31
 

--- a/STS2AIAgent.Tests/AgentLoopTests.cs
+++ b/STS2AIAgent.Tests/AgentLoopTests.cs
@@ -120,6 +120,95 @@ internal static class AgentLoopTests
         Assert.False(factory.LastRequest!.Messages.Any(message => message.Content?.Contains("focus left") == true));
     }
 
+    public static async Task PlayOnce_RethrowsRunBoundaryAfterAct()
+    {
+        var bridge = new FakeBridge
+        {
+            CompactStateJson =
+                """{"screen":"COMBAT","run_id":"run_1","session":{"phase":"run"},"available_actions":["play_card","end_turn"],"combat":{"hand":[{"i":0,"targets":[]}]}}""",
+            AfterActCompactStateJson =
+                """{"screen":"MAIN_MENU","run_id":"run_unknown","session":{"phase":"menu"},"available_actions":["switch_profile"]}"""
+        };
+        var factory = new ScriptedClientFactory(new[]
+        {
+            new LlmCompletion
+            {
+                ToolCalls = new[]
+                {
+                    new LlmToolCall
+                    {
+                        Id = "call_act",
+                        Name = "act",
+                        ArgumentsJson = """{"action":"play_card","card_index":0}"""
+                    }
+                }
+            }
+        });
+        var loop = new AgentLoop(bridge, factory, AgentSettings.CreateDefault);
+        var stopped = false;
+        try
+        {
+            await loop.PlayOnceAsync(CancellationToken.None, new CurrentRunBoundary().Check);
+        }
+        catch (AutoPlayStoppedException)
+        {
+            stopped = true;
+        }
+
+        Assert.True(stopped);
+        Assert.Equal(1, bridge.ActCalls);
+    }
+
+    public static async Task PlayOnce_InvokesCheckStateOnGetGameState()
+    {
+        var checks = 0;
+        var bridge = new FakeBridge();
+        var factory = new ScriptedClientFactory(new[]
+        {
+            new LlmCompletion
+            {
+                ToolCalls = new[]
+                {
+                    new LlmToolCall { Id = "call_state", Name = "get_game_state", ArgumentsJson = "{}" },
+                    new LlmToolCall
+                    {
+                        Id = "call_act",
+                        Name = "act",
+                        ArgumentsJson = """{"action":"play_card","card_index":0}"""
+                    }
+                }
+            }
+        });
+        var loop = new AgentLoop(bridge, factory, AgentSettings.CreateDefault);
+        await loop.PlayOnceAsync(CancellationToken.None, _ => checks++);
+        Assert.True(checks >= 3, "expected checkState on start, get_game_state, and act");
+        Assert.Equal(1, bridge.ActCalls);
+    }
+
+    public static async Task PlayOnce_StopsFurtherLlmCallsWhenRequestBudgetIsSpent()
+    {
+        var calls = 0;
+        var guard = new SessionBudgetGuard(maxRequests: 1);
+        var factory = new ScriptedClientFactory(new[]
+        {
+            new LlmCompletion
+            {
+                ToolCalls = new[]
+                {
+                    new LlmToolCall { Id = "call_state", Name = "get_game_state", ArgumentsJson = "{}" }
+                }
+            },
+            new LlmCompletion { Content = "should not be requested" }
+        })
+        {
+            OnRequest = () => calls++
+        };
+        var loop = new AgentLoop(new FakeBridge(), factory, AgentSettings.CreateDefault, budgetGuard: () => guard);
+        var result = await loop.PlayOnceAsync(CancellationToken.None);
+        Assert.Equal(1, calls);
+        Assert.Contains("请求次数上限", result.Error);
+    }
+
     public static async Task PlayOnce_ExecutesSingleValidatedAct()
     {
         var bridge = new FakeBridge();
@@ -622,6 +711,8 @@ internal static class AgentLoopTests
         public string CompactStateJson { get; set; } =
             """{"screen":"COMBAT","available_actions":["play_card","end_turn"],"combat":{"hand":[{"i":0,"line":"Strike","targets":[]}],"enemies":[{"i":0}]}}""";
 
+        public string? AfterActCompactStateJson { get; set; }
+
         public string AvailableActionsJson { get; set; } =
             """[{"name":"play_card","requires_index":true,"requires_target":false}]""";
 
@@ -667,6 +758,11 @@ internal static class AgentLoopTests
             LastX = x;
             LastY = y;
             LastTool = tool;
+            if (AfterActCompactStateJson != null)
+            {
+                CompactStateJson = AfterActCompactStateJson;
+            }
+
             return Task.FromResult(ActResultJson);
         }
 

--- a/STS2AIAgent.Tests/CompanionStartupTests.cs
+++ b/STS2AIAgent.Tests/CompanionStartupTests.cs
@@ -12,9 +12,10 @@ internal static class CompanionStartupTests
     {
         Assert.Equal("--windowed", CoopLaunchPolicy.CompanionArguments(null, "901"));
         Assert.Equal("--windowed --force-steam off --clientId 902", CoopLaunchPolicy.CompanionArguments("off", "901"));
-        Assert.Equal("--windowed --force-steam off", CoopLaunchPolicy.CompanionArguments("off", null));
+        Assert.Equal("--windowed --force-steam off --clientId 1", CoopLaunchPolicy.CompanionArguments("off", null));
 
         Expect<InvalidOperationException>(() => CoopLaunchPolicy.CompanionArguments("off", ulong.MaxValue.ToString()));
+        Expect<InvalidOperationException>(() => CoopLaunchPolicy.CompanionArguments("off", "not-a-number"));
 
         Assert.True(CoopLaunchPolicy.TryGetCompanionArguments("off", "901", out var args, out var err));
         Assert.Equal("--windowed --force-steam off --clientId 902", args);
@@ -45,6 +46,7 @@ internal static class CompanionStartupTests
             Assert.Equal(explicitCustom, CoopLaunchPolicy.CompanionSettingsPath(isolated, explicitCustom));
             Expect<InvalidOperationException>(() => CoopLaunchPolicy.CompanionSettingsPath(isolated, "relative.companion.json"));
             Expect<ArgumentException>(() => CoopLaunchPolicy.CompanionSettingsPath(""));
+            Expect<InvalidOperationException>(() => CoopLaunchPolicy.SeedCompanionSettings(isolated, isolated));
 
             File.WriteAllText(isolated, "{\"main\":true}");
             Assert.False(File.Exists(derived));
@@ -55,7 +57,7 @@ internal static class CompanionStartupTests
             File.WriteAllText(derived, "{\"companion\":true}");
             File.WriteAllText(isolated, "{\"main\":updated}");
             CoopLaunchPolicy.SeedCompanionSettings(isolated, derived);
-            Assert.Equal("{\"companion\":true}", File.ReadAllText(derived));
+            Assert.Equal("{\"main\":updated}", File.ReadAllText(derived));
         }
         finally
         {
@@ -64,86 +66,40 @@ internal static class CompanionStartupTests
         }
     }
 
-    public static void ExcludedRangeUsesDynamicPort()
+    public static void CompanionPortFileRoundTrip()
     {
-        var attempted = new List<int>();
-        var selected = LoopbackListener.Select(8080, true, port =>
+        var pid = 424242;
+        CompanionPortFile.Delete(pid);
+        Assert.True(CompanionPortFile.TryRead(pid) == null);
+        CompanionPortFile.Write(pid, 18081);
+        Assert.Equal(18081, CompanionPortFile.TryRead(pid));
+        var ports = CompanionPortFile.EnumerateCandidates(18080, pid).ToArray();
+        Assert.Equal(18080, ports[0]);
+        Assert.True(ports.Contains(18081));
+        CompanionPortFile.Delete(pid);
+        Assert.True(CompanionPortFile.TryRead(pid) == null);
+    }
+
+    public static void CompanionBootstrapDoesNotHostLobby()
+    {
+        var source = File.ReadAllText(FindSource("STS2AIAgent/Multiplayer/DualInstanceCoordinator.cs"));
+        var start = source.IndexOf("RunCompanionBootstrapAsync", StringComparison.Ordinal);
+        var open = source.IndexOf('{', start);
+        var depth = 0;
+        var end = open;
+        for (var i = open; i < source.Length; i++)
         {
-            attempted.Add(port);
-            if (port < 49000) throw new HttpListenerException(32);
-            return "listening";
-        }, () => 49000, () => throw new Exception("Automatic selection should not sleep."));
-        Assert.Equal(49000, selected.Port);
-        Assert.Equal(LoopbackListener.NearbyPortCount + 1, attempted.Count);
-        Assert.Equal("listening", selected.Listener);
-    }
+            if (source[i] == '{') depth++;
+            else if (source[i] == '}' && --depth == 0)
+            {
+                end = i;
+                break;
+            }
+        }
 
-    public static void BindRaceReselectsDynamicPort()
-    {
-        var allocated = 49000;
-        var selected = LoopbackListener.Select(65535, true, port =>
-        {
-            if (port != 49002) throw new HttpListenerException(183);
-            return port;
-        }, () => ++allocated, () => { });
-        Assert.Equal(49002, selected.Port);
-    }
-
-    public static void ExplicitPortNeverChanges()
-    {
-        var attempts = 0;
-        var waits = 0;
-        var error = Expect<InvalidOperationException>(() => LoopbackListener.Select<int>(8080, false, port =>
-        {
-            Assert.Equal(8080, port);
-            attempts++;
-            throw new HttpListenerException(183);
-        }, () => throw new Exception("Explicit port cannot fall back."), () => waits++));
-        Assert.Equal(LoopbackListener.ExplicitPortAttempts, attempts);
-        Assert.Equal(attempts - 1, waits);
-        Assert.Contains("STS2_API_PORT", error.Message);
-    }
-
-    public static void ExplicitReservedPortFailsClearly()
-    {
-        var error = Expect<InvalidOperationException>(() => LoopbackListener.Select<int>(8080, false,
-            _ => throw new HttpListenerException(32),
-            () => throw new Exception("Unexpected fallback"), () => throw new Exception("Unexpected retry")));
-        Assert.Contains("8080", error.Message);
-        Assert.True(error.InnerException is HttpListenerException);
-    }
-
-    public static void ExhaustionIsBounded()
-    {
-        var attempts = 0;
-        Expect<InvalidOperationException>(() => LoopbackListener.Select<int>(8080, true, _ =>
-        {
-            attempts++;
-            throw new HttpListenerException(5);
-        }, () => 49000, () => { }));
-        Assert.Equal(LoopbackListener.NearbyPortCount + LoopbackListener.DynamicPortAttempts, attempts);
-    }
-
-    public static void UnexpectedFailureIsNotHidden()
-    {
-        var error = Expect<HttpListenerException>(() => LoopbackListener.Select<int>(8080, true,
-            _ => throw new HttpListenerException(87),
-            () => throw new Exception("Unexpected fallback"), () => { }));
-        Assert.Equal(87, error.NativeErrorCode);
-    }
-
-    public static async Task RealLoopbackListenerResponds()
-    {
-        var started = LoopbackListener.Start(49080, allowFallback: true);
-        using var listener = started.Listener;
-        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        using var http = new HttpClient();
-        var request = http.GetAsync($"http://127.0.0.1:{started.Port}/health", timeout.Token);
-        var context = await listener.GetContextAsync().WaitAsync(timeout.Token);
-        context.Response.StatusCode = 204;
-        context.Response.Close();
-        using var response = await request;
-        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        var body = source[open..(end + 1)];
+        Assert.False(body.Contains("OpenMultiplayerTestAsync", StringComparison.Ordinal));
+        Assert.Contains("join_multiplayer_lobby", body, StringComparison.Ordinal);
     }
 
     public static void HealthRequiresExactCompanionIdentity()
@@ -175,6 +131,23 @@ internal static class CompanionStartupTests
         model.Endpoint.BaseUrl = "http://localhost:1234/v1";
         model.Endpoint.ApiKey = "";
         Assert.True(CoopLaunchPolicy.GetError(false, false, "MAIN_MENU", model) == null);
+    }
+
+    private static string FindSource(string relativePath)
+    {
+        foreach (var start in new[] { Directory.GetCurrentDirectory(), AppContext.BaseDirectory })
+        {
+            for (var directory = new DirectoryInfo(start); directory != null; directory = directory.Parent)
+            {
+                var candidate = Path.Combine(directory.FullName, relativePath);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        throw new FileNotFoundException(relativePath);
     }
 
     private static T Expect<T>(Action action) where T : Exception

--- a/STS2AIAgent.Tests/DeckSelectionContractTests.cs
+++ b/STS2AIAgent.Tests/DeckSelectionContractTests.cs
@@ -57,9 +57,16 @@ internal static class DeckSelectionContractTests
             settleBody,
             StringComparison.Ordinal);
         Assert.Contains(
+            "metadata.SelectedCount<metadata.MaxSelect",
+            settleBody,
+            StringComparison.Ordinal);
+        Assert.Contains(
             "ConfirmDeckSelectionAsync(screen,remaining)",
             settleBody,
             StringComparison.Ordinal);
+        var stateSource = WithoutWhitespace(ReadSource("STS2AIAgent/Game/GameStateService.cs"));
+        Assert.Contains("IsCardSelected(currentScreen,holder.CardModel!)", stateSource, StringComparison.Ordinal);
+        Assert.Contains("selected=selected", stateSource, StringComparison.Ordinal);
     }
 
     private static string ReadSource(string relativePath)

--- a/STS2AIAgent.Tests/GameOverContractTests.cs
+++ b/STS2AIAgent.Tests/GameOverContractTests.cs
@@ -128,8 +128,8 @@ internal static class GameOverContractTests
         var verificationBody = AgentSourceFixture.WithoutWhitespace(
             AgentSourceFixture.MethodBody(rawStateSource, "VerifyGameOverProgressSave"));
 
-        Assert.Contains("privateconstintStateVersion=15", stateSource, StringComparison.Ordinal);
-        Assert.Contains("privateconstintAgentViewVersion=9", stateSource, StringComparison.Ordinal);
+        Assert.Contains("privateconstintStateVersion=16", stateSource, StringComparison.Ordinal);
+        Assert.Contains("privateconstintAgentViewVersion=10", stateSource, StringComparison.Ordinal);
         Assert.Contains("save_status=saveVerification.Status", stateSource, StringComparison.Ordinal);
         Assert.Contains("save_verified=saveVerification.Verified", stateSource, StringComparison.Ordinal);
         Assert.Contains("save_error=saveVerification.Error", stateSource, StringComparison.Ordinal);

--- a/STS2AIAgent.Tests/ProfileSelectionContractTests.cs
+++ b/STS2AIAgent.Tests/ProfileSelectionContractTests.cs
@@ -12,6 +12,8 @@ internal static class ProfileSelectionContractTests
         var stateSource = WithoutWhitespace(ReadSource("STS2AIAgent/Game/GameStateService.cs"));
 
         Assert.Contains("native_profile_id=SaveManager.Instance.CurrentProfileId", stateSource, StringComparison.Ordinal);
+        Assert.Contains("native_profile_id=nativeProfileId", stateSource, StringComparison.Ordinal);
+        Assert.Contains("profiles=new[]", stateSource, StringComparison.Ordinal);
         Assert.Contains("names.Add(\"switch_profile\")", stateSource, StringComparison.Ordinal);
         Assert.Contains("\"switch_profile\"=>ExecuteSwitchProfileAsync(request)", actionSource, StringComparison.Ordinal);
         Assert.Contains("profileIdis<1or>3", actionSource, StringComparison.Ordinal);

--- a/STS2AIAgent.Tests/STS2AIAgent.Tests.csproj
+++ b/STS2AIAgent.Tests/STS2AIAgent.Tests.csproj
@@ -13,6 +13,7 @@
     <Compile Include="..\STS2AIAgent\Agent\CurrentRunBoundary.cs" Link="Agent\CurrentRunBoundary.cs" />
     <Compile Include="..\STS2AIAgent\Agent\SessionBudgetGuard.cs" Link="Agent\SessionBudgetGuard.cs" />
     <Compile Include="..\STS2AIAgent\Server\LoopbackListener.cs" Link="Server\LoopbackListener.cs" />
+    <Compile Include="..\STS2AIAgent\Server\CompanionPortFile.cs" Link="Server\CompanionPortFile.cs" />
     <Compile Include="..\STS2AIAgent\Multiplayer\CompanionHealth.cs" Link="Multiplayer\CompanionHealth.cs" />
     <Compile Include="..\STS2AIAgent\Multiplayer\CoopLaunchPolicy.cs" Link="Multiplayer\CoopLaunchPolicy.cs" />
     <Compile Include="..\STS2AIAgent\Multiplayer\TeamConversation.cs" Link="Multiplayer\TeamConversation.cs" />

--- a/STS2AIAgent.Tests/SessionBudgetGuardTests.cs
+++ b/STS2AIAgent.Tests/SessionBudgetGuardTests.cs
@@ -52,6 +52,16 @@ internal static class SessionBudgetGuardTests
         Assert.Contains("1,050/1,000", stop);
     }
 
+    public static void CheckBudget_CountsInFlightRequests()
+    {
+        var guard = new SessionBudgetGuard(maxRequests: 2);
+        Assert.Null(guard.CheckBudget());
+        Assert.Null(guard.CheckBudget(extraRequests: 1));
+        Assert.NotNull(guard.CheckBudget(extraRequests: 2));
+        guard.Record(0, 1);
+        Assert.NotNull(guard.CheckBudget(extraRequests: 1));
+    }
+
     public static void MaxRequests_StopsEvenWithoutUsage()
     {
         var guard = new SessionBudgetGuard(maxRequests: 3);

--- a/STS2AIAgent.Tests/TestRunner.cs
+++ b/STS2AIAgent.Tests/TestRunner.cs
@@ -125,6 +125,9 @@ internal static class TestRunner
         yield return ("TeamControl.NoOverlappingLoops", AutoPlaySessionTests.ImmediatePauseNeverOverlapsGenerations);
         yield return ("TeamControl.Lifetime", () => Task.Run(AutoPlaySessionTests.CanceledLifetimeCannotStart));
         yield return ("TeamControl.NoLateAct", AgentLoopTests.PauseAfterModelResponseDoesNotDispatchAct);
+        yield return ("AgentLoop.RunBoundaryRethrown", AgentLoopTests.PlayOnce_RethrowsRunBoundaryAfterAct);
+        yield return ("AgentLoop.CheckStateOnGetGameState", AgentLoopTests.PlayOnce_InvokesCheckStateOnGetGameState);
+        yield return ("AgentLoop.RequestBudgetStopsNextRound", AgentLoopTests.PlayOnce_StopsFurtherLlmCallsWhenRequestBudgetIsSpent);
         yield return ("TeamControl.TransportAck", TeamConversationTests.PauseControlHasExplicitAcknowledgement);
         yield return ("TeamChat.ReadOnly", AgentLoopTests.TeamChat_CannotActEvenWithPlayIntent);
         yield return ("TeamChat.NextDecision", AgentLoopTests.TeamSuggestion_ReachesNextPlayDecision);
@@ -134,13 +137,8 @@ internal static class TestRunner
         yield return ("TeamChat.ReusedPort", TeamConversationTests.ReusedPortDoesNotReceiveMessage);
         yield return ("CoopStartup.OfflineIsolation", () => Task.Run(CompanionStartupTests.OfflineLaunchKeepsAccountsIsolated));
         yield return ("CoopStartup.SettingsIsolation", () => Task.Run(CompanionStartupTests.SettingsPathCanBeIsolated));
-        yield return ("CoopStartup.ExcludedRange", () => Task.Run(CompanionStartupTests.ExcludedRangeUsesDynamicPort));
-        yield return ("CoopStartup.BindRace", () => Task.Run(CompanionStartupTests.BindRaceReselectsDynamicPort));
-        yield return ("CoopStartup.ExplicitPort", () => Task.Run(CompanionStartupTests.ExplicitPortNeverChanges));
-        yield return ("CoopStartup.ExplicitReserved", () => Task.Run(CompanionStartupTests.ExplicitReservedPortFailsClearly));
-        yield return ("CoopStartup.BoundedFailure", () => Task.Run(CompanionStartupTests.ExhaustionIsBounded));
-        yield return ("CoopStartup.UnexpectedFailure", () => Task.Run(CompanionStartupTests.UnexpectedFailureIsNotHidden));
-        yield return ("CoopStartup.RealHttp", CompanionStartupTests.RealLoopbackListenerResponds);
+        yield return ("CoopStartup.PortFile", () => Task.Run(CompanionStartupTests.CompanionPortFileRoundTrip));
+        yield return ("CoopStartup.CompanionDoesNotHost", () => Task.Run(CompanionStartupTests.CompanionBootstrapDoesNotHostLobby));
         yield return ("CoopStartup.Identity", () => Task.Run(CompanionStartupTests.HealthRequiresExactCompanionIdentity));
         yield return ("CoopStartup.Preconditions", () => Task.Run(CompanionStartupTests.LaunchPreconditionsProtectHumanRun));
         yield return ("SettingsStore.RoundTrip", () => Task.Run(SettingsStoreTests.RoundTrip_PreservesEndpointsModelsAndRoles));
@@ -163,6 +161,7 @@ internal static class TestRunner
         yield return ("Budget.NoLimit", () => Task.Run(SessionBudgetGuardTests.NoLimit_NeverStops));
         yield return ("Budget.MaxTokens", () => Task.Run(SessionBudgetGuardTests.MaxTokens_StopsWhenExceeded));
         yield return ("Budget.MaxRequests", () => Task.Run(SessionBudgetGuardTests.MaxRequests_StopsEvenWithoutUsage));
+        yield return ("Budget.InFlightRequests", () => Task.Run(SessionBudgetGuardTests.CheckBudget_CountsInFlightRequests));
         yield return ("Budget.RecoveryStops", SessionBudgetGuardTests.Recovery_AutoPlayStopsOnBudgetExceeded);
         yield return ("Budget.ResumePreservesCumulativeUsage", () => Task.Run(SessionBudgetGuardTests.InitialCounters_ResumePreservesCumulativeUsage));
         yield return ("Budget.ExceededRequestsStopsImmediately", SessionBudgetGuardTests.InitialCounters_AlreadyExceeded_RunAsyncStopsImmediately);

--- a/STS2AIAgent/Agent/AgentLoop.cs
+++ b/STS2AIAgent/Agent/AgentLoop.cs
@@ -17,13 +17,20 @@ internal sealed class AgentLoop
     private readonly ILlmClientFactory _factory;
     private readonly Func<AgentSettings> _settings;
     private readonly Func<string?>? _teamContext;
+    private readonly Func<SessionBudgetGuard?>? _budgetGuard;
 
-    public AgentLoop(IGameBridge bridge, ILlmClientFactory factory, Func<AgentSettings> settings, Func<string?>? teamContext = null)
+    public AgentLoop(
+        IGameBridge bridge,
+        ILlmClientFactory factory,
+        Func<AgentSettings> settings,
+        Func<string?>? teamContext = null,
+        Func<SessionBudgetGuard?>? budgetGuard = null)
     {
         _bridge = bridge;
         _factory = factory;
         _settings = settings;
         _teamContext = teamContext;
+        _budgetGuard = budgetGuard;
     }
 
     public async Task<AgentTurnResult> ChatAsync(
@@ -85,6 +92,7 @@ internal sealed class AgentLoop
         var actionable = await _bridge.WaitUntilActionableAsync(TimeSpan.FromSeconds(20), cancellationToken);
         if (!actionable)
         {
+            checkState?.Invoke(await _bridge.GetCompactStateJsonAsync(cancellationToken));
             return new AgentTurnResult
             {
                 Error = "Timed out waiting for an actionable state.",
@@ -176,6 +184,22 @@ internal sealed class AgentLoop
                 Thinking = resolved.Model.GetThinkingIntensity(),
                 ThinkingMode = resolved.Model.ThinkingMode
             };
+
+            var budgetReason = _budgetGuard?.Invoke()?.CheckBudget(requestsSpent);
+            if (budgetReason != null)
+            {
+                return new AgentTurnResult
+                {
+                    AssistantText = lastText,
+                    Reasoning = lastReasoning,
+                    Acted = acted,
+                    ActResultJson = actResult,
+                    Error = budgetReason,
+                    ToolRounds = rounds,
+                    Usage = accumulatedUsage,
+                    RequestsSpent = requestsSpent
+                };
+            }
 
             LlmCompletion completion;
             try
@@ -306,7 +330,7 @@ internal sealed class AgentLoop
                     continue;
                 }
 
-                var toolJson = await ExecuteReadToolAsync(call.Name, call.ArgumentsJson, cancellationToken);
+                var toolJson = await ExecuteReadToolAsync(call.Name, call.ArgumentsJson, cancellationToken, checkState);
                 messages.Add(LlmMessage.Tool(call.Id, toolJson));
             }
         }
@@ -368,6 +392,12 @@ internal sealed class AgentLoop
             return (null, null, false, null, 0);
         }
 
+        var visionBudget = _budgetGuard?.Invoke()?.CheckBudget();
+        if (visionBudget != null)
+        {
+            return (visionBudget, jpeg, false, null, 0);
+        }
+
         try
         {
             var client = _factory.Create(vision.Endpoint);
@@ -394,17 +424,21 @@ internal sealed class AgentLoop
         }
     }
 
-    private async Task<string> ExecuteReadToolAsync(string name, string argumentsJson, CancellationToken cancellationToken)
+    private async Task<string> ExecuteReadToolAsync(
+        string name,
+        string argumentsJson,
+        CancellationToken cancellationToken,
+        Action<string>? checkState = null)
     {
         try
         {
             using var args = ParseArgs(argumentsJson);
             return name switch
             {
-                "get_game_state" => await _bridge.GetCompactStateJsonAsync(cancellationToken),
+                "get_game_state" => InvokeCheckState(await _bridge.GetCompactStateJsonAsync(cancellationToken), checkState),
                 "get_raw_game_state" => await _bridge.GetRawStateJsonAsync(cancellationToken),
                 "get_available_actions" => await _bridge.GetAvailableActionsJsonAsync(cancellationToken),
-                "wait_until_actionable" => await WaitUntilActionableJsonAsync(args, cancellationToken),
+                "wait_until_actionable" => await WaitUntilActionableJsonAsync(args, cancellationToken, checkState),
                 "get_game_data_item" => await _bridge.GetGameDataItemJsonAsync(
                     ReadString(args, "collection") ?? string.Empty,
                     ReadString(args, "item_id") ?? string.Empty,
@@ -420,17 +454,25 @@ internal sealed class AgentLoop
                 _ => JsonSerializer.Serialize(new { error = $"Unknown tool '{name}'" }, JsonOptions)
             };
         }
+        catch (AutoPlayStoppedException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             return JsonSerializer.Serialize(new { error = ex.Message }, JsonOptions);
         }
     }
 
-    private async Task<string> WaitUntilActionableJsonAsync(JsonDocument args, CancellationToken cancellationToken)
+    private async Task<string> WaitUntilActionableJsonAsync(
+        JsonDocument args,
+        CancellationToken cancellationToken,
+        Action<string>? checkState = null)
     {
         var timeout = TimeSpan.FromSeconds(ReadTimeoutSeconds(args));
         var actionable = await _bridge.WaitUntilActionableAsync(timeout, cancellationToken);
         var stateJson = await _bridge.GetCompactStateJsonAsync(cancellationToken);
+        checkState?.Invoke(stateJson);
         var actionsJson = await _bridge.GetAvailableActionsJsonAsync(cancellationToken);
         return JsonSerializer.Serialize(new
         {
@@ -526,9 +568,16 @@ internal sealed class AgentLoop
                 {
                     return (action, result, "Timed out waiting for a stable state after act.");
                 }
+
+                return (action, result, null);
             }
 
+            checkState?.Invoke(await _bridge.GetCompactStateJsonAsync(cancellationToken));
             return (action, result, null);
+        }
+        catch (AutoPlayStoppedException)
+        {
+            throw;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -538,6 +587,12 @@ internal sealed class AgentLoop
         {
             return (null, JsonSerializer.Serialize(new { error = ex.Message }, JsonOptions), ex.Message);
         }
+    }
+
+    private static string InvokeCheckState(string json, Action<string>? checkState)
+    {
+        checkState?.Invoke(json);
+        return json;
     }
 
     private static void AppendJsonActFallbackIfNeeded(List<LlmMessage> messages, ResolvedModel resolved, bool allowAct)

--- a/STS2AIAgent/Agent/AgentRuntime.cs
+++ b/STS2AIAgent/Agent/AgentRuntime.cs
@@ -42,6 +42,7 @@ internal sealed class AgentRuntime
     private Process? _mcpProcess;
     private LlmUsage _sessionUsage = LlmUsage.Empty;
     private int _sessionRequests;
+    private SessionBudgetGuard _budgetGuard;
 
     public static AgentRuntime Instance => LazyInstance.Value;
 
@@ -50,13 +51,21 @@ internal sealed class AgentRuntime
     private AgentRuntime()
     {
         _settings = _store.Load();
+        _budgetGuard = _settings.CreateBudgetGuard();
         _loop = new AgentLoop(new GameBridge(), new DefaultLlmClientFactory(), () =>
         {
             lock (_gate)
             {
                 return _settings;
             }
-        }, InstanceRole.IsCompanion ? () => _teamConversation.BuildDecisionContext() : null);
+        }, InstanceRole.IsCompanion ? () => _teamConversation.BuildDecisionContext() : null,
+            () =>
+            {
+                lock (_gate)
+                {
+                    return _budgetGuard;
+                }
+            });
     }
 
     public AgentSettings Settings
@@ -151,6 +160,7 @@ internal sealed class AgentRuntime
         {
             _sessionUsage = LlmUsage.Empty;
             _sessionRequests = 0;
+            _budgetGuard = _settings.CreateBudgetGuard();
         }
         RaiseChanged();
     }
@@ -197,6 +207,17 @@ internal sealed class AgentRuntime
         cancellationToken = deadline.Token;
         // Share the turn gate with gameplay, but do not require autoplay to be
         // stopped: this request only reads state and adds conversational context.
+        string? budgetBlocked;
+        lock (_gate)
+        {
+            budgetBlocked = _budgetGuard.CheckBudget();
+        }
+
+        if (budgetBlocked != null)
+        {
+            throw new InvalidOperationException(budgetBlocked);
+        }
+
         await _turnGate.WaitAsync(cancellationToken);
         try
         {
@@ -213,14 +234,7 @@ internal sealed class AgentRuntime
             var reply = result.AssistantText;
             if (reply.Length > TeamConversation.MaxMessageLength) reply = reply[..TeamConversation.MaxMessageLength];
             _teamConversation.Add("assistant", reply);
-            lock (_gate)
-            {
-                if (result.Usage != null)
-                {
-                    _sessionUsage = LlmUsage.Combine(_sessionUsage, result.Usage) ?? LlmUsage.Empty;
-                }
-                _sessionRequests += result.RequestsSpent > 0 ? result.RequestsSpent : 1;
-            }
+            AccountTurn(result, recordBudget: true);
             RaiseChanged();
             return reply;
         }
@@ -291,6 +305,7 @@ internal sealed class AgentRuntime
         lock (_gate)
         {
             _settings = settings;
+            _budgetGuard = settings.CreateBudgetGuard(_sessionUsage.TotalTokens, _sessionRequests);
         }
 
         _store.Save(settings);
@@ -324,6 +339,7 @@ internal sealed class AgentRuntime
         lock (_gate)
         {
             _settings = loaded;
+            _budgetGuard = loaded.CreateBudgetGuard(_sessionUsage.TotalTokens, _sessionRequests);
         }
 
         RaiseChanged();
@@ -427,8 +443,7 @@ internal sealed class AgentRuntime
         string? budgetBlocked = null;
         lock (_gate)
         {
-            var guard = _settings.CreateBudgetGuard(_sessionUsage.TotalTokens, _sessionRequests);
-            budgetBlocked = guard.CheckBudget();
+            budgetBlocked = _budgetGuard.CheckBudget();
         }
 
         if (budgetBlocked != null)
@@ -463,14 +478,7 @@ internal sealed class AgentRuntime
                 _turnGate.Release();
             }
 
-            lock (_gate)
-            {
-                if (result.Usage != null)
-                {
-                    _sessionUsage = LlmUsage.Combine(_sessionUsage, result.Usage) ?? LlmUsage.Empty;
-                }
-                _sessionRequests += result.RequestsSpent > 0 ? result.RequestsSpent : 1;
-            }
+            AccountTurn(result, recordBudget: true);
 
             var reply = result.Error != null
                 ? result.Error
@@ -641,10 +649,10 @@ internal sealed class AgentRuntime
     private async Task AutoPlayLoopAsync(CancellationToken cancellationToken)
     {
         var boundary = new CurrentRunBoundary();
-        SessionBudgetGuard? budgetGuard;
+        SessionBudgetGuard budgetGuard;
         lock (_gate)
         {
-            budgetGuard = _settings.CreateBudgetGuard(_sessionUsage.TotalTokens, _sessionRequests);
+            budgetGuard = _budgetGuard;
         }
 
         try
@@ -726,7 +734,7 @@ internal sealed class AgentRuntime
         RaiseChanged();
     }
 
-    private void ApplyPlayResult(AgentTurnResult result)
+    private void AccountTurn(AgentTurnResult result, bool recordBudget = false)
     {
         lock (_gate)
         {
@@ -734,8 +742,18 @@ internal sealed class AgentRuntime
             {
                 _sessionUsage = LlmUsage.Combine(_sessionUsage, result.Usage) ?? LlmUsage.Empty;
             }
-            _sessionRequests += result.RequestsSpent > 0 ? result.RequestsSpent : (result.WaitingForGame ? 0 : 1);
+
+            _sessionRequests += Math.Max(0, result.RequestsSpent);
+            if (recordBudget)
+            {
+                _budgetGuard.Observe(result);
+            }
         }
+    }
+
+    private void ApplyPlayResult(AgentTurnResult result)
+    {
+        AccountTurn(result);
 
         if (!string.IsNullOrWhiteSpace(result.Acted))
         {

--- a/STS2AIAgent/Agent/AutoPlayRecovery.cs
+++ b/STS2AIAgent/Agent/AutoPlayRecovery.cs
@@ -57,7 +57,8 @@ internal sealed class AutoPlayRecovery
             report(result);
             if (budgetGuard != null)
             {
-                var budgetReason = budgetGuard.Observe(result);
+                // Record the finished turn, then stop before starting another.
+                var budgetReason = budgetGuard.Observe(result) ?? budgetGuard.CheckBudget();
                 if (budgetReason != null) throw new AutoPlayStoppedException(budgetReason);
             }
             var next = recovery.Observe(result);

--- a/STS2AIAgent/Agent/PlayPrompt.cs
+++ b/STS2AIAgent/Agent/PlayPrompt.cs
@@ -43,12 +43,12 @@ Hard rules:
 8. UNKNOWN is transient: reread state once; if it remains UNKNOWN, call wait_until_actionable rather than guessing.
 
 Screen playbook:
-- MAIN_MENU: prefer continue_run when present. Timeline stuck flow: open_timeline -> choose_timeline_epoch -> confirm_timeline_overlay -> close_main_menu_submenu.
+- MAIN_MENU: prefer continue_run when present. Do not call switch_profile unless asked; option_index is the native profile id 1..3 (not a 0-based list). Compact state has native_profile_id and profiles[]. Timeline stuck flow: open_timeline -> choose_timeline_epoch -> confirm_timeline_overlay -> close_main_menu_submenu.
 - CHARACTER_SELECT: default to the first unlocked character unless told otherwise. Wait for embark=true before embark. Resolve MODAL after embark.
 - MULTIPLAYER_LOBBY: use host_multiplayer_lobby / join_multiplayer_lobby / select_character / ready_multiplayer_lobby / disconnect_multiplayer_lobby from available_actions.
 - MAP: map.options[].i is the only legal node index. choose_map_node until the returned screen is the destination or stable combat.
 - COMBAT: only play_card, end_turn, use_potion, discard_potion. If a card opens CARD_SELECTION, switch immediately. Spend energy; do not end_turn with obvious free value left.
-- CARD_SELECTION: read min/max/selected/confirm. Single-select usually ends on select_deck_card. Multi-select may need confirm_selection.
+- CARD_SELECTION: read min/max/selected/confirm and cards[].selected. Single-select usually ends on select_deck_card. If min < max, keep selecting then confirm_selection; do not assume the first pick confirms.
 - REWARD: prefer collect_rewards_and_proceed when it is a full cleanup. pending card choice -> choose_reward_card or skip_reward_cards. Never proceed. claim_reward indexes the original rewards list.
 - SHOP: open_shop_inventory for the inner shop. Leave inner shop with close_shop_inventory; leave the room with proceed. Prefer relics and remove before emptying gold.
 - REST: only enabled choose_rest_option. Smith/relic flows may open CARD_SELECTION first.

--- a/STS2AIAgent/Agent/SessionBudgetGuard.cs
+++ b/STS2AIAgent/Agent/SessionBudgetGuard.cs
@@ -22,11 +22,13 @@ internal sealed class SessionBudgetGuard
 
     public bool HasLimit => MaxTokens.HasValue || MaxRequests.HasValue;
 
-    public string? CheckBudget()
+    public string? CheckBudget(int extraRequests = 0)
     {
-        if (MaxRequests.HasValue && RequestCount >= MaxRequests.Value)
+        extraRequests = Math.Max(0, extraRequests);
+        var requests = RequestCount + extraRequests;
+        if (MaxRequests.HasValue && requests >= MaxRequests.Value)
         {
-            return $"已达到会话请求次数上限（{RequestCount}/{MaxRequests.Value} 次），已自动停止游玩。";
+            return $"已达到会话请求次数上限（{requests}/{MaxRequests.Value} 次），已自动停止游玩。";
         }
 
         if (MaxTokens.HasValue && ConsumedTokens >= MaxTokens.Value)

--- a/STS2AIAgent/Config/SettingsStore.cs
+++ b/STS2AIAgent/Config/SettingsStore.cs
@@ -91,7 +91,13 @@ internal sealed class SettingsStore
         var json = JsonSerializer.Serialize(settings, JsonOptions);
         var tempPath = _path + ".tmp";
         File.WriteAllText(tempPath, json);
-        File.Copy(tempPath, _path, overwrite: true);
-        File.Delete(tempPath);
+        if (File.Exists(_path))
+        {
+            File.Replace(tempPath, _path, destinationBackupFileName: null);
+        }
+        else
+        {
+            File.Move(tempPath, _path);
+        }
     }
 }

--- a/STS2AIAgent/Game/GameActionService.cs
+++ b/STS2AIAgent/Game/GameActionService.cs
@@ -1749,8 +1749,29 @@ internal static class GameActionService
         var currentScreen = ActiveScreenContext.Instance.GetCurrentScreen();
         var screen = GameStateService.ResolveScreen(currentScreen);
 
-        if (!GameStateService.CanConfirmSelection(currentScreen) ||
-            !GameStateService.TryGetCombatHandSelection(currentScreen, out var combatHand) ||
+        if (!GameStateService.CanConfirmSelection(currentScreen))
+        {
+            throw new ApiException(409, "invalid_action", "Action is not available in the current state.", new
+            {
+                action = "confirm_selection",
+                screen
+            });
+        }
+
+        if (currentScreen is NDeckCardSelectScreen deckScreen)
+        {
+            var stableDeck = await ConfirmDeckSelectionAsync(deckScreen, TimeSpan.FromSeconds(10));
+            return new ActionResponsePayload
+            {
+                action = "confirm_selection",
+                status = stableDeck ? "completed" : "pending",
+                stable = stableDeck,
+                message = stableDeck ? "Action completed." : "Action queued but state is still transitioning.",
+                state = GameStateService.BuildStatePayload()
+            };
+        }
+
+        if (!GameStateService.TryGetCombatHandSelection(currentScreen, out var combatHand) ||
             combatHand == null ||
             !TryGetCombatHandConfirmButton(combatHand, out var confirmButton) ||
             confirmButton == null)
@@ -1844,13 +1865,7 @@ internal static class GameActionService
             }
         }
 
-        var isClosed = ActiveScreenContext.Instance.GetCurrentScreen() is not NChooseACardSelectionScreen || !GodotObject.IsInstanceValid(selectionScreen);
-        if (CombatManager.Instance.IsInProgress)
-        {
-            return isClosed && (CombatManager.Instance.IsOverOrEnding || GameStateService.IsCombatActionReady() || ArePlayerDrivenActionsSettled());
-        }
-
-        return isClosed && ArePlayerDrivenActionsSettled();
+        return false;
     }
 
     private static async Task<bool> WaitForCardsViewCloseAsync(TimeSpan timeout)
@@ -1896,13 +1911,7 @@ internal static class GameActionService
             }
         }
 
-        var isClosed = !GameStateService.TryGetCombatHandSelection(ActiveScreenContext.Instance.GetCurrentScreen(), out _);
-        if (CombatManager.Instance.IsInProgress)
-        {
-            return isClosed && (CombatManager.Instance.IsOverOrEnding || GameStateService.IsCombatActionReady() || ArePlayerDrivenActionsSettled());
-        }
-
-        return isClosed && ArePlayerDrivenActionsSettled();
+        return false;
     }
 
     private static async Task<bool> WaitForCombatHandSelectionStepAsync(
@@ -1917,7 +1926,17 @@ internal static class GameActionService
             var currentScreen = ActiveScreenContext.Instance.GetCurrentScreen();
             if (!GameStateService.TryGetCombatHandSelectionMetadata(currentScreen, out _, out var currentSelection))
             {
-                return true;
+                if (!CombatManager.Instance.IsInProgress)
+                {
+                    return ArePlayerDrivenActionsSettled();
+                }
+
+                if (CombatManager.Instance.IsOverOrEnding || GameStateService.IsCombatActionReady())
+                {
+                    return true;
+                }
+
+                continue;
             }
 
             if (currentSelection.SelectedCount != previousSelection.SelectedCount)
@@ -1928,11 +1947,17 @@ internal static class GameActionService
                     continue;
                 }
 
-                return false;
+                return true;
             }
         }
 
-        return !GameStateService.TryGetCombatHandSelection(ActiveScreenContext.Instance.GetCurrentScreen(), out _);
+        if (!GameStateService.TryGetCombatHandSelection(ActiveScreenContext.Instance.GetCurrentScreen(), out _) &&
+            CombatManager.Instance.IsInProgress)
+        {
+            return CombatManager.Instance.IsOverOrEnding || GameStateService.IsCombatActionReady();
+        }
+
+        return false;
     }
 
     private static bool TryGetCombatHandConfirmButton(NPlayerHand hand, out NConfirmButton? confirmButton)
@@ -2254,7 +2279,8 @@ internal static class GameActionService
             }
 
             if (metadata.SelectedCount < previousSelectedCount ||
-                metadata.SelectedCount < metadata.MinSelect)
+                metadata.SelectedCount < metadata.MinSelect ||
+                metadata.SelectedCount < metadata.MaxSelect)
             {
                 return true;
             }
@@ -2359,14 +2385,7 @@ internal static class GameActionService
             }
         }
 
-        var finalScreen = ActiveScreenContext.Instance.GetCurrentScreen();
-        var isClosed = !GodotObject.IsInstanceValid(screen) || finalScreen is not NCardGridSelectionScreen;
-        if (CombatManager.Instance.IsInProgress)
-        {
-            return isClosed && (CombatManager.Instance.IsOverOrEnding || GameStateService.IsCombatActionReady() || ArePlayerDrivenActionsSettled());
-        }
-
-        return isClosed && ArePlayerDrivenActionsSettled();
+        return false;
     }
 
     private static async Task<ActionResponsePayload> ExecuteOpenChestAsync()

--- a/STS2AIAgent/Game/GameStateService.cs
+++ b/STS2AIAgent/Game/GameStateService.cs
@@ -58,8 +58,8 @@ namespace STS2AIAgent.Game;
 
 internal static class GameStateService
 {
-    private const int StateVersion = 15;
-    private const int AgentViewVersion = 9;
+    private const int StateVersion = 16;
+    private const int AgentViewVersion = 10;
     private static readonly TimeSpan CombatActionSnapshotStableDelay = TimeSpan.FromMilliseconds(200);
     private static string? _lastCombatActionReadinessSignature;
     private static DateTime _lastCombatActionReadinessSinceUtc = DateTime.MinValue;
@@ -129,6 +129,7 @@ internal static class GameStateService
             agent_view = BuildAgentViewPayload(
                 screen,
                 session,
+                SaveManager.Instance.CurrentProfileId,
                 runState?.Rng.StringSeed ?? "run_unknown",
                 combatState?.RoundNumber,
                 availableActions,
@@ -853,9 +854,16 @@ internal static class GameStateService
 
     public static bool CanConfirmSelection(IScreenContext? currentScreen)
     {
-        return TryGetCombatHandSelectionMetadata(currentScreen, out _, out var metadata) &&
-            metadata.RequiresConfirmation &&
-            metadata.CanConfirm;
+        if (TryGetCombatHandSelectionMetadata(currentScreen, out _, out var combatMetadata) &&
+            combatMetadata.RequiresConfirmation &&
+            combatMetadata.CanConfirm)
+        {
+            return true;
+        }
+
+        return TryGetDeckCardSelectionMetadata(currentScreen, out var deckMetadata) &&
+            deckMetadata.CanConfirm &&
+            (deckMetadata.RequiresConfirmation || deckMetadata.MinSelect < deckMetadata.MaxSelect);
     }
 
     public static bool CanProceed(IScreenContext? currentScreen)
@@ -2770,6 +2778,7 @@ internal static class GameStateService
     private static object BuildAgentViewPayload(
         string screen,
         SessionPayload session,
+        int nativeProfileId,
         string runId,
         int? turn,
         string[] availableActions,
@@ -2800,6 +2809,13 @@ internal static class GameStateService
         {
             version = AgentViewVersion,
             screen,
+            native_profile_id = nativeProfileId,
+            profiles = new[]
+            {
+                new { id = 1, current = nativeProfileId == 1 },
+                new { id = 2, current = nativeProfileId == 2 },
+                new { id = 3, current = nativeProfileId == 3 }
+            },
             run_id = runId,
             session,
             turn,
@@ -3031,7 +3047,7 @@ internal static class GameStateService
             max = selection.max_select,
             selected = selection.selected_count,
             confirm = selection.can_confirm,
-            cards = selection.cards.Select(card => BuildAgentChoiceCardPayload(card.index, card.name, card.upgraded, card.energy_cost, card.star_cost, card.costs_x, card.star_costs_x, GetPreferredCardRulesText(card.rules_text, card.resolved_rules_text), glossaryTerms)).ToArray()
+            cards = selection.cards.Select(card => BuildAgentChoiceCardPayload(card.index, card.name, card.upgraded, card.energy_cost, card.star_cost, card.costs_x, card.star_costs_x, GetPreferredCardRulesText(card.rules_text, card.resolved_rules_text), glossaryTerms, card.selected)).ToArray()
         };
     }
 
@@ -3352,7 +3368,8 @@ internal static class GameStateService
         bool costsX,
         bool starCostsX,
         string rulesText,
-        HashSet<string> glossaryTerms)
+        HashSet<string> glossaryTerms,
+        bool selected = false)
     {
         var keywords = GetGlossaryMatches(rulesText);
         CollectGlossaryTerms(glossaryTerms, rulesText);
@@ -3361,9 +3378,42 @@ internal static class GameStateService
         {
             i = index,
             line = FormatCardLine(name, upgraded, 1, energyCost, starCost, costsX, starCostsX, rulesText),
+            selected,
             keywords,
             mods = Array.Empty<string>()
         };
+    }
+
+    private static bool IsCardSelected(IScreenContext? currentScreen, CardModel card)
+    {
+        if (currentScreen is NDeckCardSelectScreen deckCardScreen &&
+            ReflectionMemberAccessor.TryGetValue(deckCardScreen, "_selectedCards") is IEnumerable selectedDeckCards)
+        {
+            foreach (var item in selectedDeckCards)
+            {
+                if (ReferenceEquals(item, card))
+                {
+                    return true;
+                }
+            }
+        }
+
+        if (TryGetCombatHandSelection(currentScreen, out var hand) && hand != null)
+        {
+            const BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic;
+            if (typeof(NPlayerHand).GetField("_selectedCards", flags)?.GetValue(hand) is IEnumerable selectedHandCards)
+            {
+                foreach (var item in selectedHandCards)
+                {
+                    if (ReferenceEquals(item, card))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 
     private static object BuildAgentPricedCardPayload(
@@ -4029,7 +4079,10 @@ internal static class GameStateService
             can_confirm = hasCombatHandSelection
                 ? combatHandSelection.CanConfirm
                 : hasDeckCardSelection && deckCardSelection.CanConfirm,
-            cards = cards.Select((holder, index) => BuildSelectionCardPayload(holder.CardModel!, index)).ToArray()
+            cards = cards.Select((holder, index) => BuildSelectionCardPayload(
+                holder.CardModel!,
+                index,
+                IsCardSelected(currentScreen, holder.CardModel!))).ToArray()
         };
     }
 
@@ -5397,13 +5450,14 @@ internal static class GameStateService
         };
     }
 
-    private static SelectionCardPayload BuildSelectionCardPayload(CardModel card, int index)
+    private static SelectionCardPayload BuildSelectionCardPayload(CardModel card, int index, bool selected)
     {
         var resolvedRulesText = GetResolvedCardRulesText(card);
         var dynamicValues = BuildCardDynamicValuePayloads(card);
         return new SelectionCardPayload
         {
             index = index,
+            selected = selected,
             card_id = card.Id.Entry,
             name = card.Title,
             upgraded = card.IsUpgraded,
@@ -7299,6 +7353,8 @@ internal sealed class DeckCardPayload
 internal sealed class SelectionCardPayload
 {
     public int index { get; init; }
+
+    public bool selected { get; init; }
 
     public string card_id { get; init; } = string.Empty;
 

--- a/STS2AIAgent/Multiplayer/CoopLaunchPolicy.cs
+++ b/STS2AIAgent/Multiplayer/CoopLaunchPolicy.cs
@@ -7,13 +7,26 @@ internal static class CoopLaunchPolicy
     public static string CompanionArguments(string? forceSteam, string? clientId)
     {
         if (!string.Equals(forceSteam, "off", StringComparison.OrdinalIgnoreCase)) return "--windowed";
-        var arguments = "--windowed --force-steam off";
-        if (ulong.TryParse(clientId, out var id))
+        ulong companionId;
+        if (string.IsNullOrWhiteSpace(clientId))
         {
-            if (id == ulong.MaxValue) throw new InvalidOperationException("Offline clientId leaves no adjacent companion ID.");
-            arguments += " --clientId " + (id + 1).ToString(System.Globalization.CultureInfo.InvariantCulture);
+            companionId = 1;
         }
-        return arguments;
+        else if (!ulong.TryParse(clientId, out var id))
+        {
+            throw new InvalidOperationException("Offline clientId must be a non-negative integer.");
+        }
+        else if (id == ulong.MaxValue)
+        {
+            throw new InvalidOperationException("Offline clientId leaves no adjacent companion ID.");
+        }
+        else
+        {
+            companionId = id + 1;
+        }
+
+        return "--windowed --force-steam off --clientId " +
+            companionId.ToString(System.Globalization.CultureInfo.InvariantCulture);
     }
 
     public static bool TryGetCompanionArguments(string? forceSteam, string? clientId, out string arguments, out string? error)
@@ -57,14 +70,14 @@ internal static class CoopLaunchPolicy
             return;
 
         if (string.Equals(System.IO.Path.GetFullPath(mainSettingsPath), System.IO.Path.GetFullPath(companionSettingsPath), StringComparison.OrdinalIgnoreCase))
-            return;
+            throw new InvalidOperationException("Companion settings path must be different from the host settings path.");
 
         var dir = System.IO.Path.GetDirectoryName(companionSettingsPath);
         if (!string.IsNullOrEmpty(dir))
             System.IO.Directory.CreateDirectory(dir);
 
-        if (System.IO.File.Exists(mainSettingsPath) && !System.IO.File.Exists(companionSettingsPath))
-            System.IO.File.Copy(mainSettingsPath, companionSettingsPath, overwrite: false);
+        if (System.IO.File.Exists(mainSettingsPath))
+            System.IO.File.Copy(mainSettingsPath, companionSettingsPath, overwrite: true);
     }
 
     public static string? GetError(bool isCompanion, bool autoPlayRunning, string screen, ResolvedModel? model)

--- a/STS2AIAgent/Multiplayer/DualInstanceCoordinator.cs
+++ b/STS2AIAgent/Multiplayer/DualInstanceCoordinator.cs
@@ -54,13 +54,10 @@ internal static class DualInstanceCoordinator
         {
             Log.Info($"{LogPrefix} Companion bootstrap starting");
             await WaitForScreenAsync(new[] { "MAIN_MENU", "MULTIPLAYER_LOBBY" }, TimeSpan.FromSeconds(90), cancellationToken);
-            var screen = await GetScreenAsync();
-            if (!string.Equals(screen, "MULTIPLAYER_LOBBY", StringComparison.Ordinal))
+            if (await GetScreenAsync() != "MULTIPLAYER_LOBBY")
             {
-                await OpenMultiplayerTestAsync(cancellationToken);
+                await WaitForScreenAsync(new[] { "MULTIPLAYER_LOBBY" }, TimeSpan.FromSeconds(60), cancellationToken);
             }
-
-            await WaitForScreenAsync(new[] { "MULTIPLAYER_LOBBY" }, TimeSpan.FromSeconds(30), cancellationToken);
             await WaitForAnyActionAsync(new[] { "join_multiplayer_lobby" }, TimeSpan.FromSeconds(30), cancellationToken);
             await ExecuteActionAsync("join_multiplayer_lobby", cancellationToken);
             var next = await WaitForAnyActionAsync(

--- a/STS2AIAgent/Multiplayer/LocalDualInstanceLauncher.cs
+++ b/STS2AIAgent/Multiplayer/LocalDualInstanceLauncher.cs
@@ -105,15 +105,8 @@ internal static class LocalDualInstanceLauncher
             return new DualLaunchResult { Ok = false, Message = "找不到游戏可执行文件。" };
         }
 
-        int companionPort;
-        try
-        {
-            companionPort = HttpServer.FindFreePort(HttpServer.Instance.Port + 1);
-        }
-        catch (Exception ex)
-        {
-            return new DualLaunchResult { Ok = false, Message = "找不到空闲 API 端口：" + ex.Message };
-        }
+        var hostPort = HttpServer.Instance.Port;
+        var companionPort = hostPort is > 0 and < 65535 ? hostPort + 1 : 8081;
 
         if (!CoopLaunchPolicy.TryGetCompanionArguments(
                 CommandLineHelper.GetValue("force-steam"),
@@ -163,6 +156,7 @@ internal static class LocalDualInstanceLauncher
         };
 
         startInfo.Environment["STS2_API_PORT"] = companionPort.ToString();
+        startInfo.Environment["STS2_API_ALLOW_FALLBACK"] = "1";
         startInfo.Environment["STS2_AGENT_ROLE"] = InstanceRole.Companion;
         startInfo.Environment["STS2_MULTIPLAYER_HOST_IP"] = "127.0.0.1";
         startInfo.Environment["STS2_AGENT_AUTOPLAY"] = "1";
@@ -193,10 +187,10 @@ internal static class LocalDualInstanceLauncher
         // Retain the process handle after timeout/cancellation too. Retrying the
         // invite must not start a third game while this child is still alive.
         _companionProcess = process;
-        Connection = new CompanionConnection(companionPort, process.Id, sessionToken);
-        var ready = await WaitForHealthAsync(companionPort, process, TimeSpan.FromSeconds(90), cancellationToken);
-        if (!ready)
+        var readyPort = await WaitForHealthAsync(companionPort, process, TimeSpan.FromSeconds(90), cancellationToken);
+        if (readyPort == null)
         {
+            Connection = null;
             return new DualLaunchResult
             {
                 Ok = false,
@@ -208,47 +202,50 @@ internal static class LocalDualInstanceLauncher
             };
         }
 
+        Connection = new CompanionConnection(readyPort.Value, process.Id, sessionToken);
         return new DualLaunchResult
         {
             Ok = true,
-            CompanionPort = companionPort,
+            CompanionPort = readyPort.Value,
             CompanionPid = process.Id,
-            Message = $"第二实例已就绪：PID {process.Id}，API {companionPort}"
+            Message = $"第二实例已就绪：PID {process.Id}，API {readyPort.Value}"
         };
     }
 
-    private static async Task<bool> WaitForHealthAsync(int port, Process process, TimeSpan timeout, CancellationToken cancellationToken)
+    private static async Task<int?> WaitForHealthAsync(int preferredPort, Process process, TimeSpan timeout, CancellationToken cancellationToken)
     {
         using var http = new System.Net.Http.HttpClient { Timeout = TimeSpan.FromSeconds(2) };
         var deadline = DateTime.UtcNow + timeout;
-        var url = $"http://127.0.0.1:{port}/health";
         while (DateTime.UtcNow < deadline)
         {
             cancellationToken.ThrowIfCancellationRequested();
             if (process.HasExited)
             {
-                return false;
+                return null;
             }
 
-            try
+            foreach (var port in CompanionPortFile.EnumerateCandidates(preferredPort, process.Id))
             {
-                var json = await http.GetStringAsync(url, cancellationToken);
-                if (CompanionHealth.IsExpectedProcess(json, port, process.Id))
+                try
                 {
-                    return true;
+                    var json = await http.GetStringAsync($"http://127.0.0.1:{port}/health", cancellationToken);
+                    if (CompanionHealth.IsExpectedProcess(json, port, process.Id))
+                    {
+                        return port;
+                    }
                 }
-            }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                throw;
-            }
-            catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
-            {
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+                {
+                }
             }
 
             await Task.Delay(1000, cancellationToken);
         }
 
-        return false;
+        return null;
     }
 }

--- a/STS2AIAgent/Server/CompanionPortFile.cs
+++ b/STS2AIAgent/Server/CompanionPortFile.cs
@@ -1,0 +1,61 @@
+namespace STS2AIAgent.Server;
+
+internal static class CompanionPortFile
+{
+    public static string PathFor(int pid) =>
+        Path.Combine(Path.GetTempPath(), $"sts2-ai-agent-companion-{pid}.port");
+
+    public static void Write(int pid, int port)
+    {
+        File.WriteAllText(PathFor(pid), port.ToString(System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    public static int? TryRead(int pid)
+    {
+        try
+        {
+            var text = File.ReadAllText(PathFor(pid)).Trim();
+            return int.TryParse(text, out var port) && port is > 0 and <= 65535 ? port : null;
+        }
+        catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException or IOException)
+        {
+            return null;
+        }
+    }
+
+    public static void Delete(int pid)
+    {
+        try
+        {
+            File.Delete(PathFor(pid));
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+        }
+    }
+
+    public static IEnumerable<int> EnumerateCandidates(int preferredPort, int pid)
+    {
+        var seen = new HashSet<int>();
+        if (preferredPort is > 0 and <= 65535 && seen.Add(preferredPort))
+        {
+            yield return preferredPort;
+        }
+
+        var published = TryRead(pid);
+        if (published is > 0 and <= 65535 && seen.Add(published.Value))
+        {
+            yield return published.Value;
+        }
+
+        var nearby = Math.Min(LoopbackListener.NearbyPortCount, Math.Max(0, 65536 - preferredPort));
+        for (var offset = 1; offset < nearby; offset++)
+        {
+            var port = preferredPort + offset;
+            if (seen.Add(port))
+            {
+                yield return port;
+            }
+        }
+    }
+}

--- a/STS2AIAgent/Server/HttpServer.cs
+++ b/STS2AIAgent/Server/HttpServer.cs
@@ -42,12 +42,13 @@ public sealed class HttpServer
             }
 
             var preferredPort = ResolvePreferredPort();
-            var allowIncrement = !IsExplicitPortConfigured();
+            var allowIncrement = !IsExplicitPortConfigured() || AllowFallback();
             var started = LoopbackListener.Start(preferredPort, allowIncrement);
             _listener = started.Listener;
             Port = started.Port;
             PortWasAutoIncremented = started.Port != preferredPort;
             Prefix = $"http://{DefaultHost}:{Port}/";
+            PublishCompanionPort(Port);
 
             _cts = new CancellationTokenSource();
             _listenLoopTask = Task.Run(() => ListenLoopAsync(_listener, _cts.Token));
@@ -127,6 +128,7 @@ public sealed class HttpServer
             cts?.Dispose();
         }
 
+        ClearCompanionPort();
         Log.Info($"{LogPrefix} Stopped");
     }
 
@@ -161,12 +163,48 @@ public sealed class HttpServer
         }
     }
 
+    internal static bool AllowFallback()
+    {
+        var raw = Environment.GetEnvironmentVariable("STS2_API_ALLOW_FALLBACK");
+        return string.Equals(raw, "1", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(raw, "true", StringComparison.OrdinalIgnoreCase);
+    }
+
     private static bool IsExplicitPortConfigured()
     {
         var rawPort = Environment.GetEnvironmentVariable("STS2_API_PORT");
         return !string.IsNullOrWhiteSpace(rawPort) &&
             int.TryParse(rawPort.Trim(), out var port) &&
             port is > 0 and <= 65535;
+    }
+
+    private static void PublishCompanionPort(int port)
+    {
+        var role = Environment.GetEnvironmentVariable("STS2_AGENT_ROLE");
+        if (!string.Equals(role, "companion", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        try
+        {
+            CompanionPortFile.Write(Environment.ProcessId, port);
+        }
+        catch (Exception ex)
+        {
+            Log.Warn($"{LogPrefix} Failed to publish companion port: {ex.Message}");
+        }
+    }
+
+    private static void ClearCompanionPort()
+    {
+        try
+        {
+            CompanionPortFile.Delete(Environment.ProcessId);
+        }
+        catch
+        {
+        }
     }
 
     private static int ResolvePreferredPort()


### PR DESCRIPTION
## Summary
Follow-up to merged PRs #53-#66. One PR with the must-fix correctness gaps from the post-merge review.

- **Autoplay boundary:** `act` / `get_game_state` / `wait_until_actionable` rethrow or re-check `CurrentRunBoundary`, so leaving a run stops the tool loop.
- **Budget:** request caps are checked before each LLM round (including in-flight rounds). Chat and teammate replies share the same `SessionBudgetGuard`.
- **Deck selection:** `select_deck_card` no longer confirms at `min_select`; cards expose `selected`; `confirm_selection` works on deck-grid screens.
- **Combat settle:** hand selection waits for action-queue readiness; timeouts return pending instead of a weaker `stable=true`.
- **Companion launch:** preferred port may fall back (`STS2_API_ALLOW_FALLBACK` + pid port file); settings are recopied on every invite; offline launches always get a distinct `clientId`; companion joins the host lobby and does not run `multiplayer test`.
- **Profiles:** compact state includes `native_profile_id` / `profiles[]`; playbook says not to `switch_profile` unless asked.

## Test plan
- [x] `dotnet run --project STS2AIAgent.Tests/STS2AIAgent.Tests.csproj -c Release` (all passing)
- [ ] Live co-op invite (port fallback + settings reseed)
- [ ] Live deck multi-select (min < max then `confirm_selection`)
- [ ] Autoplay stop on return to main menu without extra model rounds

## Summary by Sourcery

Close post-merge correctness gaps across autoplay control, request budgeting, deck and combat selection, companion startup, and profile state reporting.

Bug Fixes:
- Stop autoplay promptly when the current run ends and prevent additional model rounds after the run boundary is crossed.
- Enforce session request budgets before every LLM round, including in-flight requests and chat or teammate replies.
- Correct deck multi-selection behavior by exposing selected cards and requiring confirmation only when appropriate.
- Improve combat and card-selection settling so pending transitions are not reported as stable completion.
- Make companion launches resilient to port changes, refresh settings on every invite, isolate offline client identities, and have companions join the host lobby.
- Expose native profile identity and available profiles while discouraging unsolicited profile switching.

Enhancements:
- Use atomic settings-file replacement and expand state payload versioning for the updated agent contract.

Documentation:
- Update the changelog and playbook guidance for autoplay boundaries, budgets, selection behavior, companion startup, and profile handling.

Tests:
- Add coverage for run-boundary handling, in-flight budgets, companion port discovery and bootstrap behavior, deck-selection contracts, and profile/state payload changes.