### PR TITLE
Release v0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.10.3 - 2026-09-07
+
+### Fixed
+- Invited teammates no longer stop autoplay while waiting to follow a map vote.
+- Map node votes are not offered during an active fight, so end_turn/play_card stay available.
+
+### Added
+- In-game autoplay and native MCP load the sts2-mcp-player play contract.
+- README and Workshop listings tell external MCP clients to load that skill.
+
+### Validation
+- Live invite run YFZH54KDS15D: companion followed map votes and played cards; host reached GAME_OVER with save_status=verified.
+
 ## v0.10.2 - 2026-09-06
 
 ### Added

--- a/STS2AIAgent.Tests/MapCombatGatingTests.cs
+++ b/STS2AIAgent.Tests/MapCombatGatingTests.cs
@@ -1,0 +1,15 @@
+using System;
+namespace STS2AIAgent.Tests;
+
+internal static class MapCombatGatingTests
+{
+    public static void ChooseMapNodeHiddenWhileCombatInProgress()
+    {
+        var source = AgentSourceFixture.WithoutWhitespace(
+            AgentSourceFixture.Read("STS2AIAgent/Game/GameStateService.cs"));
+        var start = source.IndexOf("publicstaticboolCanChooseMapNode", StringComparison.Ordinal);
+        Assert.True(start >= 0);
+        var method = source.Substring(start, Math.Min(400, source.Length - start));
+        Assert.Contains("if(CombatManager.Instance.IsInProgress){returnfalse;}", method, StringComparison.Ordinal);
+    }
+}

--- a/STS2AIAgent.Tests/TestRunner.cs
+++ b/STS2AIAgent.Tests/TestRunner.cs
@@ -226,6 +226,7 @@ internal static class TestRunner
         yield return ("DeckSelection.PayloadProgress", () => Task.Run(DeckSelectionContractTests.DeckGridPayloadReportsNativeSelectionProgress));
         yield return ("DeckSelection.ClickSettle", () => Task.Run(DeckSelectionContractTests.DeckGridClickSettlesInEitherDirectionBeforeConfirming));
         yield return ("CombatDiagnostics.CanPlay", () => Task.Run(CombatDiagnosticsContractTests.HandPayloadKeepsNativeCanPlayEvidence));
+        yield return ("Map.NoVoteDuringCombat", () => Task.Run(MapCombatGatingTests.ChooseMapNodeHiddenWhileCombatInProgress));
         yield return ("CombatDiagnostics.Readiness", () => Task.Run(CombatDiagnosticsContractTests.CombatPayloadDistinguishesQueueModalAndSnapshotLocks));
         yield return ("ProfileSelection.NativeSwitch", () => Task.Run(ProfileSelectionContractTests.NativeProfileIdentityAndSwitchAreWiredEndToEnd));
         yield return ("AgentLoop.PlayOnce", AgentLoopTests.PlayOnce_ExecutesSingleValidatedAct);

--- a/STS2AIAgent/Game/GameStateService.cs
+++ b/STS2AIAgent/Game/GameStateService.cs
@@ -859,6 +859,12 @@ internal static class GameStateService
 
     public static bool CanChooseMapNode(IScreenContext? currentScreen, RunState? runState)
     {
+        // Map votes during an active fight hide end_turn/play_card and desync co-op.
+        if (CombatManager.Instance.IsInProgress)
+        {
+            return false;
+        }
+
         return GetAvailableMapNodes(currentScreen, runState).Count > 0;
     }
 

--- a/STS2AIAgent/Server/Router.cs
+++ b/STS2AIAgent/Server/Router.cs
@@ -15,7 +15,7 @@ internal static class Router
 {
     private const string ServiceName = "sts2-ai-agent";
     private const string ProtocolVersion = "2026-03-11-v1";
-    internal const string ModVersion = "0.10.2";
+    internal const string ModVersion = "0.10.3";
     private const string LogPrefix = "[STS2AIAgent.Router]";
 
     private static long _requestCounter;

--- a/STS2AIAgent/mod_id.json
+++ b/STS2AIAgent/mod_id.json
@@ -3,7 +3,7 @@
   "name": "STS2 AI Agent",
   "author": "CharTyr",
   "description": "带一个 AI 一起爬塔。你打自己的角色，同一台电脑上 AI 可以打另一个。还在开发中，欢迎反馈。",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "min_game_version": "0.111.0",
   "has_pck": true,
   "has_dll": true,

--- a/STS2AIAgent/mod_manifest.json
+++ b/STS2AIAgent/mod_manifest.json
@@ -4,7 +4,7 @@
   "name": "STS2 AI Agent",
   "author": "CharTyr",
   "description": "带一个 AI 一起爬塔。你打自己的角色，同一台电脑上 AI 可以打另一个。还在开发中，欢迎反馈。",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "min_game_version": "0.111.0",
   "has_pck": true,
   "has_dll": true,

--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sts2-ai-agent-mcp"
-version = "0.10.2"
+version = "0.10.3"
 description = "FastMCP wrapper for the local STS2 AI Agent mod"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/mcp_server/uv.lock
+++ b/mcp_server/uv.lock
@@ -1141,7 +1141,7 @@ wheels = [
 
 [[package]]
 name = "sts2-ai-agent-mcp"
-version = "0.10.2"
+version = "0.10.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/steam-workshop/workshop.json
+++ b/steam-workshop/workshop.json
@@ -1,7 +1,7 @@
 {
   "title": "STS2 AI Agent",
   "visibility": "private",
-  "changeNote": "v0.10.2 in-mod MCP on the Connect tab",
+  "changeNote": "v0.10.3 co-op climb, game-over save, MCP skill",
   "tags": [
     "Tools & APIs",
     "Utility",


### PR DESCRIPTION
## 问题
战斗过程中仍会暴露 choose_map_node，脚本/模型一点地图就会把 end_turn 藏掉，联机局容易卡死。

## 改动
- 战斗进行中不再提供地图投票。
- 版本 0.10.3。

## 验证
- C# 单测含 Map.NoVoteDuringCombat。
- 实机邀请 MiniMax 队友 YFZH54KDS15D：队友跟票并自己出牌，对局打到 GAME_OVER，save_status=verified。

## Summary by Sourcery

Prevent combat-time map voting from blocking cooperative runs and release version 0.10.3.

Bug Fixes:
- Prevent map node voting during active combat so co-op players retain access to turn-ending and card-playing actions.
- Keep invited teammates progressing through map votes and card play until the run reaches GAME_OVER.

Build:
- Bump the mod and MCP package version to 0.10.3.

Documentation:
- Document the play contract for in-game autoplay and native MCP clients in the changelog and external MCP guidance.

Tests:
- Add coverage verifying that map voting is unavailable while combat is in progress.