### PR TITLE
fix(release): package README skill link

### DIFF
--- a/scripts/package-release.ps1
+++ b/scripts/package-release.ps1
@@ -89,6 +89,7 @@ function Rewrite-PackagedReadmeLinks {
         "(./COOP_DELIVERY.md)" = "(https://github.com/CharTyr/STS2-Agent/blob/main/COOP_DELIVERY.md)"
         "(./docs/api.md)" = "(https://github.com/CharTyr/STS2-Agent/blob/main/docs/api.md)"
         "(../skills/sts2-mcp-player/SKILL.md)" = "(https://github.com/CharTyr/STS2-Agent/blob/main/skills/sts2-mcp-player/SKILL.md)"
+        "(./skills/sts2-mcp-player/SKILL.md)" = "(https://github.com/CharTyr/STS2-Agent/blob/main/skills/sts2-mcp-player/SKILL.md)"
         "(../docs/release-readiness.md)" = "(https://github.com/CharTyr/STS2-Agent/blob/main/docs/release-readiness.md)"
     }
     foreach ($pair in $replacements.GetEnumerator()) {


### PR DESCRIPTION
Packaged README now rewrites the sts2-mcp-player relative link to GitHub so the v0.10.3 zip check passes.

## Summary by Sourcery

Bug Fixes:
- Ensure packaged English and Chinese README files rewrite both parent-relative and package-relative sts2-mcp-player links to their GitHub location.