### PR TITLE
chore: sync 0.10.4 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.10.4 - 2026-09-07
+
+### Fixed
+- Relic/shop FTUE popups no longer stay open after confirm_modal.
+- Timeline first-visit tutorial can be confirmed; screen is TIMELINE not MAIN_MENU.
+- In-game play rejects locked event options.
+
+### Changed
+- Character unlocks are documented as timeline overlays. Slot obtained epochs, then confirm_unlock.
+
+### Validation
+- Profile 3: Silent unlocked via NEOW then SILENT1. confirm_unlock completed NUnlockCardsScreen, NUnlockTimelineScreen, NUnlockPotionsScreen, NUnlockMiscScreen. GAME_OVER save_status=verified.
+
 ## v0.10.3 - 2026-09-07
 
 ### Fixed

--- a/STS2AIAgent/mod_id.json
+++ b/STS2AIAgent/mod_id.json
@@ -3,7 +3,7 @@
   "name": "STS2 AI Agent",
   "author": "CharTyr",
   "description": "带一个 AI 一起爬塔。你打自己的角色，同一台电脑上 AI 可以打另一个。还在开发中，欢迎反馈。",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "min_game_version": "0.111.0",
   "has_pck": true,
   "has_dll": true,

--- a/steam-workshop/workshop.json
+++ b/steam-workshop/workshop.json
@@ -1,7 +1,7 @@
 {
   "title": "STS2 AI Agent",
   "visibility": "private",
-  "changeNote": "v0.10.3 co-op climb, game-over save, MCP skill",
+  "changeNote": "v0.10.4 timeline unlocks, stuck FTUE confirm, locked event options",
   "tags": [
     "Tools & APIs",
     "Utility",


### PR DESCRIPTION
Sync leftover 0.10.4 metadata that preflight requires: mod_id.json version, CHANGELOG, workshop change note.

## Summary by Sourcery

Synchronize the remaining 0.10.4 release metadata and document its validated fixes and behavior changes.

Bug Fixes:
- Document the 0.10.4 fixes for tutorial confirmation, popup dismissal, and rejection of locked event options.

Enhancements:
- Document character unlock behavior and validation results for the 0.10.4 release.

Documentation:
- Add the 0.10.4 changelog entry with fixes, behavior changes, and validation details.

Chores:
- Synchronize the mod and Steam Workshop release metadata for version 0.10.4.