### PR TITLE
fix: empty reward screen no longer hangs collect_rewards

### DIFF
--- a/STS2AIAgent.Tests/RewardFlowContractTests.cs
+++ b/STS2AIAgent.Tests/RewardFlowContractTests.cs
@@ -1,0 +1,20 @@
+using STS2AIAgent.Game;
+
+namespace STS2AIAgent.Tests;
+
+internal static class RewardFlowContractTests
+{
+    public static void EmptyRewardsScreenEscapesInsteadOfPending()
+    {
+        var actionSource = AgentSourceFixture.Read("STS2AIAgent/Game/GameActionService.cs");
+        var drain = AgentSourceFixture.MethodBody(actionSource, "DrainRewardFlowAsync");
+        Assert.Contains("TryEscapeEmptyRewardsScreenAsync", drain);
+
+        var escape = AgentSourceFixture.MethodBody(actionSource, "TryEscapeEmptyRewardsScreenAsync");
+        Assert.Contains("TryEnableProceedButton", escape);
+        Assert.Contains("ForceClick()", escape);
+        Assert.Contains("NOverlayStack.Instance?.Remove", escape);
+        Assert.Contains("ProceedFromTerminalRewardsScreen", escape);
+        Assert.Contains("TryGetNextClaimableRewardButton", escape);
+    }
+}

--- a/STS2AIAgent.Tests/TestRunner.cs
+++ b/STS2AIAgent.Tests/TestRunner.cs
@@ -210,6 +210,7 @@ internal static class TestRunner
         yield return ("UnlockConfirm.Session", () => Task.Run(UnlockConfirmResolutionPolicyTests.ProbeSignatureIncludesScreenInstance));
         yield return ("UnlockScreen.MixedCardGrid", () => Task.Run(UnlockScreenContractTests.UnlockCardsScreenWithVisibleGridReportsOnlyUnlockAction));
         yield return ("GameOver.ContinueAction", () => Task.Run(GameOverContractTests.DedicatedContinueActionIsWiredEndToEnd));
+        yield return ("Reward.EmptyScreenEscape", () => Task.Run(RewardFlowContractTests.EmptyRewardsScreenEscapesInsteadOfPending));
         yield return ("Skill.McpPlayerContract", () => Task.Run(McpPlayerSkillTests.SkillTracksLivePlayContract));
         yield return ("GameOver.ReturnGate", () => Task.Run(GameOverContractTests.ReturnActionRequiresVisibleAndEnabledMainMenuButton));
         yield return ("GameOver.NativeButtons", () => Task.Run(GameOverContractTests.ContinueAndReturnUseNativeButtonsWithoutSkippingSummary));

--- a/STS2AIAgent/Game/GameActionService.cs
+++ b/STS2AIAgent/Game/GameActionService.cs
@@ -2173,7 +2173,90 @@ internal static class GameActionService
                 return await WaitForRewardFlowExitAsync(rewardsScreen, deadline);
             }
 
-            return IsRewardFlowStable();
+            if (await TryEscapeEmptyRewardsScreenAsync(rewardsScreen, deadline))
+            {
+                return true;
+            }
+        }
+
+        return IsRewardFlowStable();
+    }
+
+    private static async Task<bool> TryEscapeEmptyRewardsScreenAsync(NRewardsScreen rewardsScreen, DateTime deadline)
+    {
+        var emptySince = DateTime.UtcNow;
+        while (DateTime.UtcNow < deadline)
+        {
+            await WaitForNextFrameAsync();
+            if (!GodotObject.IsInstanceValid(rewardsScreen) ||
+                ActiveScreenContext.Instance.GetCurrentScreen() != rewardsScreen)
+            {
+                return true;
+            }
+
+            if (TryGetNextClaimableRewardButton(rewardsScreen, new HashSet<ulong>(), out _))
+            {
+                return false;
+            }
+
+            var proceedButton = GameStateService.GetRewardProceedButton(rewardsScreen);
+            if (proceedButton != null && proceedButton.IsEnabled)
+            {
+                proceedButton.ForceClick();
+                return await WaitForRewardFlowExitAsync(rewardsScreen, deadline);
+            }
+
+            if (DateTime.UtcNow - emptySince < TimeSpan.FromSeconds(1))
+            {
+                continue;
+            }
+
+            try
+            {
+                rewardsScreen.Call("TryEnableProceedButton");
+            }
+            catch
+            {
+            }
+
+            proceedButton = GameStateService.GetRewardProceedButton(rewardsScreen);
+            if (proceedButton != null)
+            {
+                proceedButton.ForceClick();
+                var proceedDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(3);
+                if (proceedDeadline > deadline)
+                {
+                    proceedDeadline = deadline;
+                }
+
+                if (await WaitForRewardFlowExitAsync(rewardsScreen, proceedDeadline))
+                {
+                    return true;
+                }
+            }
+
+            try
+            {
+                NOverlayStack.Instance?.Remove(rewardsScreen);
+            }
+            catch
+            {
+            }
+
+            if (await WaitForRewardFlowExitAsync(rewardsScreen, deadline))
+            {
+                return true;
+            }
+
+            try
+            {
+                _ = RunManager.Instance.ProceedFromTerminalRewardsScreen();
+            }
+            catch
+            {
+            }
+
+            return await WaitForRewardFlowExitAsync(rewardsScreen, deadline);
         }
 
         return IsRewardFlowStable();

--- a/skills/sts2-mcp-player/references/screen-playbooks.md
+++ b/skills/sts2-mcp-player/references/screen-playbooks.md
@@ -58,7 +58,7 @@ Use this reference when the active screen is clear and you need the exact action
 
 ## REWARD
 
-- Prefer `collect_rewards_and_proceed` for hands-off reward cleanup.
+- Prefer `collect_rewards_and_proceed` for hands-off reward cleanup. An empty rewards overlay with `can_proceed=false` is still that action; it should close the overlay instead of staying pending.
 - If `reward.pending_card_choice = true`, use `choose_reward_card` or `skip_reward_cards`.
 - If `skip_reward_cards` closes only the overlay, re-read state to see whether the parent reward remains claimable.
 - Do not use `proceed` on reward flows.


### PR DESCRIPTION
Empty combat reward screens were leaving collect_rewards_and_proceed pending forever: no claimable NRewardButton, proceed disabled, DrainRewardFlowAsync returned immediately.

That matches the live hang at floor 18 (rewards=[], can_proceed=false). The last loot row, terminal loot, and the room-exit skip path can all look like that.

After a short wait, enable/click proceed even if it is still disabled, then remove the overlay if the screen does not leave.

Live check on 0.10.4+this build: normal gold/potion/card loot still completes to MAP. Empty-overlay escape is covered by source contract tests.

## Summary by Sourcery

Ensure empty reward screens exit reliably instead of blocking reward collection.

Bug Fixes:
- Prevent empty reward screens from leaving `collect_rewards_and_proceed` pending indefinitely by escaping stalled overlays and continuing the run.

Documentation:
- Document that empty, non-proceedable reward overlays are handled by `collect_rewards_and_proceed`.

Tests:
- Add a contract test covering the empty reward screen escape behavior.