### PR TITLE
chore: ignore local mod-uploader.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ _bmad-output/
 .claude/
 .serena/
 node_modules/
+
+# Local Steam workshop uploader output
+mod-uploader.log


### PR DESCRIPTION
Stop leaving an untracked mod-uploader.log after Steam Workshop uploads.

## Summary by Sourcery

Chores:
- Ignore the local mod-uploader.log generated by Steam Workshop uploads.