### PR TITLE
fix: wait for native game-over save before Return

### DIFF
--- a/STS2AIAgent.Tests/GameOverContractTests.cs
+++ b/STS2AIAgent.Tests/GameOverContractTests.cs
@@ -66,6 +66,7 @@ internal static class GameOverContractTests
         Assert.Contains("ExecuteContinueGameOverAsync", actionSource, StringComparison.Ordinal);
         Assert.Contains("NGameOverContinueButton", continueBody, StringComparison.Ordinal);
         Assert.Contains("ForceClick", continueBody, StringComparison.Ordinal);
+        Assert.Contains("IsGameOverSummaryStarted", continueBody, StringComparison.Ordinal);
         Assert.Contains("WaitForGameOverSummaryReadyAsync", continueBody, StringComparison.Ordinal);
         Assert.Contains("NReturnToMainMenuButton", returnBody, StringComparison.Ordinal);
         Assert.Contains("ForceClick", returnBody, StringComparison.Ordinal);
@@ -81,6 +82,10 @@ internal static class GameOverContractTests
         Assert.False(
             continueBody.Contains("GetProceedButton", StringComparison.Ordinal),
             "continue_game_over must resolve NGameOverContinueButton directly, not reuse the generic proceed-button path.");
+        Assert.False(
+            continueBody.Contains("TrySkipGameOverSummary", StringComparison.Ordinal),
+            "continue_game_over must wait for the native Return button instead of skipping the summary save.");
+        Assert.Contains("TimeSpan.FromSeconds(60)", continueBody, StringComparison.Ordinal);
     }
 
     public static void ContinueWaitsForNativeSummaryReadiness()
@@ -96,6 +101,29 @@ internal static class GameOverContractTests
         Assert.False(
             waitBody.Contains("CanContinueGameOver", StringComparison.Ordinal),
             "Disabling Continue starts the native summary animation; it must not complete the action before the summary button is ready.");
+    }
+
+    public static void ContinueDoesNotForceEnableReturnBeforeNativeSave()
+    {
+        var rawActionSource = AgentSourceFixture.Read("STS2AIAgent/Game/GameActionService.cs");
+        var continueBody = AgentSourceFixture.WithoutWhitespace(
+            AgentSourceFixture.MethodBody(rawActionSource, "ExecuteContinueGameOverAsync"));
+        var stateSource = AgentSourceFixture.Read("STS2AIAgent/Game/GameStateService.cs");
+
+        Assert.Contains("WaitForGameOverContinueOrSummaryAsync", continueBody, StringComparison.Ordinal);
+        Assert.Contains("TimeSpan.FromSeconds(60)", continueBody, StringComparison.Ordinal);
+        Assert.False(
+            continueBody.Contains(".Enable()", StringComparison.Ordinal),
+            "continue_game_over must not Enable the native Return button before SaveProgressFile.");
+        Assert.False(
+            continueBody.Contains("TrySkipGameOverSummary", StringComparison.Ordinal),
+            "continue_game_over must wait for the native Return button instead of skipping the summary save.");
+        Assert.False(
+            continueBody.Contains("TimeSpan.FromSeconds(15)", StringComparison.Ordinal),
+            "continue_game_over must not fall back to the 15-second skip timeout.");
+        Assert.False(
+            stateSource.Contains("TrySkipGameOverSummary", StringComparison.Ordinal),
+            "The skip helper that previously force-enabled Return must not remain in GameStateService.");
     }
 
     public static void GameOverPayloadKeepsContinueSummaryAndReturnAsDistinctPhases()

--- a/STS2AIAgent.Tests/TestRunner.cs
+++ b/STS2AIAgent.Tests/TestRunner.cs
@@ -215,6 +215,7 @@ internal static class TestRunner
         yield return ("GameOver.ReturnGate", () => Task.Run(GameOverContractTests.ReturnActionRequiresVisibleAndEnabledMainMenuButton));
         yield return ("GameOver.NativeButtons", () => Task.Run(GameOverContractTests.ContinueAndReturnUseNativeButtonsWithoutSkippingSummary));
         yield return ("GameOver.SummaryReady", () => Task.Run(GameOverContractTests.ContinueWaitsForNativeSummaryReadiness));
+        yield return ("GameOver.NoForcedReturn", () => Task.Run(GameOverContractTests.ContinueDoesNotForceEnableReturnBeforeNativeSave));
         yield return ("GameOver.Phases", () => Task.Run(GameOverContractTests.GameOverPayloadKeepsContinueSummaryAndReturnAsDistinctPhases));
         yield return ("GameOver.SaveContract", () => Task.Run(GameOverContractTests.GameOverPayloadReportsPhysicalProgressSaveVerification));
         yield return ("GameOver.SaveVerified", () => Task.Run(ProgressSaveVerificationTests.MatchingPhysicalFileIsVerified));

--- a/STS2AIAgent/Game/GameActionService.cs
+++ b/STS2AIAgent/Game/GameActionService.cs
@@ -125,6 +125,7 @@ internal static class GameActionService
             "switch_profile" => ExecuteSwitchProfileAsync(request),
             "continue_run" => ExecuteContinueRunAsync(),
             "continue_game_over" => ExecuteContinueGameOverAsync(),
+            "dismiss_game_over_wait" => ExecuteDismissGameOverWaitAsync(),
             "abandon_run" => ExecuteAbandonRunAsync(),
             "save_and_quit" => ExecuteSaveAndQuitAsync(),
             "open_character_select" => ExecuteOpenCharacterSelectAsync(),
@@ -4597,13 +4598,45 @@ internal static class GameActionService
         };
     }
 
+    private static async Task<ActionResponsePayload> ExecuteDismissGameOverWaitAsync()
+    {
+        var currentScreen = ActiveScreenContext.Instance.GetCurrentScreen();
+        var screen = GameStateService.ResolveScreen(currentScreen);
+        if (currentScreen is not NGameOverScreen || !GameStateService.IsWaitingForOtherPlayers(currentScreen))
+        {
+            throw new ApiException(409, "invalid_action", "Action is not available in the current state.", new
+            {
+                action = "dismiss_game_over_wait",
+                screen
+            });
+        }
+
+        GameStateService.HideWaitingForOtherPlayers(currentScreen);
+        var stable = await WaitForGameOverContinueOrSummaryAsync(TimeSpan.FromSeconds(8));
+        return new ActionResponsePayload
+        {
+            action = "dismiss_game_over_wait",
+            status = stable ? "completed" : "pending",
+            stable = stable,
+            message = stable ? "Action completed." : "Action queued but state is still transitioning.",
+            state = GameStateService.BuildStatePayload()
+        };
+    }
+
     private static async Task<ActionResponsePayload> ExecuteContinueGameOverAsync()
     {
         var currentScreen = ActiveScreenContext.Instance.GetCurrentScreen();
         var screen = GameStateService.ResolveScreen(currentScreen);
 
-        if (currentScreen is not NGameOverScreen gameOverScreen
-            || !GameStateService.CanContinueGameOver(currentScreen))
+        if (currentScreen is NGameOverScreen && GameStateService.IsWaitingForOtherPlayers(currentScreen))
+        {
+            GameStateService.HideWaitingForOtherPlayers(currentScreen);
+            await WaitForGameOverContinueOrSummaryAsync(TimeSpan.FromSeconds(8));
+            currentScreen = ActiveScreenContext.Instance.GetCurrentScreen();
+            screen = GameStateService.ResolveScreen(currentScreen);
+        }
+
+        if (currentScreen is not NGameOverScreen gameOverScreen)
         {
             throw new ApiException(409, "invalid_action", "Action is not available in the current state.", new
             {
@@ -4612,15 +4645,71 @@ internal static class GameActionService
             });
         }
 
-        NGameOverContinueButton continueButton = GameStateService.GetGameOverContinueButton(currentScreen)
-            ?? throw new ApiException(503, "state_unavailable", "Game-over continue button is unavailable.", new
+        if (GameStateService.CanReturnToMainMenu(gameOverScreen))
+        {
+            return new ActionResponsePayload
             {
                 action = "continue_game_over",
-                screen
-            }, retryable: true);
+                status = "completed",
+                stable = true,
+                message = "Action completed.",
+                state = GameStateService.BuildStatePayload()
+            };
+        }
 
-        continueButton.ForceClick();
-        var stable = await WaitForGameOverSummaryReadyAsync(gameOverScreen, TimeSpan.FromSeconds(15));
+        // Intro animation disables Continue for a second. Clicking then is a
+        // no-op, and later retries refuse to click because they think summary
+        // already started.
+        if (!GameStateService.CanContinueGameOver(gameOverScreen)
+            && !GameStateService.IsGameOverSummaryStarted(gameOverScreen))
+        {
+            await WaitForGameOverContinueOrSummaryAsync(TimeSpan.FromSeconds(8));
+            currentScreen = ActiveScreenContext.Instance.GetCurrentScreen();
+            if (currentScreen is not NGameOverScreen gameOverAfterIntro)
+            {
+                throw new ApiException(409, "invalid_action", "Action is not available in the current state.", new
+                {
+                    action = "continue_game_over",
+                    screen = GameStateService.ResolveScreen(currentScreen)
+                });
+            }
+
+            gameOverScreen = gameOverAfterIntro;
+            if (GameStateService.CanReturnToMainMenu(gameOverScreen))
+            {
+                return new ActionResponsePayload
+                {
+                    action = "continue_game_over",
+                    status = "completed",
+                    stable = true,
+                    message = "Action completed.",
+                    state = GameStateService.BuildStatePayload()
+                };
+            }
+        }
+
+        // Clicking Continue after the native summary has started re-runs
+        // OpenSummaryScreen and restarts the animation, so the main-menu
+        // button never appears. Only click once, then wait for native Return.
+        if (!GameStateService.IsGameOverSummaryStarted(gameOverScreen))
+        {
+            NGameOverContinueButton continueButton = GameStateService.GetGameOverContinueButton(currentScreen)
+                ?? throw new ApiException(503, "state_unavailable", "Game-over continue button is unavailable.", new
+                {
+                    action = "continue_game_over",
+                    screen
+                }, retryable: true);
+
+            continueButton.Visible = true;
+            continueButton.Set("disabled", false);
+            TryInvokePressed(continueButton);
+            continueButton.ForceClick();
+        }
+
+        // Native summary writes badges, score, unlocks, then enables Return.
+        // Do not force-enable that button: it lets the player leave before
+        // SaveProgressFile runs, so lifetime stats stay stale.
+        var stable = await WaitForGameOverSummaryReadyAsync(gameOverScreen, TimeSpan.FromSeconds(60));
 
         return new ActionResponsePayload
         {
@@ -5521,6 +5610,27 @@ internal static class GameActionService
         return ActiveScreenContext.Instance.GetCurrentScreen() is not NGameOverScreen;
     }
 
+    private static async Task<bool> WaitForGameOverContinueOrSummaryAsync(TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            await WaitForNextFrameAsync();
+            var currentScreen = ActiveScreenContext.Instance.GetCurrentScreen();
+            if (GameStateService.CanContinueGameOver(currentScreen)
+                || GameStateService.CanReturnToMainMenu(currentScreen)
+                || currentScreen is not NGameOverScreen)
+            {
+                return true;
+            }
+        }
+
+        var last = ActiveScreenContext.Instance.GetCurrentScreen();
+        return GameStateService.CanContinueGameOver(last)
+            || GameStateService.CanReturnToMainMenu(last)
+            || last is not NGameOverScreen;
+    }
+
     private static async Task<bool> WaitForGameOverSummaryReadyAsync(
         NGameOverScreen gameOverScreen,
         TimeSpan timeout)
@@ -5662,6 +5772,50 @@ internal static class GameActionService
         const BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic;
         var field = target.GetType().GetField(fieldName, flags);
         return field?.GetValue(target) as T;
+    }
+
+    private static void TryInvokePressed(NButton button)
+    {
+        const BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+        foreach (var name in new[] { "OnContinueButtonPressed", "OnPressed" })
+        {
+            try
+            {
+                var method = button.GetType().GetMethod(name, flags, binder: null, types: Type.EmptyTypes, modifiers: null);
+                method?.Invoke(button, null);
+            }
+            catch
+            {
+            }
+        }
+
+        try
+        {
+            var asyncPressed = button.GetType().GetMethod("OnContinueButtonPressedAsync", flags);
+            if (asyncPressed?.Invoke(button, null) is Task task)
+            {
+                ObserveBackgroundResult(task.ContinueWith(static completed =>
+                {
+                    if (completed.IsFaulted)
+                    {
+                        return false;
+                    }
+
+                    return true;
+                }), "continue_game_over");
+            }
+        }
+        catch
+        {
+        }
+
+        try
+        {
+            button.EmitSignal(Button.SignalName.Pressed);
+        }
+        catch
+        {
+        }
     }
 
     private static void InvokePrivateVoid(object target, string methodName, params object?[] args)

--- a/STS2AIAgent/Game/GameStateService.cs
+++ b/STS2AIAgent/Game/GameStateService.cs
@@ -727,7 +727,26 @@ internal static class GameStateService
         }
 
         var gameOver = BuildGameOverPayload(currentScreen, runState) ?? new GameOverPayload();
+        if (gameOver.waiting_for_other_players)
+        {
+            descriptors.Add(new ActionDescriptor
+            {
+                name = "dismiss_game_over_wait",
+                requires_target = false,
+                requires_index = false
+            });
+        }
+
         if (gameOver.can_continue)
+        {
+            descriptors.Add(new ActionDescriptor
+            {
+                name = "continue_game_over",
+                requires_target = false,
+                requires_index = false
+            });
+        }
+        else if (GetGameOverContinueButton(currentScreen) != null && !gameOver.can_return_to_main_menu)
         {
             descriptors.Add(new ActionDescriptor
             {
@@ -2678,7 +2697,16 @@ internal static class GameStateService
         }
 
         var gameOver = BuildGameOverPayload(currentScreen, runState) ?? new GameOverPayload();
+        if (gameOver.waiting_for_other_players)
+        {
+            names.Add("dismiss_game_over_wait");
+        }
+
         if (gameOver.can_continue)
+        {
+            names.Add("continue_game_over");
+        }
+        else if (GetGameOverContinueButton(currentScreen) != null && !gameOver.can_return_to_main_menu)
         {
             names.Add("continue_game_over");
         }
@@ -3402,6 +3430,7 @@ internal static class GameStateService
             phase = gameOver.phase,
             can_continue = gameOver.can_continue,
             can_return = gameOver.can_return_to_main_menu,
+            waiting_for_other_players = gameOver.waiting_for_other_players,
             save_status = gameOver.save_status,
             save_verified = gameOver.save_verified,
             save_error = gameOver.save_error
@@ -4712,6 +4741,7 @@ internal static class GameStateService
                 && mainMenuButton?.IsEnabled == true
                 && mainMenuButton?.IsVisibleInTree() == true,
             showing_summary = mainMenuButton?.Visible == true,
+            waiting_for_other_players = IsWaitingForOtherPlayers(currentScreen),
             save_status = saveVerification.Status,
             save_verified = saveVerification.Verified,
             save_error = saveVerification.Error
@@ -5853,6 +5883,93 @@ internal static class GameStateService
     {
         return (currentScreen as NGameOverScreen)?
             .GetNodeOrNull<NGameOverContinueButton>("%ContinueButton");
+    }
+
+    public static bool IsWaitingForOtherPlayers(IScreenContext? currentScreen)
+    {
+        var overlay = GetWaitingForOtherPlayersOverlay(currentScreen);
+        return overlay != null && overlay.IsVisibleInTree();
+    }
+
+    public static CanvasItem? GetWaitingForOtherPlayersOverlay(IScreenContext? currentScreen)
+    {
+        if (currentScreen is not NGameOverScreen gameOver)
+        {
+            return null;
+        }
+
+        foreach (var path in new[] { "%WaitingForOtherPlayers", "WaitingForOtherPlayers" })
+        {
+            var node = gameOver.GetNodeOrNull<CanvasItem>(path);
+            if (node != null)
+            {
+                return node;
+            }
+        }
+
+        return FindDescendants<CanvasItem>(gameOver)
+            .FirstOrDefault(node => GodotObject.IsInstanceValid(node)
+                && node.Name.ToString().Contains("WaitingForOtherPlayers", StringComparison.OrdinalIgnoreCase));
+    }
+
+    public static bool HideWaitingForOtherPlayers(IScreenContext? currentScreen)
+    {
+        if (currentScreen is not NGameOverScreen gameOver)
+        {
+            return false;
+        }
+
+        var hidden = false;
+        const BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+        var setVisible = gameOver.GetType().GetMethod("SetWaitingForOtherPlayersOverlayVisible", flags, binder: null, types: new[] { typeof(bool) }, modifiers: null);
+        if (setVisible != null)
+        {
+            setVisible.Invoke(gameOver, new object[] { false });
+            hidden = true;
+        }
+
+        var hide = gameOver.GetType().GetMethod("HideWaitingForPlayersScreen", flags, binder: null, types: Type.EmptyTypes, modifiers: null);
+        if (hide != null)
+        {
+            hide.Invoke(gameOver, null);
+            hidden = true;
+        }
+
+        var overlay = GetWaitingForOtherPlayersOverlay(gameOver);
+        if (overlay != null && overlay.Visible)
+        {
+            overlay.Visible = false;
+            hidden = true;
+        }
+
+        return hidden || !IsWaitingForOtherPlayers(gameOver);
+    }
+
+    public static bool IsGameOverSummaryStarted(IScreenContext? currentScreen)
+    {
+        if (currentScreen is not NGameOverScreen gameOver)
+        {
+            return false;
+        }
+
+        if (GetGameOverMainMenuButton(gameOver)?.Visible == true)
+        {
+            return true;
+        }
+
+        const BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+        try
+        {
+            if (gameOver.GetType().GetField("_isAnimatingSummary", flags)?.GetValue(gameOver) is true)
+            {
+                return true;
+            }
+        }
+        catch
+        {
+        }
+
+        return false;
     }
 
     public static NReturnToMainMenuButton? GetGameOverMainMenuButton(IScreenContext? currentScreen)
@@ -7532,6 +7649,8 @@ internal sealed class GameOverPayload
     public bool can_return_to_main_menu { get; init; }
 
     public bool showing_summary { get; init; }
+
+    public bool waiting_for_other_players { get; init; }
 
     public string save_status { get; init; } = "pending";
 


### PR DESCRIPTION
GAME_OVER 结算动画超过约 15 秒时，模组会提前 Enable 返回主菜单按钮。玩家或 Agent 一旦提前离开，原生 `SaveProgressFile` 还没跑完，主机 `progress.save` 的徽章、分数、解锁等聚合字段就不会随本局更新。

## 改动
- `continue_game_over` 入场动画未结束时先等 Continue 真正可点，避免点空。
- 只点一次原生 Continue；结算开始后不再重点。
- 最多等 60 秒，等游戏自己点亮返回按钮，不再 15 秒后强行 Enable。
- 超时只返回 pending，让下一轮继续等，不再跳过结算保存。

## 验证
- 合同测试 `GameOver.NoForcedReturn` 锁死这条回归。
- 隔离实机 0 层 `die`：Continue 2.47 秒完成，`save_status=verified`，`progress.save` 在 Continue 之后再次写入，随后正常回到主菜单。

## Summary by Sourcery

Ensure game-over completion waits for the native summary save before returning to the main menu.

New Features:
- Add an action and state reporting for dismissing the game-over waiting-for-other-players overlay.

Bug Fixes:
- Prevent leaving the game-over screen before native progress saving completes, preserving updated badges, scores, and unlocks.
- Prevent premature Continue interactions during the game-over intro and avoid restarting the native summary animation.

Enhancements:
- Allow game-over continuation to wait up to 60 seconds for the native Return button instead of forcibly enabling it after a shorter timeout.
- Expose continue_game_over while the native Continue control exists but is temporarily disabled.

Tests:
- Add contract coverage ensuring game-over flow does not force-enable Return, skip the summary, or use the previous timeout.