### PR TITLE
Fix simple card multi-select acknowledgements

### DIFF
--- a/STS2AIAgent.Tests/DeckSelectionContractTests.cs
+++ b/STS2AIAgent.Tests/DeckSelectionContractTests.cs
@@ -3,7 +3,8 @@ namespace STS2AIAgent.Tests;
 /// <summary>
 /// Source-level contracts for Godot card-grid selections. These screens cannot be
 /// instantiated in the lightweight test process, so the tests verify that the
-/// native private selection state is exposed and consumed by the action settle path.
+/// native private selection state is exposed and consumed by the action settle and
+/// explicit confirmation paths.
 /// </summary>
 internal static class DeckSelectionContractTests
 {
@@ -77,6 +78,23 @@ internal static class DeckSelectionContractTests
         var stateSource = WithoutWhitespace(ReadSource("STS2AIAgent/Game/GameStateService.cs"));
         Assert.Contains("IsCardSelected(currentScreen,holder.CardModel!)", stateSource, StringComparison.Ordinal);
         Assert.Contains("selected=selected", stateSource, StringComparison.Ordinal);
+    }
+
+    public static void CardGridConfirmationUsesSharedExecutor()
+    {
+        var rawActionSource = ReadSource(
+            "STS2AIAgent/Game/GameActionService.cs");
+        var confirmBody = WithoutWhitespace(
+            MethodBody(rawActionSource, "ExecuteConfirmSelectionAsync"));
+
+        Assert.Contains(
+            "currentScreenisNCardGridSelectionScreencardGridScreen",
+            confirmBody,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "ConfirmDeckSelectionAsync(cardGridScreen,TimeSpan.FromSeconds(10))",
+            confirmBody,
+            StringComparison.Ordinal);
     }
 
     private static string ReadSource(string relativePath)

--- a/STS2AIAgent.Tests/DeckSelectionContractTests.cs
+++ b/STS2AIAgent.Tests/DeckSelectionContractTests.cs
@@ -1,35 +1,41 @@
 namespace STS2AIAgent.Tests;
 
 /// <summary>
-/// Source-level contracts for Godot deck-grid selections. These screens cannot be
+/// Source-level contracts for Godot card-grid selections. These screens cannot be
 /// instantiated in the lightweight test process, so the tests verify that the
 /// native private selection state is exposed and consumed by the action settle path.
 /// </summary>
 internal static class DeckSelectionContractTests
 {
-    public static void DeckGridPayloadReportsNativeSelectionProgress()
+    public static void CardGridPayloadReportsNativeSelectionProgress()
     {
         var rawStateSource = ReadSource(
             "STS2AIAgent/Game/GameStateService.cs");
         var stateSource = WithoutWhitespace(rawStateSource);
         var payloadBody = WithoutWhitespace(
             MethodBody(rawStateSource, "BuildSelectionPayload"));
-
-        Assert.Contains("NDeckCardSelectScreen", stateSource, StringComparison.Ordinal);
+        Assert.Contains(
+            "NDeckCardSelectScreenorNSimpleCardSelectScreen",
+            stateSource,
+            StringComparison.Ordinal);
         Assert.Contains("\"_prefs\"", stateSource, StringComparison.Ordinal);
         Assert.Contains("\"_selectedCards\"", stateSource, StringComparison.Ordinal);
         Assert.Contains("selectedCount++", stateSource, StringComparison.Ordinal);
         Assert.Contains(
-            "selected_count=hasCombatHandSelection?combatHandSelection.SelectedCount:hasDeckCardSelection?deckCardSelection.SelectedCount:0",
+            "selected_count=hasCombatHandSelection?combatHandSelection.SelectedCount:hasCardGridSelection?cardGridSelection.SelectedCount:0",
             payloadBody,
             StringComparison.Ordinal);
         Assert.Contains(
-            "min_select=hasCombatHandSelection?combatHandSelection.MinSelect:hasDeckCardSelection?deckCardSelection.MinSelect:1",
+            "min_select=hasCombatHandSelection?combatHandSelection.MinSelect:hasCardGridSelection?cardGridSelection.MinSelect:1",
             payloadBody,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "IsCardSelected(currentScreen,holder.CardModel!)",
+            stateSource,
             StringComparison.Ordinal);
     }
 
-    public static void DeckGridClickSettlesInEitherDirectionBeforeConfirming()
+    public static void CardGridClickSettlesInEitherDirectionBeforeConfirming()
     {
         var rawActionSource = ReadSource(
             "STS2AIAgent/Game/GameActionService.cs");
@@ -37,9 +43,13 @@ internal static class DeckSelectionContractTests
             MethodBody(rawActionSource, "ExecuteSelectDeckCardAsync"));
         var settleBody = WithoutWhitespace(
             MethodBody(
-                rawActionSource, "SettleDeckCardSelectionClickAsync"));
+                rawActionSource, "SettleCardGridSelectionClickAsync"));
 
-        Assert.Contains("SettleDeckCardSelectionClickAsync", selectBody, StringComparison.Ordinal);
+        Assert.Contains("SettleCardGridSelectionClickAsync", selectBody, StringComparison.Ordinal);
+        Assert.Contains(
+            "NCardGridSelectionScreencardGridScreenwhenisCardGridSelection",
+            selectBody,
+            StringComparison.Ordinal);
         Assert.Contains(
             "metadata.SelectedCount==previousSelectedCount",
             settleBody,

--- a/STS2AIAgent.Tests/TestRunner.cs
+++ b/STS2AIAgent.Tests/TestRunner.cs
@@ -241,8 +241,8 @@ internal static class TestRunner
         yield return ("GameOver.SaveMismatch", () => Task.Run(ProgressSaveVerificationTests.MismatchedScoreOrUnlockStateCannotReportSuccess));
         yield return ("GameOver.SaveMissingMalformed", () => Task.Run(ProgressSaveVerificationTests.MissingOrMalformedFileCannotReportSuccess));
         yield return ("GameOver.SaveReadFailure", () => Task.Run(ProgressSaveVerificationTests.ReadFailureCannotReportSuccess));
-        yield return ("DeckSelection.PayloadProgress", () => Task.Run(DeckSelectionContractTests.DeckGridPayloadReportsNativeSelectionProgress));
-        yield return ("DeckSelection.ClickSettle", () => Task.Run(DeckSelectionContractTests.DeckGridClickSettlesInEitherDirectionBeforeConfirming));
+        yield return ("CardGridSelection.PayloadProgress", () => Task.Run(DeckSelectionContractTests.CardGridPayloadReportsNativeSelectionProgress));
+        yield return ("CardGridSelection.ClickSettle", () => Task.Run(DeckSelectionContractTests.CardGridClickSettlesInEitherDirectionBeforeConfirming));
         yield return ("CombatDiagnostics.CanPlay", () => Task.Run(CombatDiagnosticsContractTests.HandPayloadKeepsNativeCanPlayEvidence));
         yield return ("Map.NoVoteDuringCombat", () => Task.Run(MapCombatGatingTests.ChooseMapNodeHiddenWhileCombatInProgress));
         yield return ("CombatDiagnostics.Readiness", () => Task.Run(CombatDiagnosticsContractTests.CombatPayloadDistinguishesQueueModalAndSnapshotLocks));

--- a/STS2AIAgent.Tests/TestRunner.cs
+++ b/STS2AIAgent.Tests/TestRunner.cs
@@ -243,6 +243,7 @@ internal static class TestRunner
         yield return ("GameOver.SaveReadFailure", () => Task.Run(ProgressSaveVerificationTests.ReadFailureCannotReportSuccess));
         yield return ("CardGridSelection.PayloadProgress", () => Task.Run(DeckSelectionContractTests.CardGridPayloadReportsNativeSelectionProgress));
         yield return ("CardGridSelection.ClickSettle", () => Task.Run(DeckSelectionContractTests.CardGridClickSettlesInEitherDirectionBeforeConfirming));
+        yield return ("CardGridSelection.ConfirmDispatch", () => Task.Run(DeckSelectionContractTests.CardGridConfirmationUsesSharedExecutor));
         yield return ("CombatDiagnostics.CanPlay", () => Task.Run(CombatDiagnosticsContractTests.HandPayloadKeepsNativeCanPlayEvidence));
         yield return ("Map.NoVoteDuringCombat", () => Task.Run(MapCombatGatingTests.ChooseMapNodeHiddenWhileCombatInProgress));
         yield return ("CombatDiagnostics.Readiness", () => Task.Run(CombatDiagnosticsContractTests.CombatPayloadDistinguishesQueueModalAndSnapshotLocks));

--- a/STS2AIAgent/Game/GameActionService.cs
+++ b/STS2AIAgent/Game/GameActionService.cs
@@ -1924,8 +1924,8 @@ internal static class GameActionService
         }
 
         var isCombatHandSelection = GameStateService.TryGetCombatHandSelectionMetadata(currentScreen, out var combatHand, out var combatHandSelection);
-        var isDeckCardSelection = GameStateService.TryGetDeckCardSelectionMetadata(
-            currentScreen, out var deckCardSelection);
+        var isCardGridSelection = GameStateService.TryGetCardGridSelectionMetadata(
+            currentScreen, out var cardGridSelection);
         var selected = options[request.option_index.Value];
         if (isCombatHandSelection)
         {
@@ -1952,10 +1952,10 @@ internal static class GameActionService
 
         var stable = currentScreen switch
         {
-            NDeckCardSelectScreen deckCardScreen
-                when isDeckCardSelection =>
-                await SettleDeckCardSelectionClickAsync(
-                    deckCardScreen, deckCardSelection.SelectedCount, TimeSpan.FromSeconds(10)),
+            NCardGridSelectionScreen cardGridScreen
+                when isCardGridSelection =>
+                await SettleCardGridSelectionClickAsync(
+                    cardGridScreen, cardGridSelection.SelectedCount, TimeSpan.FromSeconds(10)),
             NCardGridSelectionScreen cardSelectScreen => await ConfirmDeckSelectionAsync(cardSelectScreen, TimeSpan.FromSeconds(10)),
             NChooseACardSelectionScreen chooseCardScreen => await WaitForChooseCardSelectionResolutionAsync(chooseCardScreen, TimeSpan.FromSeconds(10)),
             _ when isCombatHandSelection => await WaitForCombatHandSelectionStepAsync(combatHandSelection, TimeSpan.FromSeconds(10)),
@@ -2600,8 +2600,8 @@ internal static class GameActionService
         return false;
     }
 
-    private static async Task<bool> SettleDeckCardSelectionClickAsync(
-        NDeckCardSelectScreen screen,
+    private static async Task<bool> SettleCardGridSelectionClickAsync(
+        NCardGridSelectionScreen screen,
         int previousSelectedCount,
         TimeSpan timeout)
     {
@@ -2616,7 +2616,7 @@ internal static class GameActionService
                 return await WaitForDeckSelectionResolutionAsync(screen, deadline);
             }
 
-            if (!GameStateService.TryGetDeckCardSelectionMetadata(screen, out var metadata) ||
+            if (!GameStateService.TryGetCardGridSelectionMetadata(screen, out var metadata) ||
                 metadata.SelectedCount == previousSelectedCount)
             {
                 continue;

--- a/STS2AIAgent/Game/GameActionService.cs
+++ b/STS2AIAgent/Game/GameActionService.cs
@@ -1986,15 +1986,15 @@ internal static class GameActionService
             });
         }
 
-        if (currentScreen is NDeckCardSelectScreen deckScreen)
+        if (currentScreen is NCardGridSelectionScreen cardGridScreen)
         {
-            var stableDeck = await ConfirmDeckSelectionAsync(deckScreen, TimeSpan.FromSeconds(10));
+            var stableGrid = await ConfirmDeckSelectionAsync(cardGridScreen, TimeSpan.FromSeconds(10));
             return new ActionResponsePayload
             {
                 action = "confirm_selection",
-                status = stableDeck ? "completed" : "pending",
-                stable = stableDeck,
-                message = stableDeck ? "Action completed." : "Action queued but state is still transitioning.",
+                status = stableGrid ? "completed" : "pending",
+                stable = stableGrid,
+                message = stableGrid ? "Action completed." : "Action queued but state is still transitioning.",
                 state = GameStateService.BuildStatePayload()
             };
         }

--- a/STS2AIAgent/Game/GameStateService.cs
+++ b/STS2AIAgent/Game/GameStateService.cs
@@ -931,9 +931,9 @@ internal static class GameStateService
             return true;
         }
 
-        return TryGetDeckCardSelectionMetadata(currentScreen, out var deckMetadata) &&
-            deckMetadata.CanConfirm &&
-            (deckMetadata.RequiresConfirmation || deckMetadata.MinSelect < deckMetadata.MaxSelect);
+        return TryGetCardGridSelectionMetadata(currentScreen, out var gridMetadata) &&
+            gridMetadata.CanConfirm &&
+            (gridMetadata.RequiresConfirmation || gridMetadata.MinSelect < gridMetadata.MaxSelect);
     }
 
     public static bool CanProceed(IScreenContext? currentScreen)
@@ -1639,14 +1639,14 @@ internal static class GameStateService
         return Array.Empty<NCardHolder>();
     }
 
-    public static bool TryGetDeckCardSelectionMetadata(
+    public static bool TryGetCardGridSelectionMetadata(
         IScreenContext? currentScreen,
-        out DeckCardSelectionMetadata metadata)
+        out CardGridSelectionMetadata metadata)
     {
         metadata = default;
-        if (currentScreen is not NDeckCardSelectScreen deckCardScreen ||
-            ReflectionMemberAccessor.TryGetValue(deckCardScreen, "_prefs") is not CardSelectorPrefs prefs ||
-            ReflectionMemberAccessor.TryGetValue(deckCardScreen, "_selectedCards") is not IEnumerable selectedCards)
+        if (currentScreen is not (NDeckCardSelectScreen or NSimpleCardSelectScreen) ||
+            ReflectionMemberAccessor.TryGetValue(currentScreen, "_prefs") is not CardSelectorPrefs prefs ||
+            ReflectionMemberAccessor.TryGetValue(currentScreen, "_selectedCards") is not IEnumerable selectedCards)
         {
             return false;
         }
@@ -1657,7 +1657,7 @@ internal static class GameStateService
             selectedCount++;
         }
 
-        metadata = new DeckCardSelectionMetadata(
+        metadata = new CardGridSelectionMetadata(
             prefs.MinSelect,
             prefs.MaxSelect,
             selectedCount,
@@ -3492,10 +3492,10 @@ internal static class GameStateService
 
     private static bool IsCardSelected(IScreenContext? currentScreen, CardModel card)
     {
-        if (currentScreen is NDeckCardSelectScreen deckCardScreen &&
-            ReflectionMemberAccessor.TryGetValue(deckCardScreen, "_selectedCards") is IEnumerable selectedDeckCards)
+        if (currentScreen is NDeckCardSelectScreen or NSimpleCardSelectScreen &&
+            ReflectionMemberAccessor.TryGetValue(currentScreen, "_selectedCards") is IEnumerable selectedGridCards)
         {
-            foreach (var item in selectedDeckCards)
+            foreach (var item in selectedGridCards)
             {
                 if (ReferenceEquals(item, card))
                 {
@@ -4163,8 +4163,8 @@ internal static class GameStateService
 
         var hasCombatHandSelection = TryGetCombatHandSelectionMetadata(
             currentScreen, out _, out var combatHandSelection);
-        var hasDeckCardSelection = TryGetDeckCardSelectionMetadata(
-            currentScreen, out var deckCardSelection);
+        var hasCardGridSelection = TryGetCardGridSelectionMetadata(
+            currentScreen, out var cardGridSelection);
 
         return new SelectionPayload
         {
@@ -4182,19 +4182,19 @@ internal static class GameStateService
             prompt = GetDeckSelectionPrompt(currentScreen) ?? string.Empty,
             min_select = hasCombatHandSelection
                 ? combatHandSelection.MinSelect
-                : hasDeckCardSelection ? deckCardSelection.MinSelect : 1,
+                : hasCardGridSelection ? cardGridSelection.MinSelect : 1,
             max_select = hasCombatHandSelection
                 ? combatHandSelection.MaxSelect
-                : hasDeckCardSelection ? deckCardSelection.MaxSelect : 1,
+                : hasCardGridSelection ? cardGridSelection.MaxSelect : 1,
             selected_count = hasCombatHandSelection
                 ? combatHandSelection.SelectedCount
-                : hasDeckCardSelection ? deckCardSelection.SelectedCount : 0,
+                : hasCardGridSelection ? cardGridSelection.SelectedCount : 0,
             requires_confirmation = hasCombatHandSelection
                 ? combatHandSelection.RequiresConfirmation
-                : hasDeckCardSelection && deckCardSelection.RequiresConfirmation,
+                : hasCardGridSelection && cardGridSelection.RequiresConfirmation,
             can_confirm = hasCombatHandSelection
                 ? combatHandSelection.CanConfirm
-                : hasDeckCardSelection && deckCardSelection.CanConfirm,
+                : hasCardGridSelection && cardGridSelection.CanConfirm,
             cards = cards.Select((holder, index) => BuildSelectionCardPayload(
                 holder.CardModel!,
                 index,
@@ -6985,7 +6985,7 @@ internal readonly record struct CombatHandSelectionMetadata(
     bool RequiresConfirmation,
     bool CanConfirm);
 
-internal readonly record struct DeckCardSelectionMetadata(
+internal readonly record struct CardGridSelectionMetadata(
     int MinSelect,
     int MaxSelect,
     int SelectedCount,


### PR DESCRIPTION
## Problem

`GameStateService` only read native multi-select metadata from `NDeckCardSelectScreen`. Event/reward flows can use `NSimpleCardSelectScreen`, which has the same private `_prefs` and `_selectedCards` fields.

On a real Slay the Spire 2 v0.111.0 run, a prompt requiring two common cards accepted and visibly highlighted the first click, but `/state` still reported `min_select=1`, `max_select=1`, `selected_count=0`. The agent therefore treated the native click as unacknowledged, retried/toggled it, and never completed the screen.

## Fix

- Read card-grid metadata from both `NDeckCardSelectScreen` and `NSimpleCardSelectScreen`.
- Expose native selected-card flags and the real min/max/selected/confirmation values in the selection payload.
- Settle clicks against observed card-grid selection progress before deciding whether to confirm.
- Add source-contract coverage for simple-screen metadata and the shared settle path.

## Verification

- Release build: 0 warnings, 0 errors.
- C# standalone suite: 185/185 passed on latest upstream `main`.
- MCP Python suite: 49/49 passed on latest upstream `main`.
- `git diff --check`: passed.

### Real-game regression evidence

Tested by rebuilding/deploying this fork, restarting through the normal stack launcher, and continuing the exact affected native run (`run_id=0QZEB57XQKN1`, floor 30):

- Before: prompt “选择2张普通牌加入到你的牌组。”, visible first-card highlight, API selection `1/1/0`, repeated ~10 s action timeouts.
- After: the same screen reported `min_select=2`, `max_select=2`, `selected_count=0` before autonomous input.
- First selection returned HTTP 200 in 30 ms.
- Second selection returned HTTP 200 in 232 ms; the native game logged the two chosen cards and advanced out of the screen:

    [INFO] [STS2AIAgent.Router] req_20260910_152629_5006_50 POST /action
    [INFO] [STS2AIAgent.Router] req_20260910_152629_5006_50 Completed 200 in 30ms
    [INFO] [STS2AIAgent.Router] req_20260910_152630_6306_52 POST /action
    [INFO] Player 1 chose cards [VIVHITE_CARD_OPEN_SET_SHELTER,VIVHITE_CARD_RECURRENT_STARLIGHT]
    [INFO] [STS2AIAgent.Router] req_20260910_152630_6306_52 Completed 200 in 232ms

The run then continued autonomously through REST/MAP/COMBAT and multiple later one- and two-card selection screens. The deployed DLL used for the regression run had SHA-256 `57E714F9FBEA913826A7D6FF4982EF8CAFF72CD43361FB11DF089EBB9185AA6B`.

A 45-second 1920x1080 capture of continued autonomous play was decoded end-to-end (450/450 frames); SHA-256: `7DBE783C705DC99EC6E4BF9A8E4F1D19D59C746BD778498253CFF766EEA33869`.

## Summary by Sourcery

Support reliable multi-select acknowledgements across all native card-grid selection screens.

Bug Fixes:
- Fix card-selection state reporting and click acknowledgement for simple card-selection screens so multi-card prompts complete correctly.

Enhancements:
- Unify card-grid metadata handling, selection progress settling, and confirmation across deck and simple card-selection screens.

Tests:
- Extend source-contract coverage for simple-screen metadata, shared click settling, and confirmation dispatch.