### PR TITLE
feat(coop): continue a saved multiplayer run with the AI teammate

### DIFF
--- a/STS2AIAgent.Tests/CompanionStartupTests.cs
+++ b/STS2AIAgent.Tests/CompanionStartupTests.cs
@@ -97,6 +97,11 @@ internal static class CompanionStartupTests
             "CHARACTER_SELECT",
             new[] { "unready" },
             hasLobby: true) == null);
+        // Continuing a saved co-op run: the load screen only needs Embark.
+        Assert.Equal("embark", CoopLaunchPolicy.NextCompanionBootstrapAction(
+            "MULTIPLAYER_LOAD",
+            new[] { "embark", "unready" },
+            hasLobby: true));
         Assert.Equal("choose_bundle", CoopLaunchPolicy.NextCompanionBootstrapAction(
             "BUNDLE_SELECTION",
             new[] { "choose_bundle" },

--- a/STS2AIAgent.Tests/ContinueCoopContractTests.cs
+++ b/STS2AIAgent.Tests/ContinueCoopContractTests.cs
@@ -1,0 +1,133 @@
+namespace STS2AIAgent.Tests;
+
+/// <summary>
+/// Source-level contracts for <c>continue_ai_teammate</c>. The state and action services need the
+/// game assemblies, so the pieces a client relies on are pinned by reading the source: the action is
+/// advertised (descriptor list and <c>available_actions</c>) behind one availability probe, the
+/// executor re-checks that probe, a failure after the load flow started is a retryable
+/// <c>continue_failed</c>, the load screen only advertises what the executor can perform, and the
+/// waits the load flow adds are bounded and cancellable.
+/// </summary>
+internal static class ContinueCoopContractTests
+{
+    private const string StatePath = "STS2AIAgent/Game/GameStateService.cs";
+    private const string ActionPath = "STS2AIAgent/Game/GameActionService.cs";
+    private const string Guard = "if (CanContinueAiTeammate(currentScreen))";
+
+    public static void ActionIsAdvertisedBehindTheSaveProbe()
+    {
+        var state = AgentSourceFixture.Read(StatePath);
+
+        // The probe mirrors the game's own gate for showing "Load" in the multiplayer submenu, on
+        // the host's visible main menu only.
+        var probe = AgentSourceFixture.MethodBody(state, "CanContinueAiTeammate");
+        Assert.Contains("InstanceRole.IsCompanion", probe, StringComparison.Ordinal);
+        Assert.Contains("currentScreen is not NMainMenu mainMenu || !mainMenu.IsVisibleInTree()", probe, StringComparison.Ordinal);
+        Assert.Contains("return SaveManager.Instance.HasMultiplayerRunSave;", probe, StringComparison.Ordinal);
+
+        // Each exposure list must carry its own guard: a descriptor without the name entry (or the
+        // reverse) leaves a rule-following client unable to discover or legally call the action.
+        var descriptors = AgentSourceFixture.MethodBody(state, "BuildAvailableActionsPayload");
+        Assert.Contains(Guard, descriptors, StringComparison.Ordinal);
+        Assert.Contains("name = \"continue_ai_teammate\"", descriptors, StringComparison.Ordinal);
+
+        var names = AgentSourceFixture.MethodBody(state, "BuildAvailableActionNames");
+        Assert.Contains(Guard, names, StringComparison.Ordinal);
+        Assert.Contains("names.Add(\"continue_ai_teammate\")", names, StringComparison.Ordinal);
+    }
+
+    public static void ExecutorRechecksTheProbeAndFailsRetryably()
+    {
+        var action = AgentSourceFixture.Read(ActionPath);
+        var body = AgentSourceFixture.MethodBody(action, "ExecuteContinueAiTeammateAsync");
+
+        Assert.Contains("CoopLaunchPolicy.GetError(", body, StringComparison.Ordinal);
+        Assert.Contains("GameStateService.CanContinueAiTeammate(", body, StringComparison.Ordinal);
+        Assert.Contains("DualLaunchOutcomePolicy.IsInProgress(outcome)", body, StringComparison.Ordinal);
+
+        // docs/api.md lists continue_failed as retryable: a game restart clears the stuck ENet port.
+        // The throw is the whole statement from its `throw` to the next `;` at statement level, so a
+        // reformat of the anonymous details object does not move the assertion.
+        var code = body.IndexOf("\"continue_failed\"", StringComparison.Ordinal);
+        Assert.True(code >= 0, "continue_failed must be raised from the executor.");
+        var start = body.LastIndexOf("throw new ApiException(", code, StringComparison.Ordinal);
+        var end = body.IndexOf(";", code, StringComparison.Ordinal);
+        Assert.True(start >= 0 && end > start, "continue_failed must be thrown as an ApiException.");
+        var statement = body.Substring(start, end - start);
+        Assert.Contains("retryable: true", statement, StringComparison.Ordinal);
+    }
+
+    public static void LoadScreenAdvertisesOnlyWhatTheExecutorHandles()
+    {
+        var state = AgentSourceFixture.Read(StatePath);
+        var action = AgentSourceFixture.Read(ActionPath);
+
+        // embark: the load screen resolves the button and the executor waits for the ready
+        // transition instead of reporting completion after a single frame.
+        var embarkButton = AgentSourceFixture.MethodBody(state, "GetCharacterEmbarkButton");
+        Assert.Contains("GetMultiplayerLoadScreen(currentScreen)", embarkButton, StringComparison.Ordinal);
+        var embark = AgentSourceFixture.MethodBody(action, "ExecuteEmbarkAsync");
+        Assert.Contains("NMultiplayerLoadGameScreen loadScreen", embark, StringComparison.Ordinal);
+        Assert.Contains("WaitForLoadEmbarkTransitionAsync(loadScreen", embark, StringComparison.Ordinal);
+
+        // unready: the executor only handles NCharacterSelectScreen, so the state must not advertise
+        // it on the load screen.
+        var unreadyButton = AgentSourceFixture.MethodBody(state, "GetCharacterUnreadyButton");
+        Assert.True(
+            !unreadyButton.Contains("GetMultiplayerLoadScreen", StringComparison.Ordinal),
+            "unready must not be advertised on the load screen while the executor has no path for it.");
+    }
+
+    public static void LoadEmbarkWaitIsBoundedAndSettlesOnEveryExit()
+    {
+        var action = AgentSourceFixture.Read(ActionPath);
+
+        var wait = AgentSourceFixture.MethodBody(action, "WaitForLoadEmbarkTransitionAsync");
+        Assert.Contains("var deadline = DateTime.UtcNow + timeout;", wait, StringComparison.Ordinal);
+        Assert.Contains("while (DateTime.UtcNow < deadline)", wait, StringComparison.Ordinal);
+        Assert.Contains("return IsLoadEmbarkSettled(screen);", wait, StringComparison.Ordinal);
+
+        // Settled means: the screen was replaced or freed, a modal took over, or the game disabled
+        // Embark (which NMultiplayerLoadGameScreen.OnEmbarkPressed does synchronously on ready).
+        var settled = AgentSourceFixture.MethodBody(action, "IsLoadEmbarkSettled");
+        Assert.Contains("!ReferenceEquals(currentScreen, screen)", settled, StringComparison.Ordinal);
+        Assert.Contains("!GodotObject.IsInstanceValid(screen)", settled, StringComparison.Ordinal);
+        Assert.Contains("GameStateService.GetOpenModal() != null", settled, StringComparison.Ordinal);
+        Assert.Contains("!GameStateService.CanEmbark(currentScreen)", settled, StringComparison.Ordinal);
+    }
+
+    public static void StartLocalLoadWaitsHonourTheCoordinatorToken()
+    {
+        // Scope: the coordinator's token reaches every wait inside StartLocalLoadAsync. The HTTP
+        // executor itself still passes CancellationToken.None, the same as invite_ai_teammate.
+        var action = AgentSourceFixture.Read(ActionPath);
+        Assert.Contains(
+            "StartLocalLoadAsync(CancellationToken cancellationToken",
+            action,
+            StringComparison.Ordinal);
+
+        var load = AgentSourceFixture.MethodBody(action, "StartLocalLoadAsync");
+        var waits = 0;
+        var index = 0;
+        while ((index = load.IndexOf("WaitForMainMenuSubmenuOpenAsync<", index, StringComparison.Ordinal)) >= 0)
+        {
+            var end = load.IndexOf(");", index, StringComparison.Ordinal);
+            var call = load.Substring(index, end - index);
+            Assert.True(
+                call.EndsWith(", cancellationToken", StringComparison.Ordinal),
+                "every submenu wait inside StartLocalLoadAsync must receive the cancellation token: " + call);
+            waits++;
+            index = end;
+        }
+
+        Assert.True(waits >= 3, "StartLocalLoadAsync opens the multiplayer submenu and waits for the load screen.");
+
+        var submenuWait = AgentSourceFixture.DeclarationBody(
+            action,
+            "private static async Task<bool> WaitForMainMenuSubmenuOpenAsync<TSubmenu>(");
+        Assert.Contains("cancellationToken.ThrowIfCancellationRequested();", submenuWait, StringComparison.Ordinal);
+
+        var coordinator = AgentSourceFixture.Read("STS2AIAgent/Multiplayer/DualInstanceCoordinator.cs");
+        Assert.Contains("GameActionService.StartLocalLoadAsync(cancellationToken)", coordinator, StringComparison.Ordinal);
+    }
+}

--- a/STS2AIAgent.Tests/CurrentRunBoundaryTests.cs
+++ b/STS2AIAgent.Tests/CurrentRunBoundaryTests.cs
@@ -18,6 +18,7 @@ internal static class CurrentRunBoundaryTests
         var boundary = new CurrentRunBoundary();
         boundary.Check(State("CHARACTER_SELECT", "character_select"));
         boundary.Check(State("MULTIPLAYER_LOBBY", "multiplayer_lobby"));
+        boundary.Check(State("MULTIPLAYER_LOAD", "menu"));
     }
 
     public static void StopsWhenLeavingRunToMainMenu()

--- a/STS2AIAgent.Tests/ScreenResolutionContractTests.cs
+++ b/STS2AIAgent.Tests/ScreenResolutionContractTests.cs
@@ -24,6 +24,7 @@ internal static class ScreenResolutionContractTests
         ("NCombatRoom", "COMBAT"),
         ("NMapScreen or NMapRoom", "MAP"),
         ("NCharacterSelectScreen", "CHARACTER_SELECT"),
+        ("NMultiplayerLoadGameScreen", "MULTIPLAYER_LOAD"),
         ("NChooseABundleSelectionScreen", "BUNDLE_SELECTION"),
         ("NCapstoneSubmenuStack", "CAPSTONE_SELECTION"),
         ("NCrystalSphereScreen", "CRYSTAL_SPHERE"),
@@ -52,7 +53,7 @@ internal static class ScreenResolutionContractTests
             Assert.Equal(screenName, resolved);
         }
 
-        // The five new names are the exact strings the sibling skill/documentation tasks publish.
+        // These names are the exact strings the sibling skill/documentation tasks publish.
         Assert.Equal("FAKE_MERCHANT", actual["NFakeMerchant"]);
         Assert.Equal("PATCH_NOTES", actual["NPatchNotesScreen"]);
         Assert.Equal("CARD_INSPECT", actual["NInspectCardScreen"]);

--- a/STS2AIAgent.Tests/TestRunner.cs
+++ b/STS2AIAgent.Tests/TestRunner.cs
@@ -433,6 +433,11 @@ internal static class TestRunner
         yield return ("HttpServerPort.FallbackGate", () => Task.Run(HttpServerPortPolicyTests.FallbackPolicyGateIsPresent));
         yield return ("DeckSelectionAvailability.MatchesExecutableSet", () => Task.Run(DeckSelectionAvailabilityTests.AvailabilityMatchesTheExecutableSet));
         yield return ("DeckSelectionAvailability.ExecutorKeepsGuard", () => Task.Run(DeckSelectionAvailabilityTests.ExecutorKeepsItsGuard));
+        yield return ("ContinueCoop.Advertised", () => Task.Run(ContinueCoopContractTests.ActionIsAdvertisedBehindTheSaveProbe));
+        yield return ("ContinueCoop.ExecutorGuard", () => Task.Run(ContinueCoopContractTests.ExecutorRechecksTheProbeAndFailsRetryably));
+        yield return ("ContinueCoop.LoadScreenSurface", () => Task.Run(ContinueCoopContractTests.LoadScreenAdvertisesOnlyWhatTheExecutorHandles));
+        yield return ("ContinueCoop.LoadEmbarkWait", () => Task.Run(ContinueCoopContractTests.LoadEmbarkWaitIsBoundedAndSettlesOnEveryExit));
+        yield return ("ContinueCoop.LoadCancellation", () => Task.Run(ContinueCoopContractTests.StartLocalLoadWaitsHonourTheCoordinatorToken));
         yield return ("AgentErrorEnvelope.ApiExceptionKeepsItsHttpMetadata", () => Task.Run(AgentErrorEnvelopeTests.ApiExceptionKeepsItsHttpMetadata));
         yield return ("AgentErrorEnvelope.ApiExceptionDefaultsArePreserved", () => Task.Run(AgentErrorEnvelopeTests.ApiExceptionDefaultsArePreserved));
         yield return ("AgentErrorEnvelope.UnexpectedFailureIsClassifiedNotDropped", () => Task.Run(AgentErrorEnvelopeTests.UnexpectedFailureIsClassifiedNotDropped));

--- a/STS2AIAgent/Agent/AgentRuntime.cs
+++ b/STS2AIAgent/Agent/AgentRuntime.cs
@@ -520,7 +520,12 @@ internal sealed class AgentRuntime
 
     public Task LaunchDualInstanceAsync(AgentSettings settings, CancellationToken cancellationToken)
     {
-        return Task.Run(() => LaunchDualInstanceCoreAsync(settings, cancellationToken), cancellationToken);
+        return Task.Run(() => LaunchDualInstanceCoreAsync(settings, cancellationToken, continueRun: false), cancellationToken);
+    }
+
+    public Task ContinueDualInstanceAsync(AgentSettings settings, CancellationToken cancellationToken)
+    {
+        return Task.Run(() => LaunchDualInstanceCoreAsync(settings, cancellationToken, continueRun: true), cancellationToken);
     }
 
     public void ClearChat()
@@ -712,7 +717,7 @@ internal sealed class AgentRuntime
         }
     }
 
-    private async Task LaunchDualInstanceCoreAsync(AgentSettings settings, CancellationToken cancellationToken)
+    private async Task LaunchDualInstanceCoreAsync(AgentSettings settings, CancellationToken cancellationToken, bool continueRun)
     {
         if (!await _dualLaunchGate.WaitAsync(0, cancellationToken))
         {
@@ -746,9 +751,13 @@ internal sealed class AgentRuntime
             // The child reads settings at startup. Persist the edited model
             // selection before launching so both windows use the same choices.
             SaveSettings(settings);
-            _dualStatus = Loc.T("正在邀请 AI 队友，等待游戏窗口连接…");
+            _dualStatus = continueRun
+                ? Loc.T("正在继续联机存档，等待队友窗口连回…")
+                : Loc.T("正在邀请 AI 队友，等待游戏窗口连接…");
             RaiseChanged();
-            var launchResult = await DualInstanceCoordinator.HostLocalCoopResultAsync(cancellationToken);
+            var launchResult = continueRun
+                ? await DualInstanceCoordinator.ContinueLocalCoopResultAsync(cancellationToken)
+                : await DualInstanceCoordinator.HostLocalCoopResultAsync(cancellationToken);
             _dualStatus = launchResult.Message;
             _dualLaunchOutcome = launchResult.Ok ? DualLaunchOutcome.Succeeded : DualLaunchOutcome.Failed;
         }
@@ -759,7 +768,9 @@ internal sealed class AgentRuntime
         }
         catch (Exception ex)
         {
-            _dualStatus = Loc.T("邀请队友失败：{0}", ex.Message);
+            _dualStatus = continueRun
+                ? Loc.T("继续联机存档失败：{0}", ex.Message)
+                : Loc.T("邀请队友失败：{0}", ex.Message);
             _dualLaunchOutcome = DualLaunchOutcome.Failed;
         }
         finally

--- a/STS2AIAgent/Agent/CurrentRunBoundary.cs
+++ b/STS2AIAgent/Agent/CurrentRunBoundary.cs
@@ -26,7 +26,7 @@ internal sealed class CurrentRunBoundary
     public void Check(string? screen, string? phase, string? seed)
     {
         if (_enteredRun && (
-            screen is "MAIN_MENU" or "CHARACTER_SELECT" or "MULTIPLAYER_LOBBY" ||
+            screen is "MAIN_MENU" or "CHARACTER_SELECT" or "MULTIPLAYER_LOBBY" or "MULTIPLAYER_LOAD" ||
             phase is "character_select" or "multiplayer_lobby" or "menu"))
         {
             throw new AutoPlayStoppedException(Loc.T(LeftRunMessage), StopKindPolicy.RunEnd);

--- a/STS2AIAgent/Game/GameActionService.cs
+++ b/STS2AIAgent/Game/GameActionService.cs
@@ -187,6 +187,7 @@ internal static class GameActionService
             "dismiss_modal" => ExecuteDismissModalAsync(),
             "return_to_main_menu" => ExecuteReturnToMainMenuAsync(),
             "invite_ai_teammate" => ExecuteInviteAiTeammateAsync(),
+            "continue_ai_teammate" => ExecuteContinueAiTeammateAsync(),
             _ => throw new ApiException(409, "invalid_action", "Action is not supported yet.", new
             {
                 action = request.action
@@ -4400,6 +4401,30 @@ internal static class GameActionService
         var currentScreen = ActiveScreenContext.Instance.GetCurrentScreen();
         var screen = GameStateService.ResolveScreen(currentScreen);
 
+        if (GameStateService.CanEmbark(currentScreen) && currentScreen is NMultiplayerLoadGameScreen loadScreen)
+        {
+            var loadEmbark = GameStateService.GetCharacterEmbarkButton(currentScreen)
+                ?? throw new ApiException(503, "state_unavailable", "Embark button is unavailable.", new
+                {
+                    action = "embark",
+                    screen
+                }, retryable: true);
+
+            loadEmbark.ForceClick();
+            var loadStable = await WaitForLoadEmbarkTransitionAsync(loadScreen, TimeSpan.FromSeconds(10));
+
+            return new ActionResponsePayload
+            {
+                action = "embark",
+                status = loadStable ? "completed" : "pending",
+                stable = loadStable,
+                message = loadStable
+                    ? "Action completed."
+                    : MenuTransitionPolicy.DescribeUnsettled("embark", CurrentModalName()),
+                state = GameStateService.BuildStatePayload()
+            };
+        }
+
         if (!GameStateService.CanEmbark(currentScreen) || currentScreen is not NCharacterSelectScreen characterSelectScreen)
         {
             throw new ApiException(409, "invalid_action", "Action is not available in the current state.", new
@@ -5153,6 +5178,117 @@ internal static class GameActionService
         return await ExecuteModalButtonAsync("dismiss_modal", GameStateService.GetModalCancelButton);
     }
 
+    /// <summary>
+    /// Host side: reload the saved multiplayer run over local ENet (fastmp host_standard) and launch the companion so it rejoins as its saved player.
+    /// </summary>
+    private static async Task<ActionResponsePayload> ExecuteContinueAiTeammateAsync()
+    {
+        var payload = GameStateService.BuildStatePayload();
+        var error = CoopLaunchPolicy.GetError(
+            InstanceRole.IsCompanion,
+            AgentRuntime.Instance.PlayRunning,
+            payload.screen,
+            AgentRuntime.Instance.Settings);
+        if (error != null)
+        {
+            throw new ApiException(409, "invalid_action", error, new
+            {
+                action = "continue_ai_teammate",
+                screen = payload.screen
+            });
+        }
+
+        if (!GameStateService.CanContinueAiTeammate(ActiveScreenContext.Instance.GetCurrentScreen()))
+        {
+            throw new ApiException(409, "invalid_action", "No saved multiplayer run to continue.", new
+            {
+                action = "continue_ai_teammate",
+                screen = payload.screen
+            });
+        }
+
+        await AgentRuntime.Instance.ContinueDualInstanceAsync(AgentRuntime.Instance.Settings, CancellationToken.None);
+        // Same classification as invite_ai_teammate: read the structured outcome, never the localized text.
+        var outcome = AgentRuntime.Instance.DualLaunchOutcome;
+        var message = AgentRuntime.Instance.DualStatus;
+        if (DualLaunchOutcomePolicy.IsInProgress(outcome))
+        {
+            return new ActionResponsePayload
+            {
+                action = "continue_ai_teammate",
+                status = "pending",
+                stable = false,
+                message = message,
+                state = GameStateService.BuildStatePayload()
+            };
+        }
+
+        if (DualLaunchOutcomePolicy.IsFailure(outcome) || outcome == DualLaunchOutcome.Idle)
+        {
+            // Retryable: the usual cause is port 33771 still held by the previous run in this process,
+            // which a game restart clears.
+            throw new ApiException(409, "continue_failed", message, new
+            {
+                action = "continue_ai_teammate",
+                screen = GameStateService.BuildStatePayload().screen,
+                outcome = outcome.ToString()
+            }, retryable: true);
+        }
+
+        return new ActionResponsePayload
+        {
+            action = "continue_ai_teammate",
+            status = "completed",
+            stable = true,
+            message = message,
+            state = GameStateService.BuildStatePayload()
+        };
+    }
+
+    /// <summary>
+    /// Opens the multiplayer submenu and presses its private "load run" button. With fastmp injected the game hosts the saved run on ENet:33771.
+    /// </summary>
+    internal static async Task<bool> StartLocalLoadAsync(CancellationToken cancellationToken = default)
+    {
+        var currentScreen = ActiveScreenContext.Instance.GetCurrentScreen();
+        if (currentScreen is not NMainMenu mainMenu)
+        {
+            throw new InvalidOperationException(Loc.T("请先回到主菜单，再继续联机对局。"));
+        }
+
+        var submenu = mainMenu.SubmenuStack.GetSubmenuType<NMultiplayerSubmenu>();
+        if (submenu == null)
+        {
+            mainMenu.Call("OpenMultiplayerSubmenu");
+            await WaitForMainMenuSubmenuOpenAsync<NMultiplayerSubmenu>(mainMenu, TimeSpan.FromSeconds(5), cancellationToken);
+            submenu = mainMenu.SubmenuStack.GetSubmenuType<NMultiplayerSubmenu>()
+                ?? throw new InvalidOperationException(Loc.T("找不到多人子菜单。"));
+        }
+        else
+        {
+            mainMenu.SubmenuStack.Push(submenu);
+            await WaitForMainMenuSubmenuOpenAsync<NMultiplayerSubmenu>(mainMenu, TimeSpan.FromSeconds(5), cancellationToken);
+        }
+
+        const BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+        var startLoad = typeof(NMultiplayerSubmenu).GetMethod("StartLoad", flags)
+            ?? throw new InvalidOperationException(Loc.T("找不到读档方法 StartLoad。"));
+        startLoad.Invoke(submenu, new object?[] { null });
+
+        var opened = await WaitForMainMenuSubmenuOpenAsync<NMultiplayerLoadGameScreen>(mainMenu, TimeSpan.FromSeconds(10), cancellationToken);
+        if (!opened)
+        {
+            var modal = GameStateService.GetOpenModal();
+            if (modal != null)
+            {
+                throw new InvalidOperationException(Loc.T("读档开房失败（多半是本地直连端口 33771 还被上一局占着）：重启游戏后再试。"));
+            }
+            throw new TimeoutException(Loc.T("读档后没有进入多人读档界面。"));
+        }
+
+        return true;
+    }
+
     private static async Task<ActionResponsePayload> ExecuteInviteAiTeammateAsync()
     {
         var payload = GameStateService.BuildStatePayload();
@@ -5690,12 +5826,13 @@ internal static class GameActionService
         return false;
     }
 
-    private static async Task<bool> WaitForMainMenuSubmenuOpenAsync<TSubmenu>(NMainMenu screen, TimeSpan timeout)
+    private static async Task<bool> WaitForMainMenuSubmenuOpenAsync<TSubmenu>(NMainMenu screen, TimeSpan timeout, CancellationToken cancellationToken = default)
         where TSubmenu : NSubmenu
     {
         var deadline = DateTime.UtcNow + timeout;
         while (DateTime.UtcNow < deadline)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             await WaitForNextFrameAsync();
 
             var currentScreen = ActiveScreenContext.Instance.GetCurrentScreen();
@@ -5928,6 +6065,37 @@ internal static class GameActionService
 
         return GodotObject.IsInstanceValid(screen) &&
             screen.Lobby.LocalPlayer.character.Id.Entry == currentCharacterId;
+    }
+
+    /// <summary>
+    /// The load screen disables its Embark button the moment the local player is marked ready and
+    /// swaps it for Unready; leaving the screen (run started, modal, menu torn down) also counts.
+    /// </summary>
+    private static async Task<bool> WaitForLoadEmbarkTransitionAsync(NMultiplayerLoadGameScreen screen, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            await WaitForNextFrameAsync();
+
+            if (IsLoadEmbarkSettled(screen))
+            {
+                return true;
+            }
+        }
+
+        return IsLoadEmbarkSettled(screen);
+    }
+
+    private static bool IsLoadEmbarkSettled(NMultiplayerLoadGameScreen screen)
+    {
+        var currentScreen = ActiveScreenContext.Instance.GetCurrentScreen();
+        if (!ReferenceEquals(currentScreen, screen) || !GodotObject.IsInstanceValid(screen))
+        {
+            return true;
+        }
+
+        return GameStateService.GetOpenModal() != null || !GameStateService.CanEmbark(currentScreen);
     }
 
     private static async Task<bool> WaitForEmbarkTransitionAsync(NCharacterSelectScreen screen, TimeSpan timeout)

--- a/STS2AIAgent/Game/GameStateService.cs
+++ b/STS2AIAgent/Game/GameStateService.cs
@@ -57,6 +57,7 @@ using MegaCrit.Sts2.Core.Saves;
 using MegaCrit.Sts2.Core.Saves.Managers;
 using MegaCrit.Sts2.Core.Timeline;
 using MegaCrit.Sts2.addons.mega_text;
+using STS2AIAgent.Config;
 using STS2AIAgent.Localization;
 using STS2AIAgent.Multiplayer;
 
@@ -182,6 +183,17 @@ internal static class GameStateService
             {
                 mode = characterSelectScreen.Lobby.NetService.Type.IsMultiplayer() ? "multiplayer" : "singleplayer",
                 phase = "character_select",
+                control_scope = "local_player"
+            };
+        }
+
+        // The multiplayer load screen is a lobby over a saved run: players ready up before the run resumes.
+        if (GetMultiplayerLoadScreen(currentScreen) != null)
+        {
+            return new SessionPayload
+            {
+                mode = "multiplayer",
+                phase = "multiplayer_lobby",
                 control_scope = "local_player"
             };
         }
@@ -354,6 +366,16 @@ internal static class GameStateService
             descriptors.Add(new ActionDescriptor
             {
                 name = "invite_ai_teammate",
+                requires_target = false,
+                requires_index = false
+            });
+        }
+
+        if (CanContinueAiTeammate(currentScreen))
+        {
+            descriptors.Add(new ActionDescriptor
+            {
+                name = "continue_ai_teammate",
                 requires_target = false,
                 requires_index = false
             });
@@ -1455,6 +1477,25 @@ internal static class GameStateService
 
         var submenuStack = GetSubmenuStack(submenu);
         return submenuStack != null && submenuStack.SubmenusOpen;
+    }
+
+    /// <summary>
+    /// Host main menu with a saved multiplayer run on disk: the same gate the game uses to show
+    /// "Load" instead of "Host" in its multiplayer submenu. The companion never continues a run itself.
+    /// </summary>
+    public static bool CanContinueAiTeammate(IScreenContext? currentScreen)
+    {
+        if (InstanceRole.IsCompanion)
+        {
+            return false;
+        }
+
+        if (currentScreen is not NMainMenu mainMenu || !mainMenu.IsVisibleInTree())
+        {
+            return false;
+        }
+
+        return SaveManager.Instance.HasMultiplayerRunSave;
     }
 
     public static bool CanEmbark(IScreenContext? currentScreen)
@@ -2619,6 +2660,11 @@ internal static class GameStateService
         if (currentScreen is NMainMenu mainMenu && mainMenu.IsVisibleInTree())
         {
             names.Add("invite_ai_teammate");
+        }
+
+        if (CanContinueAiTeammate(currentScreen))
+        {
+            names.Add("continue_ai_teammate");
         }
 
         if (CanChooseTimelineEpoch(currentScreen))
@@ -6152,11 +6198,19 @@ internal static class GameStateService
             .ToArray();
     }
 
+    public static NMultiplayerLoadGameScreen? GetMultiplayerLoadScreen(IScreenContext? currentScreen)
+    {
+        return currentScreen as NMultiplayerLoadGameScreen;
+    }
+
     public static NConfirmButton? GetCharacterEmbarkButton(IScreenContext? currentScreen)
     {
+        var load = GetMultiplayerLoadScreen(currentScreen);
+        if (load != null) return load.GetNodeOrNull<NConfirmButton>("ConfirmButton");
         return GetCharacterSelectScreen(currentScreen)?.GetNodeOrNull<NConfirmButton>("ConfirmButton");
     }
 
+    // Only the character-select screen advertises unready: the executor has no load-screen path for it.
     public static NBackButton? GetCharacterUnreadyButton(IScreenContext? currentScreen)
     {
         return GetCharacterSelectScreen(currentScreen)?.GetNodeOrNull<NBackButton>("UnreadyButton");
@@ -6890,6 +6944,7 @@ internal static class GameStateService
             NCombatRoom => "COMBAT",
             NMapScreen or NMapRoom => "MAP",
             NCharacterSelectScreen => "CHARACTER_SELECT",
+            NMultiplayerLoadGameScreen => "MULTIPLAYER_LOAD",
             NChooseABundleSelectionScreen => "BUNDLE_SELECTION",
             NCapstoneSubmenuStack => "CAPSTONE_SELECTION",
             NCrystalSphereScreen => "CRYSTAL_SPHERE",

--- a/STS2AIAgent/Localization/Loc.Strings.Runtime.cs
+++ b/STS2AIAgent/Localization/Loc.Strings.Runtime.cs
@@ -20,6 +20,16 @@ internal static partial class Loc
         map["跟随你的地图选择。"] = "Following your map choice.";
         map["确认阻挡操作的教学弹窗。"] = "Confirmed the tutorial popup that was blocking the action.";
 
+        // Continue a saved co-op run (Multiplayer/DualInstanceCoordinator.cs, Game/GameActionService.cs).
+        map["请先回到主菜单，再继续联机对局。"] = "Return to the main menu before continuing the co-op run.";
+        map["读档开房失败：{0}"] = "Loading the saved run failed: {0}";
+        map["正在继续联机存档，等待队友窗口连回…"] = "Continuing the saved co-op run; waiting for the teammate window to reconnect…";
+        map["继续联机存档失败：{0}"] = "Continuing the saved co-op run failed: {0}";
+        map["{0}。已按存档开好本地房，等队友窗口连回来后两边各点一次出发。"] = "{0}. The saved run is hosted locally; once the teammate window reconnects, both sides click Embark once.";
+        map["找不到读档方法 StartLoad。"] = "Could not find the StartLoad method.";
+        map["读档开房失败（多半是本地直连端口 33771 还被上一局占着）：重启游戏后再试。"] = "Loading the saved run failed (local port 33771 is most likely still held by the previous run): restart the game and try again.";
+        map["读档后没有进入多人读档界面。"] = "The multiplayer load screen did not open after loading the save.";
+
         // Single step.
         map["单步决策中"] = "Deciding the single step";
         map["单步已取消"] = "Single step cancelled";

--- a/STS2AIAgent/Multiplayer/CoopLaunchPolicy.cs
+++ b/STS2AIAgent/Multiplayer/CoopLaunchPolicy.cs
@@ -170,6 +170,12 @@ internal static class CoopLaunchPolicy
             return null;
         }
 
+        if (string.Equals(screen, "MULTIPLAYER_LOAD", StringComparison.OrdinalIgnoreCase))
+        {
+            if (Contains(actions, "embark")) return "embark";
+            return null;
+        }
+
         if (string.Equals(screen, "CHARACTER_SELECT", StringComparison.OrdinalIgnoreCase))
         {
             if (Contains(actions, "embark")) return "embark";

--- a/STS2AIAgent/Multiplayer/DualInstanceCoordinator.cs
+++ b/STS2AIAgent/Multiplayer/DualInstanceCoordinator.cs
@@ -53,6 +53,40 @@ internal static class DualInstanceCoordinator
         return (true, Loc.T("{0}。本机已创建 4 人大厅，请选角色后 Ready 开局。你打自己的角色；AI 会自动加入、点开局并打另一个角色。", launch.Message));
     }
 
+    /// <summary>
+    /// Host side: inject fastmp so the saved multiplayer run is hosted over local ENet, load it, then launch the companion to rejoin.
+    /// </summary>
+    public static async Task<(bool Ok, string Message)> ContinueLocalCoopResultAsync(CancellationToken cancellationToken)
+    {
+        if (await GetScreenAsync() != "MAIN_MENU")
+        {
+            return (false, Loc.T("请先回到主菜单，再继续联机对局。"));
+        }
+
+        try
+        {
+            EnableFastMpENetHost();
+            await GameThread.InvokeAsync(async () => await GameActionService.StartLocalLoadAsync(cancellationToken));
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Log.Warn($"{LogPrefix} Continue local coop failed: {ex.Message}");
+            return (false, Loc.T("读档开房失败：{0}", ex.Message));
+        }
+
+        var launch = await LocalDualInstanceLauncher.LaunchCompanionAsync(cancellationToken);
+        if (!launch.Ok)
+        {
+            return (false, launch.Message);
+        }
+
+        return (true, Loc.T("{0}。已按存档开好本地房，等队友窗口连回来后两边各点一次出发。", launch.Message));
+    }
+
     public static async Task<bool> RunCompanionBootstrapAsync(CancellationToken cancellationToken)
     {
         if (!InstanceRole.IsCompanion)

--- a/docs/api.md
+++ b/docs/api.md
@@ -61,6 +61,7 @@
 | `companion_session_required` | 403 | 需要有效的 AI 队友会话令牌（见下） | 否 |
 | `companion_not_ready` | 409 | 队友实例尚未就绪，无法响应控制 | 是 |
 | `invite_failed` | 409 | 邀请 AI 队友失败（主菜单状态或配置不满足） | 是 |
+| `continue_failed` | 409 | 读档开房流程启动后失败（读档界面没打开，或本地直连端口 33771 仍被上一局占用，重启游戏后可重试）；前置条件不满足（不在主菜单、没有联机存档、模型未验证）仍返回 `invalid_action` | 是 |
 | `collection_not_found` | 404 | `GET /data/{collection}` 的集合名不存在 | 否 |
 | `export_error` | 500 | 游戏元数据导出失败 | 是 |
 | `origin_not_allowed` | 403 | 原生 MCP 请求的 `Origin` 不受信任 | 否 |
@@ -74,6 +75,7 @@
 | `MAIN_MENU` | 主菜单、补丁说明、子菜单、Logo 动画 |
 | `CHARACTER_SELECT` | 角色选择界面 |
 | `MULTIPLAYER_LOBBY` | 多人联机房间界面（`host_multiplayer_lobby` / `join_multiplayer_lobby` / `ready_multiplayer_lobby` / `disconnect_multiplayer_lobby`） |
+| `MULTIPLAYER_LOAD` | 多人读档界面（`continue_ai_teammate` 读入联机存档后、各玩家 `embark` 之前） |
 | `BUNDLE_SELECTION` | 开局卡包选择界面（用 `choose_bundle` / `confirm_bundle`） |
 | `CAPSTONE_SELECTION` | Capstone 选项界面（用 `choose_capstone_option`） |
 | `MAP` | 地图界面 |
@@ -1082,6 +1084,7 @@ compact 里的位置与 `/state` 不同，但同名同源、同为新增键；`/
 - `dismiss_modal` — 关闭阻塞弹窗
 - `return_to_main_menu` — 返回主菜单
 - `invite_ai_teammate` — 邀请 AI 队友
+- `continue_ai_teammate` — 继续上次的联机存档并重新拉起 AI 队友（仅主机主菜单且存在联机存档时出现在 `available_actions`；读档流程失败返回 `continue_failed`）
 <!-- END ACTION CONTRACT -->
 
 ### 请求体
@@ -1782,6 +1785,7 @@ Invoke-RestMethod -Uri 'http://127.0.0.1:8080/data/cards' | ConvertTo-Json -Dept
 | 查看浮层 | `CARD_INSPECT` / `RELIC_INSPECT`；用 `close_cards_view` 关闭 | 已实现，待实机验证 |
 | 假商人事件商店 | `FAKE_MERCHANT`；`open_shop_inventory` 可打开 | 已实现，待实机验证 |
 | 角色选择 | `character_select` / `select_character` / `embark` | 已实现，待实机验证 |
+| 继续联机存档 | `MULTIPLAYER_LOAD` / `continue_ai_teammate` / `embark` | 已实现，2026-09-12 本地双实例实测通过 |
 | 药水系统 | `run.potions[*].can_use` / `use_potion` / `discard_potion` | 已实现，待实机验证 |
 | 阻塞弹窗 | `modal` / `confirm_modal` / `dismiss_modal` | 已实现，待实机验证 |
 | 游戏结束 | `game_over` / `return_to_main_menu` | 已实现，待实机验证 |

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -110,6 +110,7 @@
 - `ready_multiplayer_lobby`
 - `disconnect_multiplayer_lobby`
 - `invite_ai_teammate`
+- `continue_ai_teammate`
 
 奖励 / 选牌：
 

--- a/mcp_server/src/sts2_mcp/client.py
+++ b/mcp_server/src/sts2_mcp/client.py
@@ -390,6 +390,15 @@ class Sts2Client:
             },
         )
 
+    def continue_ai_teammate(self) -> dict[str, Any]:
+        return self.execute_action(
+            "continue_ai_teammate",
+            client_context={
+                "source": "mcp",
+                "tool_name": "continue_ai_teammate",
+            },
+        )
+
     def choose_timeline_epoch(self, option_index: int) -> dict[str, Any]:
         return self.execute_action(
             "choose_timeline_epoch",

--- a/mcp_server/src/sts2_mcp/server.py
+++ b/mcp_server/src/sts2_mcp/server.py
@@ -114,6 +114,7 @@ _LEGACY_ACTION_TOOLS: tuple[ActionToolSpec, ...] = (
     ActionToolSpec("ready_multiplayer_lobby", "no_args", "Mark the local player ready in the multiplayer lobby."),
     ActionToolSpec("disconnect_multiplayer_lobby", "no_args", "Leave the multiplayer lobby."),
     ActionToolSpec("invite_ai_teammate", "no_args", "Invite the AI teammate and launch the companion instance."),
+    ActionToolSpec("continue_ai_teammate", "no_args", "Continue the saved multiplayer run from the main menu and relaunch the AI teammate to rejoin it."),
 
 )
 


### PR DESCRIPTION
## Why
Loading a saved multiplayer run from the main menu hosts it over Steam
networking, so the locally launched companion never reconnects and the
host sees a disconnected portrait. Any co-op run therefore had to be
finished in one sitting.

## What
New host action `continue_ai_teammate`, advertised in `available_actions`
only on the host's main menu while a multiplayer run save exists on disk
(the same gate the game uses to show "Load" in its multiplayer submenu):

- injects `fastmp` so the game hosts the saved run over local ENet, the
  same path `invite_ai_teammate` already uses;
- reflects `NMultiplayerSubmenu.StartLoad`, waits for
  `NMultiplayerLoadGameScreen`, then launches the companion, which rejoins
  under its saved NetId;
- the load screen is surfaced as `MULTIPLAYER_LOAD` (session phase
  `multiplayer_lobby`); `embark` works on it and waits for the ready
  transition; the companion bootstrap presses Embark there; the run
  boundary treats it like the other pre-run screens;
- failures after the load flow started return `continue_failed`
  (retryable), classified on the structured launch outcome exactly like
  the invite path. Unmet preconditions still return `invalid_action`.

`docs/api.md` gains the action, the screen and the error code. New
offline contract tests pin action exposure, the retryable failure
envelope, the load-screen surface, bounded waits and cancellation
propagation.

## Verification
- Live two-instance run on 2026-09-12: continue from the main menu, both
  windows on `MULTIPLAYER_LOAD`, both embark, back in the Act 3 boss room
  with decks and relics intact.
- `scripts/check_verification_gates.py`: all seven gates pass.
- `dotnet run --project STS2AIAgent.Tests -c Release`: 355 pass. The only
  failure, `Skill.McpPlayerContract`, also fails on current `main` and is
  unrelated to this change.

## Known limit
If the previous run in the same game process still holds ENet port 33771,
the host cannot be created; the error text tells the user to restart the
game. A fresh host process continues fine.

## Summary by Sourcery

Enable hosts to resume saved multiplayer runs locally and automatically reconnect the AI teammate.

New Features:
- Add support for continuing saved multiplayer runs with a locally reconnected AI teammate through the MCP action `continue_ai_teammate`.
- Expose the multiplayer load screen and support Embark while waiting for both players to rejoin the saved run.

Bug Fixes:
- Allow saved multiplayer runs to resume without relying on Steam-hosted networking, avoiding disconnected local companion sessions.

Enhancements:
- Classify post-start continuation failures as retryable and preserve bounded, cancellable load-flow waits.

Documentation:
- Document the continuation action, multiplayer load screen, and retryable `continue_failed` error in the API and MCP documentation.

Tests:
- Add contract coverage for action availability, retryable failures, load-screen behavior, bounded waits, cancellation, and companion bootstrap behavior.