### PR TITLE
feat(coop): let the companion leave character choice to the host

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ This mod is still in development. Some things may be unfinished or break. Please
 - A second game window will launch automatically and join the co-op lobby. You play your character; the AI controls its character!
 - The main window shows whether the teammate is connected, waiting on you/the game/the model, or why it stopped and what to click next. **Pause teammate** gives immediate feedback; already submitted actions still finish.
 - Use team chat to coordinate in plain English or Chinese.
+- By default the teammate takes the preselected character and readies up by itself. To pick its character yourself (in the teammate window, or through the companion API with `select_character` then `embark`), set `companionAutoSelectCharacter` to `false` in the mod's `settings.json`; the teammate then waits on the character screen without a timeout.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -85,6 +85,7 @@ https://github.com/user-attachments/assets/89353468-a299-4315-9516-e520bcbfbd4b
 - 系统会自动拉起第二个游戏实例并加入本地联机大厅！你控制主角色，AI 队友控制副角色。
 - 主窗口会显示队友是否在连、正在等你/等游戏/请求模型，或为什么停、下一步点哪里。点 **暂停队友** 会立刻反馈；已提交的动作会先完成。
 - 可以直接用文字和队友商量路线与集火策略。
+- 队友默认拿大厅预选的角色并自动准备。想自己给它选角（在队友窗口里选，或通过队友 API 先 `select_character` 再 `embark`），把 mod 的 `settings.json` 里 `companionAutoSelectCharacter` 设为 `false`；此时队友会停在选角界面等你，没有超时。
 
 ---
 

--- a/STS2AIAgent.Tests/CompanionStartupTests.cs
+++ b/STS2AIAgent.Tests/CompanionStartupTests.cs
@@ -97,6 +97,23 @@ internal static class CompanionStartupTests
             "CHARACTER_SELECT",
             new[] { "unready" },
             hasLobby: true) == null);
+        // CompanionAutoSelectCharacter=false: leave pick + Ready to the human/agent, on both
+        // screens where that choice is made. Joining the lobby is still done by the companion.
+        Assert.True(CoopLaunchPolicy.NextCompanionBootstrapAction(
+            "CHARACTER_SELECT",
+            new[] { "select_character", "ready_multiplayer_lobby", "embark" },
+            hasLobby: true,
+            autoSelectCharacter: false) == null);
+        Assert.True(CoopLaunchPolicy.NextCompanionBootstrapAction(
+            "MULTIPLAYER_LOBBY",
+            new[] { "select_character", "ready_multiplayer_lobby" },
+            hasLobby: true,
+            autoSelectCharacter: false) == null);
+        Assert.Equal("join_multiplayer_lobby", CoopLaunchPolicy.NextCompanionBootstrapAction(
+            "MULTIPLAYER_LOBBY",
+            new[] { "join_multiplayer_lobby" },
+            hasLobby: false,
+            autoSelectCharacter: false));
         // Continuing a saved co-op run: the load screen only needs Embark.
         Assert.Equal("embark", CoopLaunchPolicy.NextCompanionBootstrapAction(
             "MULTIPLAYER_LOAD",
@@ -372,10 +389,31 @@ internal static class CompanionStartupTests
         var body = source[open..(end + 1)];
         Assert.False(body.Contains("OpenMultiplayerTestAsync", StringComparison.Ordinal));
         Assert.Contains("NextCompanionBootstrapAction", body, StringComparison.Ordinal);
+        // The flag must reach the policy from settings (not a literal), and the bootstrap
+        // deadline must be held while a human is choosing the character.
+        Assert.Contains("Settings?.CompanionAutoSelectCharacter ?? true", body, StringComparison.Ordinal);
+        Assert.Contains("CoopLaunchPolicy.WaitsForHumanChoice(", body, StringComparison.Ordinal);
+        Assert.Contains("deadline = DateTime.UtcNow + budget;", body, StringComparison.Ordinal);
         Assert.Equal("join_multiplayer_lobby", CoopLaunchPolicy.NextCompanionBootstrapAction(
             "MULTIPLAYER_LOBBY",
             new[] { "join_multiplayer_lobby" },
             hasLobby: false));
+    }
+
+    public static void BootstrapHoldsTheClockOnlyWhileAHumanChooses()
+    {
+        // Flag on: never a human wait.
+        Assert.False(CoopLaunchPolicy.WaitsForHumanChoice("CHARACTER_SELECT", new[] { "select_character", "embark" }, hasLobby: true, autoSelectCharacter: true));
+        // Flag off: the two screens where the character is chosen hold the clock.
+        Assert.True(CoopLaunchPolicy.WaitsForHumanChoice("CHARACTER_SELECT", new[] { "select_character", "embark" }, hasLobby: true, autoSelectCharacter: false));
+        Assert.True(CoopLaunchPolicy.WaitsForHumanChoice("MULTIPLAYER_LOBBY", new[] { "select_character", "ready_multiplayer_lobby" }, hasLobby: true, autoSelectCharacter: false));
+        // Machine steps keep the deadline: joining, main menu, the load screen, the run itself.
+        Assert.False(CoopLaunchPolicy.WaitsForHumanChoice("MULTIPLAYER_LOBBY", new[] { "join_multiplayer_lobby" }, hasLobby: false, autoSelectCharacter: false));
+        Assert.False(CoopLaunchPolicy.WaitsForHumanChoice("MAIN_MENU", Array.Empty<string>(), hasLobby: false, autoSelectCharacter: false));
+        Assert.False(CoopLaunchPolicy.WaitsForHumanChoice("MULTIPLAYER_LOAD", new[] { "embark" }, hasLobby: true, autoSelectCharacter: false));
+        Assert.False(CoopLaunchPolicy.WaitsForHumanChoice("COMBAT", new[] { "play_card", "end_turn" }, hasLobby: true, autoSelectCharacter: false));
+        // Already readied (only unready left): nothing to choose, the clock runs.
+        Assert.False(CoopLaunchPolicy.WaitsForHumanChoice("CHARACTER_SELECT", new[] { "unready" }, hasLobby: true, autoSelectCharacter: false));
     }
 
     public static void HealthRequiresExactCompanionIdentity()

--- a/STS2AIAgent.Tests/SettingsStoreTests.cs
+++ b/STS2AIAgent.Tests/SettingsStoreTests.cs
@@ -248,6 +248,7 @@ internal static class SettingsStoreTests
         source.OverlayLeft = 12;
         source.OverlayTop = 34;
         source.Endpoints[0].ApiKey = "sk-clone";
+        source.CompanionAutoSelectCharacter = false;
 
         var clone = SettingsClone.Clone(source);
 
@@ -262,6 +263,7 @@ internal static class SettingsStoreTests
         Assert.Equal(12f, clone.OverlayLeft);
         Assert.Equal(34f, clone.OverlayTop);
         Assert.Equal("sk-clone", clone.Endpoints[0].ApiKey);
+        Assert.False(clone.CompanionAutoSelectCharacter);
         Assert.Equal(source.ConversationModelId, clone.ConversationModelId);
     }
 

--- a/STS2AIAgent.Tests/TestRunner.cs
+++ b/STS2AIAgent.Tests/TestRunner.cs
@@ -189,6 +189,7 @@ internal static class TestRunner
         yield return ("CoopStartup.SettingsIsolation", () => Task.Run(CompanionStartupTests.SettingsPathCanBeIsolated));
         yield return ("CoopStartup.PortFile", () => Task.Run(CompanionStartupTests.CompanionPortFileRoundTrip));
         yield return ("CoopStartup.CompanionDoesNotHost", () => Task.Run(CompanionStartupTests.CompanionBootstrapDoesNotHostLobby));
+        yield return ("CoopStartup.HumanChoiceHoldsClock", () => Task.Run(CompanionStartupTests.BootstrapHoldsTheClockOnlyWhileAHumanChooses));
         yield return ("CoopStartup.Identity", () => Task.Run(CompanionStartupTests.HealthRequiresExactCompanionIdentity));
         yield return ("CoopStartup.Preconditions", () => Task.Run(CompanionStartupTests.LaunchPreconditionsProtectHumanRun));
         yield return ("SettingsStore.RoundTrip", () => Task.Run(SettingsStoreTests.RoundTrip_PreservesEndpointsModelsAndRoles));

--- a/STS2AIAgent/Config/AgentSettings.cs
+++ b/STS2AIAgent/Config/AgentSettings.cs
@@ -24,6 +24,9 @@ internal sealed class AgentSettings
 
     public bool HasSeenFirstRunGuide { get; set; }
 
+    /// <summary>Companion picks the preselected character and readies up by itself. Set false to choose for it via the companion API.</summary>
+    public bool CompanionAutoSelectCharacter { get; set; } = true;
+
     public List<ModelRoleTestRecord> RoleTests { get; set; } = new();
 
     public float? OverlayLeft { get; set; }

--- a/STS2AIAgent/Config/SettingsClone.cs
+++ b/STS2AIAgent/Config/SettingsClone.cs
@@ -42,6 +42,7 @@ internal static class SettingsClone
             AttachScreenshotInChat = source.AttachScreenshotInChat,
             OverlayVisibleOnStart = source.OverlayVisibleOnStart,
             HasSeenFirstRunGuide = source.HasSeenFirstRunGuide,
+            CompanionAutoSelectCharacter = source.CompanionAutoSelectCharacter,
             OverlayLeft = source.OverlayLeft,
             OverlayTop = source.OverlayTop,
             McpServerPath = source.McpServerPath,

--- a/STS2AIAgent/Multiplayer/CoopLaunchPolicy.cs
+++ b/STS2AIAgent/Multiplayer/CoopLaunchPolicy.cs
@@ -157,10 +157,44 @@ internal static class CoopLaunchPolicy
         return null;
     }
 
+    /// <summary>
+    /// True while the bootstrap is idle only because a human (or an external agent) has to pick
+    /// the character: the flag is off and the companion sits on a screen where that choice is
+    /// made. The bootstrap deadline must not run during this wait; it was sized for machine
+    /// steps, and the person may be away from the companion window for a while.
+    /// </summary>
+    public static bool WaitsForHumanChoice(
+        string screen,
+        IReadOnlyList<string> availableActions,
+        bool hasLobby,
+        bool autoSelectCharacter)
+    {
+        if (autoSelectCharacter)
+        {
+            return false;
+        }
+
+        if (string.Equals(screen, "CHARACTER_SELECT", StringComparison.OrdinalIgnoreCase))
+        {
+            return Contains(availableActions, "select_character")
+                || Contains(availableActions, "ready_multiplayer_lobby")
+                || Contains(availableActions, "embark");
+        }
+
+        if (string.Equals(screen, "MULTIPLAYER_LOBBY", StringComparison.OrdinalIgnoreCase))
+        {
+            return hasLobby
+                && (Contains(availableActions, "select_character") || Contains(availableActions, "ready_multiplayer_lobby"));
+        }
+
+        return false;
+    }
+
     public static string? NextCompanionBootstrapAction(
         string screen,
         IReadOnlyList<string> availableActions,
-        bool hasLobby)
+        bool hasLobby,
+        bool autoSelectCharacter = true)
     {
         var actions = availableActions ?? Array.Empty<string>();
         if (string.Equals(screen, "MODAL", StringComparison.OrdinalIgnoreCase))
@@ -178,6 +212,10 @@ internal static class CoopLaunchPolicy
 
         if (string.Equals(screen, "CHARACTER_SELECT", StringComparison.OrdinalIgnoreCase))
         {
+            // The lobby preselects the first character, so auto-ready locks it in. With
+            // CompanionAutoSelectCharacter=false the choice and Ready are left to a human or
+            // the external agent (select_character + embark on the companion API).
+            if (!autoSelectCharacter) return null;
             if (Contains(actions, "embark")) return "embark";
             if (Contains(actions, "ready_multiplayer_lobby")) return "ready_multiplayer_lobby";
             if (Contains(actions, "select_character")) return "select_character";
@@ -225,7 +263,10 @@ internal static class CoopLaunchPolicy
 
         if (string.Equals(screen, "MULTIPLAYER_LOBBY", StringComparison.OrdinalIgnoreCase))
         {
+            // Joining is machine work and always happens; picking and readying are the same
+            // human decision as on CHARACTER_SELECT and follow the same flag.
             if (!hasLobby && Contains(actions, "join_multiplayer_lobby")) return "join_multiplayer_lobby";
+            if (!autoSelectCharacter) return null;
             if (Contains(actions, "ready_multiplayer_lobby")) return "ready_multiplayer_lobby";
             if (Contains(actions, "select_character")) return "select_character";
             return null;

--- a/STS2AIAgent/Multiplayer/DualInstanceCoordinator.cs
+++ b/STS2AIAgent/Multiplayer/DualInstanceCoordinator.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using MegaCrit.Sts2.Core.Helpers;
 using MegaCrit.Sts2.Core.Logging;
+using STS2AIAgent.Agent;
 using STS2AIAgent.Config;
 using STS2AIAgent.Game;
 using STS2AIAgent.Localization;
@@ -97,7 +98,8 @@ internal static class DualInstanceCoordinator
         try
         {
             Log.Info($"{LogPrefix} Companion bootstrap starting");
-            var deadline = DateTime.UtcNow + TimeSpan.FromMinutes(5);
+            var budget = TimeSpan.FromMinutes(5);
+            var deadline = DateTime.UtcNow + budget;
             string? lastLog = null;
             while (DateTime.UtcNow < deadline)
             {
@@ -108,10 +110,18 @@ internal static class DualInstanceCoordinator
                     return true;
                 });
                 var snapshot = await GetBootstrapSnapshotAsync();
+                var autoSelectCharacter = AgentRuntime.Instance?.Settings?.CompanionAutoSelectCharacter ?? true;
                 var next = CoopLaunchPolicy.NextCompanionBootstrapAction(
                     snapshot.Screen,
                     snapshot.Actions,
-                    snapshot.HasLobby);
+                    snapshot.HasLobby,
+                    autoSelectCharacter);
+                if (CoopLaunchPolicy.WaitsForHumanChoice(snapshot.Screen, snapshot.Actions, snapshot.HasLobby, autoSelectCharacter))
+                {
+                    // The five-minute budget covers machine steps only. While a person is choosing
+                    // the character the clock is held, so the companion never times itself out.
+                    deadline = DateTime.UtcNow + budget;
+                }
                 var log = snapshot.Screen + "|" + (next ?? "-") + "|" + string.Join(",", snapshot.Actions);
                 if (!string.Equals(log, lastLog, StringComparison.Ordinal))
                 {


### PR DESCRIPTION
## Why
The lobby preselects the first character and the companion bootstrap
readies and embarks immediately, so the AI teammate always plays that
character. There is no way to hand the choice to the host or to an
external agent driving the companion API.

## What
New setting `CompanionAutoSelectCharacter`, default `true`, which keeps
today's behaviour. When `false` the bootstrap makes no character decision
on either screen where one is made: it stops on `CHARACTER_SELECT`, and on
`MULTIPLAYER_LOBBY` it still joins but neither selects nor readies. A human
in the companion window, or an external agent through the companion API
(`select_character`, then `embark`), picks the character.

The five-minute bootstrap budget was sized for machine steps; while the
companion waits for that human choice the clock is held, so nobody is
timed out for being away from the window. `SettingsClone` carries the
flag, a source contract test pins the wiring from settings to the policy,
and the README documents the setting. An overlay checkbox is left for a
follow-up.

## Verification
- `dotnet run --project STS2AIAgent.Tests -c Release`: 357 pass / 0 fail
  (CRLF checkout, as on CI).
- `scripts/check_verification_gates.py`: all seven gates pass.
- Used on 2026-09-12 in a live two-instance session: the companion waited
  on the character screen until picked through the API.

## Summary by Sourcery

Allow hosts or external agents to control the companion’s character selection while retaining the existing automatic behavior by default.

New Features:
- Add a setting that lets hosts or external agents choose the companion’s character instead of relying on automatic selection.

Bug Fixes:
- Prevent the companion bootstrap from timing out while waiting for a human or external agent to make the character choice.

Enhancements:
- Preserve automatic character selection by default while still joining the multiplayer lobby when manual selection is enabled.
- Propagate the setting through cloned configuration and document its use in English and Chinese README files.

Documentation:
- Document manual companion character selection through the teammate window or companion API.

Tests:
- Add coverage for manual character selection behavior, timeout handling, settings cloning, and settings-to-policy wiring.