### PR TITLE
fix: 暂停菜单不再冒充 capstone（#88）+ 读档前验 NetId，别让游戏改写存档（#89）

### DIFF
--- a/STS2AIAgent.Tests/CoopSavePrecheckTests.cs
+++ b/STS2AIAgent.Tests/CoopSavePrecheckTests.cs
@@ -1,0 +1,81 @@
+using STS2AIAgent.Multiplayer;
+
+namespace STS2AIAgent.Tests;
+
+/// <summary>
+/// Offline contract for the co-op save precheck. The game renames the multiplayer run save (and its
+/// backup) to *.VAL.corrupt when the save's players[].net_id set does not contain the local player
+/// id, so the ids have to be read out of the save text and compared before any load. The rule is
+/// fail-open: a save the probe could not read must never block a legitimate continue.
+/// </summary>
+internal static class CoopSavePrecheckTests
+{
+    private const string TwoPlayerSave = """
+        { "schema_version": 20, "players": [ { "net_id": 1, "current_hp": 70 }, { "net_id": 2026091302 } ] }
+        """;
+
+    public static void ReadsPlayerNetIdsFromTheSave()
+    {
+        var ids = CoopSavePrecheckPolicy.ReadPlayerNetIds(TwoPlayerSave);
+        Assert.Equal(2, ids.Count);
+        Assert.Equal(1UL, ids[0]);
+        Assert.Equal(2026091302UL, ids[1]);
+    }
+
+    public static void ReadsNumericStringNetIds()
+    {
+        var ids = CoopSavePrecheckPolicy.ReadPlayerNetIds(
+            """{ "players": [ { "net_id": "7" }, { "net_id": 8 } ] }""");
+        Assert.Equal(2, ids.Count);
+        Assert.Equal(7UL, ids[0]);
+        Assert.Equal(8UL, ids[1]);
+    }
+
+    public static void UnreadableSavesYieldNoIds()
+    {
+        Assert.Equal(0, CoopSavePrecheckPolicy.ReadPlayerNetIds(null).Count);
+        Assert.Equal(0, CoopSavePrecheckPolicy.ReadPlayerNetIds("   ").Count);
+        Assert.Equal(0, CoopSavePrecheckPolicy.ReadPlayerNetIds("not json").Count);
+        Assert.Equal(0, CoopSavePrecheckPolicy.ReadPlayerNetIds("{}").Count);
+        Assert.Equal(0, CoopSavePrecheckPolicy.ReadPlayerNetIds("""{ "players": {} }""").Count);
+        Assert.Equal(0, CoopSavePrecheckPolicy.ReadPlayerNetIds("""{ "players": [] }""").Count);
+        // A player entry without a usable net_id is skipped, never guessed.
+        Assert.Equal(0, CoopSavePrecheckPolicy.ReadPlayerNetIds("""{ "players": [ { "net_id": "abc" }, {} ] }""").Count);
+    }
+
+    public static void HostMismatchNamesBothIdsAndTheConsequence()
+    {
+        var ids = CoopSavePrecheckPolicy.ReadPlayerNetIds(TwoPlayerSave);
+        Assert.True(CoopSavePrecheckPolicy.DescribeHostMismatch(ids, 1) == null);
+        Assert.True(CoopSavePrecheckPolicy.DescribeHostMismatch(ids, 2026091302) == null);
+
+        var message = CoopSavePrecheckPolicy.DescribeHostMismatch(ids, 2026091007);
+        Assert.NotNull(message);
+        Assert.Contains("2026091007", message);
+        Assert.Contains("1,2026091302", message);
+        Assert.Contains(".VAL.corrupt", message);
+        Assert.Contains("--clientId", message);
+    }
+
+    public static void CompanionMismatchNamesBothIdsAndTheRejection()
+    {
+        var ids = CoopSavePrecheckPolicy.ReadPlayerNetIds(TwoPlayerSave);
+        Assert.True(CoopSavePrecheckPolicy.DescribeCompanionMismatch(ids, 2026091302) == null);
+
+        var message = CoopSavePrecheckPolicy.DescribeCompanionMismatch(ids, 2);
+        Assert.NotNull(message);
+        Assert.Contains("NetId 2", message);
+        Assert.Contains("NotInSaveGame", message);
+        Assert.Contains("1,2026091302", message);
+    }
+
+    public static void UnreadableIdsFailOpen()
+    {
+        Assert.True(CoopSavePrecheckPolicy.DescribeHostMismatch(Array.Empty<ulong>(), 5) == null);
+        Assert.True(CoopSavePrecheckPolicy.DescribeCompanionMismatch(Array.Empty<ulong>(), 5) == null);
+
+        var noIds = CoopSavePrecheckPolicy.ReadPlayerNetIds("not json");
+        Assert.True(CoopSavePrecheckPolicy.DescribeHostMismatch(noIds, 5) == null);
+        Assert.True(CoopSavePrecheckPolicy.DescribeCompanionMismatch(noIds, 5) == null);
+    }
+}

--- a/STS2AIAgent.Tests/STS2AIAgent.Tests.csproj
+++ b/STS2AIAgent.Tests/STS2AIAgent.Tests.csproj
@@ -25,6 +25,7 @@
     <Compile Include="..\STS2AIAgent\Multiplayer\CompanionPlayPolicy.cs" Link="Multiplayer\CompanionPlayPolicy.cs" />
     <Compile Include="..\STS2AIAgent\Multiplayer\CompanionProfileBootstrap.cs" Link="Multiplayer\CompanionProfileBootstrap.cs" />
     <Compile Include="..\STS2AIAgent\Multiplayer\CoopLaunchPolicy.cs" Link="Multiplayer\CoopLaunchPolicy.cs" />
+    <Compile Include="..\STS2AIAgent\Multiplayer\CoopSavePrecheckPolicy.cs" Link="Multiplayer\CoopSavePrecheckPolicy.cs" />
     <Compile Include="..\STS2AIAgent\Multiplayer\TeamConversation.cs" Link="Multiplayer\TeamConversation.cs" />
     <Compile Include="..\STS2AIAgent\Multiplayer\CompanionConnection.cs" Link="Multiplayer\CompanionConnection.cs" />
     <Compile Include="..\STS2AIAgent\Config\*.cs" Link="Config\%(Filename)%(Extension)" />

--- a/STS2AIAgent.Tests/ScreenResolutionContractTests.cs
+++ b/STS2AIAgent.Tests/ScreenResolutionContractTests.cs
@@ -143,6 +143,57 @@ internal static class ScreenResolutionContractTests
         Assert.Contains("return currentScreen is not NCardsViewScreen;", closed, StringComparison.Ordinal);
     }
 
+    public static void PauseMenuIsNotADecisionScreen()
+    {
+        var rawState = AgentSourceFixture.Read("STS2AIAgent/Game/GameStateService.cs");
+        var resolveBody = Flat(AgentSourceFixture.MethodBody(rawState, "ResolveNonModalScreen"));
+
+        // The pause menu rides in the same NCapstoneSubmenuStack as the Settings/Compendium/Feedback
+        // overlays and is told apart by Type, so it must claim PAUSE_MENU before the combat branch and
+        // the visible card grid can name a paused game COMBAT or CARD_SELECTION.
+        const string pauseGuard =
+            "if(currentScreenisNCapstoneSubmenuStack{Type:CapstoneSubmenuType.PauseMenu})";
+        var pauseIndex = resolveBody.IndexOf(pauseGuard, StringComparison.Ordinal);
+        var combatIndex = resolveBody.IndexOf("FindActiveCombatRoom(currentScreen)", StringComparison.Ordinal);
+        var visibleGridIndex = resolveBody.IndexOf(
+            "GetVisibleGridCardHolders(rootNode).Count>0", StringComparison.Ordinal);
+
+        Assert.True(pauseIndex >= 0, "ResolveNonModalScreen must claim PAUSE_MENU for the pause overlay.");
+        Assert.True(combatIndex >= 0, "The combat branch must remain covered by this contract.");
+        Assert.True(visibleGridIndex >= 0, "The visible card-grid fallback must remain covered by this contract.");
+        Assert.True(pauseIndex < combatIndex, "PAUSE_MENU must resolve before FindActiveCombatRoom can report COMBAT.");
+        Assert.True(pauseIndex < visibleGridIndex, "PAUSE_MENU must resolve before the visible grid can report CARD_SELECTION.");
+        Assert.Contains("return\"PAUSE_MENU\";", resolveBody[pauseIndex..combatIndex], StringComparison.Ordinal);
+        Assert.Contains(
+            "NCapstoneSubmenuStack=>\"CAPSTONE_SELECTION\"",
+            resolveBody,
+            StringComparison.Ordinal);
+
+        // The pause menu is the one capstone-container type whose buttons are not a decision list, so
+        // the option getter drops it and both action lists stay empty while it is up.
+        var capstoneButtons = Flat(AgentSourceFixture.DeclarationBody(
+            rawState,
+            "public static IReadOnlyList<NButton> GetCapstoneButtons("));
+        Assert.Contains(
+            "capstoneScreen.Type==CapstoneSubmenuType.PauseMenu",
+            capstoneButtons,
+            StringComparison.Ordinal);
+
+        var names = Flat(AgentSourceFixture.MethodBody(rawState, "BuildAvailableActionNames"));
+        var descriptors = Flat(AgentSourceFixture.MethodBody(rawState, "BuildAvailableActionsPayload"));
+        Assert.Contains(pauseGuard, names, StringComparison.Ordinal);
+        Assert.Contains(pauseGuard, descriptors, StringComparison.Ordinal);
+
+        // The pause branch returns ahead of the combat actions, so nothing is advertised while paused.
+        var pauseInNames = names.IndexOf(pauseGuard, StringComparison.Ordinal);
+        var endTurnIndex = names.IndexOf(
+            "if(CanEndTurn(currentScreen,combatState,requireButtonReady:false))",
+            StringComparison.Ordinal);
+        Assert.True(
+            endTurnIndex >= 0 && pauseInNames >= 0 && pauseInNames < endTurnIndex,
+            "The pause branch must return before the combat actions are advertised.");
+    }
+
     private static (string ScreenType, string ScreenName)[] SwitchMappings(string methodBody)
     {
         var normalized = Normalize(methodBody);
@@ -161,4 +212,6 @@ internal static class ScreenResolutionContractTests
     {
         return Regex.Replace(source, "\\s+", " ");
     }
+
+    private static string Flat(string source) => AgentSourceFixture.WithoutWhitespace(source);
 }

--- a/STS2AIAgent.Tests/SourceCoverageTests.cs
+++ b/STS2AIAgent.Tests/SourceCoverageTests.cs
@@ -32,6 +32,7 @@ internal static class SourceCoverageTests
         "STS2AIAgent/Multiplayer/LocalDualInstanceLauncher.cs",
         "STS2AIAgent/Agent/GameBridge.cs",
         "STS2AIAgent/Multiplayer/DualInstanceCoordinator.cs",
+        "STS2AIAgent/Multiplayer/CoopSaveProbe.cs",
         "STS2AIAgent/Server/HttpServer.cs",
         "STS2AIAgent/Ui/UiFactory.cs",
         "STS2AIAgent/Game/GameThread.cs",

--- a/STS2AIAgent.Tests/TestRunner.cs
+++ b/STS2AIAgent.Tests/TestRunner.cs
@@ -192,6 +192,12 @@ internal static class TestRunner
         yield return ("CoopStartup.HumanChoiceHoldsClock", () => Task.Run(CompanionStartupTests.BootstrapHoldsTheClockOnlyWhileAHumanChooses));
         yield return ("CoopStartup.Identity", () => Task.Run(CompanionStartupTests.HealthRequiresExactCompanionIdentity));
         yield return ("CoopStartup.Preconditions", () => Task.Run(CompanionStartupTests.LaunchPreconditionsProtectHumanRun));
+        yield return ("CoopSave.ReadNetIds", () => Task.Run(CoopSavePrecheckTests.ReadsPlayerNetIdsFromTheSave));
+        yield return ("CoopSave.NumericStringNetIds", () => Task.Run(CoopSavePrecheckTests.ReadsNumericStringNetIds));
+        yield return ("CoopSave.UnreadableSaves", () => Task.Run(CoopSavePrecheckTests.UnreadableSavesYieldNoIds));
+        yield return ("CoopSave.HostMismatch", () => Task.Run(CoopSavePrecheckTests.HostMismatchNamesBothIdsAndTheConsequence));
+        yield return ("CoopSave.CompanionMismatch", () => Task.Run(CoopSavePrecheckTests.CompanionMismatchNamesBothIdsAndTheRejection));
+        yield return ("CoopSave.FailOpenWhenUnreadable", () => Task.Run(CoopSavePrecheckTests.UnreadableIdsFailOpen));
         yield return ("SettingsStore.RoundTrip", () => Task.Run(SettingsStoreTests.RoundTrip_PreservesEndpointsModelsAndRoles));
         yield return ("ProactiveChat.LegacySettingsStayOff", () => Task.Run(SettingsStoreTests.ProactiveChat_LegacyFileLoadsDisabledWithDefaultTone));
         yield return ("ProactiveChat.StoredToneRepaired", () => Task.Run(SettingsStoreTests.ProactiveChat_UnknownStoredToneIsRepaired));
@@ -408,6 +414,7 @@ internal static class TestRunner
         yield return ("ScreenResolution.FakeMerchant", () => Task.Run(ScreenResolutionContractTests.FakeMerchantOpensThroughTheSharedButton));
         yield return ("ScreenResolution.PatchNotes", () => Task.Run(ScreenResolutionContractTests.PatchNotesClosePathIsWidenedWithoutWeakeningSubmenus));
         yield return ("ScreenResolution.InspectOverlays", () => Task.Run(ScreenResolutionContractTests.InspectOverlaysCloseThroughTheirOwnClose));
+        yield return ("ScreenResolution.PauseMenu", () => Task.Run(ScreenResolutionContractTests.PauseMenuIsNotADecisionScreen));
         yield return ("TimelineIndex.OneSpace", () => Task.Run(TimelineIndexContractTests.ExecutorIndexesTheSameSlotListTheStateExposes));
         yield return ("TimelineIndex.NonActionableRejected", () => Task.Run(TimelineIndexContractTests.NonActionableSlotsAreRejectedExplicitly));
         yield return ("TimelineIndex.DescriptorFlags", () => Task.Run(TimelineIndexContractTests.CrystalDescriptorsCarryTheirRequirements));

--- a/STS2AIAgent/Game/GameActionService.cs
+++ b/STS2AIAgent/Game/GameActionService.cs
@@ -5044,9 +5044,26 @@ internal static class GameActionService
                 command
             }, retryable: true);
 
-        var runState = RunManager.Instance.DebugOnlyGetState();
-        var player = GameStateService.GetLocalPlayer(runState);
-        var result = devConsole.ProcessNetCommand(player, command);
+        // A command implementation can throw (BestiaryConsoleCmd.Process does on a null model) and the
+        // exception used to reach the HTTP layer as a bare 500 internal_error. Report it as a
+        // client-visible, non-retryable invalid_action, keeping the original type and message so the
+        // cause is still visible instead of being swallowed or dressed up as success.
+        CmdResult result;
+        try
+        {
+            var runState = RunManager.Instance.DebugOnlyGetState();
+            var player = GameStateService.GetLocalPlayer(runState);
+            result = devConsole.ProcessNetCommand(player, command);
+        }
+        catch (Exception ex)
+        {
+            throw new ApiException(409, "invalid_action", $"Console command failed: {ex.GetType().Name}: {ex.Message}", new
+            {
+                action = "run_console_command",
+                command
+            });
+        }
+
         if (!result.success)
         {
             throw new ApiException(409, "invalid_action", string.IsNullOrWhiteSpace(result.msg) ? "Console command failed." : result.msg, new
@@ -5207,6 +5224,42 @@ internal static class GameActionService
             });
         }
 
+        // The load path canonicalizes the save against this process's local player id and, on a
+        // mismatch, renames current_run_mp.save and its .backup to *.VAL.corrupt without restoring
+        // them. Check both ids against the save first: a mismatched --clientId must not be allowed to
+        // destroy the only co-op save slot, and retrying it cannot succeed, so this is invalid_action.
+        CoopSaveProbe.TryReadMultiplayerSaveNetIds(out var saveNetIds, out _);
+        var localPlayerId = CoopSaveProbe.ResolveLoadLocalPlayerId();
+        var hostMismatch = CoopSavePrecheckPolicy.DescribeHostMismatch(saveNetIds, localPlayerId);
+        if (hostMismatch != null)
+        {
+            throw new ApiException(409, "invalid_action", hostMismatch, new
+            {
+                action = "continue_ai_teammate",
+                save_player_net_ids = saveNetIds,
+                local_player_id = localPlayerId
+            });
+        }
+
+        if (!CoopSaveProbe.TryResolveCompanionClientId(out var companionClientId, out var companionIdError))
+        {
+            throw new ApiException(409, "invalid_action", companionIdError!, new
+            {
+                action = "continue_ai_teammate"
+            });
+        }
+
+        var companionMismatch = CoopSavePrecheckPolicy.DescribeCompanionMismatch(saveNetIds, companionClientId);
+        if (companionMismatch != null)
+        {
+            throw new ApiException(409, "invalid_action", companionMismatch, new
+            {
+                action = "continue_ai_teammate",
+                save_player_net_ids = saveNetIds,
+                companion_client_id = companionClientId
+            });
+        }
+
         await AgentRuntime.Instance.ContinueDualInstanceAsync(AgentRuntime.Instance.Settings, CancellationToken.None);
         // Same classification as invite_ai_teammate: read the structured outcome, never the localized text.
         var outcome = AgentRuntime.Instance.DualLaunchOutcome;
@@ -5281,7 +5334,11 @@ internal static class GameActionService
             var modal = GameStateService.GetOpenModal();
             if (modal != null)
             {
-                throw new InvalidOperationException(Loc.T("读档开房失败（多半是本地直连端口 33771 还被上一局占着）：重启游戏后再试。"));
+                // The open modal is what is actually observable here; the port is only the usual
+                // cause, so it is reported as a possibility instead of being asserted as the reason.
+                throw new InvalidOperationException(Loc.T(
+                    "读档开房失败：当前弹窗是 {0}。常见原因是本地直连端口 33771 仍被上一局占着；可重启游戏后再试。",
+                    modal.GetType().Name));
             }
             throw new TimeoutException(Loc.T("读档后没有进入多人读档界面。"));
         }

--- a/STS2AIAgent/Game/GameStateService.cs
+++ b/STS2AIAgent/Game/GameStateService.cs
@@ -252,6 +252,17 @@ internal static class GameStateService
             };
         }
 
+        // The pause menu is a human overlay: nothing is actionable while it is up, so the descriptor
+        // list stays empty instead of advertising the paused combat actions.
+        if (currentScreen is NCapstoneSubmenuStack { Type: CapstoneSubmenuType.PauseMenu })
+        {
+            return new AvailableActionsPayload
+            {
+                screen = ResolveScreen(currentScreen),
+                actions = descriptors.ToArray()
+            };
+        }
+
         if (currentScreen is NUnlockScreen)
         {
             if (CanConfirmUnlock(currentScreen))
@@ -1194,7 +1205,11 @@ internal static class GameStateService
 
     public static IReadOnlyList<NButton> GetCapstoneButtons(IScreenContext? currentScreen)
     {
-        if (currentScreen is not NCapstoneSubmenuStack capstoneScreen)
+        // Only the Settings/Compendium/Feedback overlays are capstone decision lists now; the pause
+        // menu shares the container but its own buttons include "放弃" and "保存并退出", so it must
+        // never read as a capstone option list.
+        if (currentScreen is not NCapstoneSubmenuStack capstoneScreen ||
+            capstoneScreen.Type == CapstoneSubmenuType.PauseMenu)
         {
             return Array.Empty<NButton>();
         }
@@ -2599,6 +2614,13 @@ internal static class GameStateService
                 names.Add("dismiss_modal");
             }
 
+            return names.ToArray();
+        }
+
+        // The human paused the game: combat actions are swallowed while paused and the overlay's own
+        // buttons (including "放弃") are not agent decisions, so advertise nothing.
+        if (currentScreen is NCapstoneSubmenuStack { Type: CapstoneSubmenuType.PauseMenu })
+        {
             return names.ToArray();
         }
 
@@ -6875,6 +6897,15 @@ internal static class GameStateService
 
     private static string ResolveNonModalScreen(IScreenContext? currentScreen)
     {
+        // The capstone container hosts every overlay and tells them apart by its own Type; the
+        // in-game pause menu rides in it too. It has to claim PAUSE_MENU before the combat and
+        // visible-grid branches below can name the paused scene COMBAT or CARD_SELECTION, which
+        // would advertise a live action list over a game the human just paused.
+        if (currentScreen is NCapstoneSubmenuStack { Type: CapstoneSubmenuType.PauseMenu })
+        {
+            return "PAUSE_MENU";
+        }
+
         if (currentScreen is NUnlockScreen)
         {
             return "UNLOCK";

--- a/STS2AIAgent/Localization/Loc.Strings.Runtime.cs
+++ b/STS2AIAgent/Localization/Loc.Strings.Runtime.cs
@@ -27,8 +27,12 @@ internal static partial class Loc
         map["继续联机存档失败：{0}"] = "Continuing the saved co-op run failed: {0}";
         map["{0}。已按存档开好本地房，等队友窗口连回来后两边各点一次出发。"] = "{0}. The saved run is hosted locally; once the teammate window reconnects, both sides click Embark once.";
         map["找不到读档方法 StartLoad。"] = "Could not find the StartLoad method.";
-        map["读档开房失败（多半是本地直连端口 33771 还被上一局占着）：重启游戏后再试。"] = "Loading the saved run failed (local port 33771 is most likely still held by the previous run): restart the game and try again.";
+        map["读档开房失败：当前弹窗是 {0}。常见原因是本地直连端口 33771 仍被上一局占着；可重启游戏后再试。"] = "Loading the saved run failed: the open modal is {0}. The usual cause is the local direct port 33771 still held by the previous run; restart the game and try again.";
         map["读档后没有进入多人读档界面。"] = "The multiplayer load screen did not open after loading the save.";
+        // The two NetId prechecks in Multiplayer/CoopSavePrecheckPolicy.cs. Both fire before the
+        // game is allowed to load, because a failed load renames the co-op save to *.VAL.corrupt.
+        map["主机的 NetId {0} 不在联机存档的玩家列表（{1}）里：游戏会拒绝读档，并把这局存档改名成 .VAL.corrupt 挪走且不还原，所以现在开不了房。离线主机的 NetId 就是启动参数 --clientId 的值（未传时默认为 1），请改用它重开主机；或者先删掉这份存档再开。"] = "Host NetId {0} is not in the saved co-op run's player list ({1}): the game refuses to load it and renames this run's save to *.VAL.corrupt without restoring it, so no lobby is hosted. An offline host's NetId is the --clientId launch argument (1 when omitted); restart the host with that value, or delete this save first.";
+        map["本次会用 NetId {0} 拉起 AI 队友，但联机存档的玩家列表（{1}）里没有这个 id：队友加入会被游戏拒绝（NotInSaveGame）退回主菜单，主机则卡在读档界面。队友 id 是主机 id + 1，请把主机启动参数 --clientId 改成「存档里队友的 id 减一」后重开。"] = "This attempt would launch the AI teammate with NetId {0}, but that id is not in the saved co-op run's player list ({1}): the game rejects the join (NotInSaveGame) and sends the teammate back to the main menu while the host stays stuck on the load screen. The teammate id is host id + 1, so restart the host with --clientId set to the saved teammate id minus one.";
 
         // Single step.
         map["单步决策中"] = "Deciding the single step";

--- a/STS2AIAgent/Multiplayer/CoopSavePrecheckPolicy.cs
+++ b/STS2AIAgent/Multiplayer/CoopSavePrecheckPolicy.cs
@@ -1,0 +1,143 @@
+using System.Globalization;
+using System.Text.Json;
+using STS2AIAgent.Localization;
+
+namespace STS2AIAgent.Multiplayer;
+
+/// <summary>
+/// Pure half of the co-op save precheck: it reads the player ids out of a multiplayer run save and
+/// decides whether this process may load that save. It deliberately references no game types, so
+/// <c>STS2AIAgent.Tests</c> can compile and drive it offline.
+///
+/// Why the check exists at all: the game's own load path
+/// (<c>MegaCrit.Sts2.Core.Runs.RunManager.CanonicalizeSave</c>) throws when the save's
+/// <c>players[].net_id</c> set does not contain the local player id, and
+/// <c>RunSaveManager.RenameBrokenMultiplayerRunSave</c> then renames <c>current_run_mp.save</c> and
+/// its <c>.backup</c> to <c>*.VAL.corrupt</c> without restoring them. There is one multiplayer save
+/// slot, so a mismatch has to be caught before the load is attempted.
+/// </summary>
+internal static class CoopSavePrecheckPolicy
+{
+    /// <summary>
+    /// Player ids from <c>players[].net_id</c>. An empty list means "no evidence" for every
+    /// caller: null, blank, malformed JSON and a missing <c>players</c> array all return empty
+    /// instead of throwing, and ids given as numbers or numeric strings both count.
+    /// </summary>
+    public static IReadOnlyList<ulong> ReadPlayerNetIds(string? saveJson)
+    {
+        if (string.IsNullOrWhiteSpace(saveJson))
+        {
+            return Array.Empty<ulong>();
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(saveJson);
+            if (document.RootElement.ValueKind != JsonValueKind.Object
+                || !document.RootElement.TryGetProperty("players", out var players)
+                || players.ValueKind != JsonValueKind.Array)
+            {
+                return Array.Empty<ulong>();
+            }
+
+            var ids = new List<ulong>();
+            foreach (var player in players.EnumerateArray())
+            {
+                if (player.ValueKind != JsonValueKind.Object
+                    || !player.TryGetProperty("net_id", out var netId)
+                    || !TryReadNetId(netId, out var id))
+                {
+                    continue;
+                }
+
+                ids.Add(id);
+            }
+
+            return ids;
+        }
+        catch (JsonException)
+        {
+            // An unparseable save proves nothing about the ids, so it must not block a load.
+            return Array.Empty<ulong>();
+        }
+    }
+
+    /// <summary>
+    /// Null when the save cannot prove a mismatch - unreadable ids, or an id that is present - so
+    /// a save the probe could not read never blocks a legitimate load. Otherwise the player-facing
+    /// explanation, which names both ids and the consequence.
+    /// </summary>
+    public static string? DescribeHostMismatch(IReadOnlyList<ulong> netIds, ulong localPlayerId)
+    {
+        if (netIds is not { Count: > 0 } || Contains(netIds, localPlayerId))
+        {
+            return null;
+        }
+
+        return Loc.T(
+            "主机的 NetId {0} 不在联机存档的玩家列表（{1}）里：游戏会拒绝读档，并把这局存档改名成 .VAL.corrupt 挪走且不还原，所以现在开不了房。离线主机的 NetId 就是启动参数 --clientId 的值（未传时默认为 1），请改用它重开主机；或者先删掉这份存档再开。",
+            localPlayerId,
+            Join(netIds));
+    }
+
+    /// <summary>
+    /// Null on the same fail-open rule as <see cref="DescribeHostMismatch"/>. The companion id has
+    /// to be in the save too: the host refuses a join for an id that is not in the saved roster
+    /// (<c>JoinFlow: Disconnected during join flow, reason: NotInSaveGame</c>), which leaves the
+    /// teammate back at the main menu and the host stuck on the load screen.
+    /// </summary>
+    public static string? DescribeCompanionMismatch(IReadOnlyList<ulong> netIds, ulong companionClientId)
+    {
+        if (netIds is not { Count: > 0 } || Contains(netIds, companionClientId))
+        {
+            return null;
+        }
+
+        return Loc.T(
+            "本次会用 NetId {0} 拉起 AI 队友，但联机存档的玩家列表（{1}）里没有这个 id：队友加入会被游戏拒绝（NotInSaveGame）退回主菜单，主机则卡在读档界面。队友 id 是主机 id + 1，请把主机启动参数 --clientId 改成「存档里队友的 id 减一」后重开。",
+            companionClientId,
+            Join(netIds));
+    }
+
+    private static bool TryReadNetId(JsonElement element, out ulong id)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Number:
+                return element.TryGetUInt64(out id);
+            case JsonValueKind.String:
+                return ulong.TryParse(
+                    element.GetString(),
+                    NumberStyles.Integer,
+                    CultureInfo.InvariantCulture,
+                    out id);
+            default:
+                id = 0;
+                return false;
+        }
+    }
+
+    private static bool Contains(IReadOnlyList<ulong> ids, ulong id)
+    {
+        for (var i = 0; i < ids.Count; i++)
+        {
+            if (ids[i] == id)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string Join(IReadOnlyList<ulong> ids)
+    {
+        var parts = new string[ids.Count];
+        for (var i = 0; i < ids.Count; i++)
+        {
+            parts[i] = ids[i].ToString(CultureInfo.InvariantCulture);
+        }
+
+        return string.Join(",", parts);
+    }
+}

--- a/STS2AIAgent/Multiplayer/CoopSaveProbe.cs
+++ b/STS2AIAgent/Multiplayer/CoopSaveProbe.cs
@@ -1,0 +1,106 @@
+using MegaCrit.Sts2.Core.Helpers;
+using MegaCrit.Sts2.Core.Platform;
+using MegaCrit.Sts2.Core.Saves;
+using MegaCrit.Sts2.Core.Saves.Managers;
+using STS2AIAgent.Localization;
+
+namespace STS2AIAgent.Multiplayer;
+
+/// <summary>
+/// Game-side half of the co-op save precheck. It only reads: it opens the current profile's
+/// multiplayer run save and hands the text to <see cref="CoopSavePrecheckPolicy"/>. It never
+/// writes, renames or loads the save, so it can never trigger the destructive
+/// <c>RenameBrokenMultiplayerRunSave</c> the check exists to avoid.
+/// </summary>
+internal static class CoopSaveProbe
+{
+    /// <summary>
+    /// Reads <c>players[].net_id</c> out of the multiplayer run save. False (with an empty id list)
+    /// means the ids could not be read - no profile, no save, an unreadable file, or a file without
+    /// player ids - and every consumer treats that as "no evidence", never as a mismatch.
+    /// </summary>
+    public static bool TryReadMultiplayerSaveNetIds(out IReadOnlyList<ulong> netIds, out string? error)
+    {
+        netIds = Array.Empty<ulong>();
+
+        try
+        {
+            var saveManager = SaveManager.Instance;
+            if (!saveManager.IsProfileInitialized)
+            {
+                error = "save_profile_not_initialized";
+                return false;
+            }
+
+            // RunSaveManager.multiplayerRunSaveFileName is a public const ("current_run_mp.save"),
+            // verified against the sts2 assembly, so read it instead of a literal: a rename in a game
+            // patch would otherwise make this probe quietly read the wrong file and fail open.
+            var relativePath = Path.Combine(UserDataPathProvider.SavesDir, RunSaveManager.multiplayerRunSaveFileName);
+            var scopedPath = saveManager.GetProfileScopedPath(relativePath);
+            if (!Godot.FileAccess.FileExists(scopedPath))
+            {
+                error = "multiplayer_save_missing";
+                return false;
+            }
+
+            // Same Godot user:// filesystem SaveManager writes through: reopening the file with
+            // System.IO can fail while the engine still owns it even though Godot reads it fine.
+            using var file = Godot.FileAccess.Open(scopedPath, Godot.FileAccess.ModeFlags.Read);
+            if (file is null)
+            {
+                error = "multiplayer_save_read_failed:Godot:" + Godot.FileAccess.GetOpenError();
+                return false;
+            }
+
+            var ids = CoopSavePrecheckPolicy.ReadPlayerNetIds(file.GetAsText());
+            if (ids.Count == 0)
+            {
+                error = "multiplayer_save_no_player_ids";
+                return false;
+            }
+
+            netIds = ids;
+            error = null;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            netIds = Array.Empty<ulong>();
+            error = "multiplayer_save_read_failed:" + ex.GetType().Name;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// The local player id the game will canonicalize the save against. Copied from the load button
+    /// itself (<c>NMultiplayerSubmenu.StartLoad</c>): it picks <c>PlatformType.None</c> whenever the
+    /// <c>-fastmp</c> argument is present, and this flow always injects that argument
+    /// (<c>EnableFastMpENetHost</c>) before pressing the button - so the offline id is what the save
+    /// is checked against even on a Steam-initialized host, where
+    /// <c>PlatformUtil.PrimaryPlatform</c> would report the Steam id instead.
+    /// </summary>
+    public static ulong ResolveLoadLocalPlayerId()
+    {
+        return PlatformUtil.GetLocalPlayerId(PlatformType.None);
+    }
+
+    /// <summary>
+    /// Companion id exactly as the launcher computes it, or the launcher's own message. Resolving it
+    /// here rather than in the callers keeps <c>CommandLineHelper</c> out of the HTTP handler.
+    /// </summary>
+    public static bool TryResolveCompanionClientId(out ulong companionClientId, out string? error)
+    {
+        try
+        {
+            companionClientId = CoopLaunchPolicy.ResolveCompanionClientId(CommandLineHelper.GetValue("clientId"));
+            error = null;
+            return true;
+        }
+        catch (InvalidOperationException ex)
+        {
+            companionClientId = 0;
+            error = Loc.T("无法计算队友启动参数：{0}", ex.Message);
+            return false;
+        }
+    }
+}

--- a/STS2AIAgent/Multiplayer/DualInstanceCoordinator.cs
+++ b/STS2AIAgent/Multiplayer/DualInstanceCoordinator.cs
@@ -64,6 +64,28 @@ internal static class DualInstanceCoordinator
             return (false, Loc.T("请先回到主菜单，再继续联机对局。"));
         }
 
+        // Backstop for callers that do not go through the HTTP executor: the game renames the
+        // multiplayer save to *.VAL.corrupt when the save does not contain the local player id, so
+        // both ids have to be checked before EnableFastMpENetHost/StartLocalLoadAsync can fire.
+        CoopSaveProbe.TryReadMultiplayerSaveNetIds(out var saveNetIds, out _);
+        var localPlayerId = CoopSaveProbe.ResolveLoadLocalPlayerId();
+        var hostMismatch = CoopSavePrecheckPolicy.DescribeHostMismatch(saveNetIds, localPlayerId);
+        if (hostMismatch != null)
+        {
+            return (false, hostMismatch);
+        }
+
+        if (!CoopSaveProbe.TryResolveCompanionClientId(out var companionClientId, out var companionIdError))
+        {
+            return (false, companionIdError!);
+        }
+
+        var companionMismatch = CoopSavePrecheckPolicy.DescribeCompanionMismatch(saveNetIds, companionClientId);
+        if (companionMismatch != null)
+        {
+            return (false, companionMismatch);
+        }
+
         try
         {
             EnableFastMpENetHost();

--- a/docs/api.md
+++ b/docs/api.md
@@ -62,6 +62,8 @@
 | `companion_not_ready` | 409 | 队友实例尚未就绪，无法响应控制 | 是 |
 | `invite_failed` | 409 | 邀请 AI 队友失败（主菜单状态或配置不满足） | 是 |
 | `continue_failed` | 409 | 读档开房流程启动后失败（读档界面没打开，或本地直连端口 33771 仍被上一局占用，重启游戏后可重试）；前置条件不满足（不在主菜单、没有联机存档、模型未验证）仍返回 `invalid_action` | 是 |
+| `invalid_action`（`continue_ai_teammate` 的 NetId 前置检查） | 409 | 读档**之前**的只读比对不通过：本机 NetId 不在联机存档 `players[].net_id` 里（游戏会拒绝读档，并把这局存档改名成 `*.VAL.corrupt` 挪走且不还原），或本次要拉起的 AI 队友 NetId 不在存档里（加入会被 `NotInSaveGame` 拒绝）。详情带 `save_player_net_ids`，以及 `local_player_id` 或 `companion_client_id` | 否 |
+| `invalid_action`（`run_console_command` 的命令抛异常） | 409 | 命令被游戏接受后实现抛异常（例如 `bestiary` 会 `NullReferenceException`）。消息为 `Console command failed: <异常类型>: <异常消息>`，详情带 `command` | 否 |
 | `collection_not_found` | 404 | `GET /data/{collection}` 的集合名不存在 | 否 |
 | `export_error` | 500 | 游戏元数据导出失败 | 是 |
 | `origin_not_allowed` | 403 | 原生 MCP 请求的 `Origin` 不受信任 | 否 |
@@ -78,6 +80,7 @@
 | `MULTIPLAYER_LOAD` | 多人读档界面（`continue_ai_teammate` 读入联机存档后、各玩家 `embark` 之前） |
 | `BUNDLE_SELECTION` | 开局卡包选择界面（用 `choose_bundle` / `confirm_bundle`） |
 | `CAPSTONE_SELECTION` | Capstone 选项界面（用 `choose_capstone_option`） |
+| `PAUSE_MENU` | 暂停菜单叠加层（人工按下暂停；agent 在此期间没有可用动作，也拿不到 capstone 选项） |
 | `MAP` | 地图界面 |
 | `COMBAT` | 战斗中 |
 | `EVENT` | 事件交互 |
@@ -100,6 +103,8 @@
 | `RELIC_INSPECT` | 遗物查看浮层（用 `close_cards_view` 关闭） |
 | `FEEDBACK` | 反馈提交页；不提供关闭动作，仅用于诊断 |
 | `UNKNOWN` | 无法识别的界面 |
+
+暂停菜单是人按下暂停后出现的叠加层（游戏用同一个 `NCapstoneSubmenuStack` 容器承载它，靠 `Type == PauseMenu` 区分）。暂停期间 agent 没有可用动作：`available_actions` 与 `/actions/available` 都为空，`capstone` 也不会出现。
 
 ## Action Status
 
@@ -1084,7 +1089,7 @@ compact 里的位置与 `/state` 不同，但同名同源、同为新增键；`/
 - `dismiss_modal` — 关闭阻塞弹窗
 - `return_to_main_menu` — 返回主菜单
 - `invite_ai_teammate` — 邀请 AI 队友
-- `continue_ai_teammate` — 继续上次的联机存档并重新拉起 AI 队友（仅主机主菜单且存在联机存档时出现在 `available_actions`；读档流程失败返回 `continue_failed`）
+- `continue_ai_teammate` — 继续上次的联机存档并重新拉起 AI 队友（仅主机主菜单且存在联机存档时出现在 `available_actions`；读档流程失败返回 `continue_failed`）。读档前会只读比对存档 `players[].net_id` 与本机 NetId（离线／`-fastmp` 主机即启动参数 `--clientId`，未传为 1）和队友 NetId（主机 id + 1）：任一不匹配返回**不可重试**的 `invalid_action`，以免触发游戏把该存档改名成 `*.VAL.corrupt` 的破坏性读档。
 <!-- END ACTION CONTRACT -->
 
 ### 请求体

--- a/docs/live-validation-checklist.md
+++ b/docs/live-validation-checklist.md
@@ -51,7 +51,8 @@ before and after).
 
 ### Found in this session
 
-Two things only a live game shows, both still open:
+Two things only a live game shows. Both were fixed and re-verified in the same session (issues #88 and
+#89):
 
 - **The pause menu is reported as an open `capstone` and offered as `choose_capstone_option`.** Opening the
   pause menu in a fight (top-bar button, and also via Escape) leaves `/state.screen` at `COMBAT`, fills
@@ -66,6 +67,37 @@ Two things only a live game shows, both still open:
   `BestiaryConsoleCmd.Process` throws a `NullReferenceException`; the mod surfaces it as an unhandled server
   error with `details: null`. It is a debug-only path (and the game labels the command WIP), but a 500 with
   no context is not an honest envelope for a console command that was accepted and then threw.
+
+### Fixes verified in the same session
+
+All three were re-run against the patched build on the same isolated instance.
+
+- **The pause menu is its own screen and stops being a decision screen.** The container tells its overlays
+  apart by its own `Type` (`CapstoneSubmenuType` is `None` / `Settings` / `Compendium` / `Feedback` /
+  `PauseMenu` — there is no boss-reward option screen in this build), and `GetCapstoneButtons` now excludes
+  `PauseMenu`. With the pause menu open, `/state` reports `screen = PAUSE_MENU`, `available_actions = []`,
+  `/actions/available` answers with an empty list and `capstone` is null, `choose_capstone_option` is 409
+  `invalid_action`, and Escape returns the run to the screen underneath. The teammate's own bootstrap logged
+  `Companion bootstrap PAUSE_MENU|-|`, so the companion sees the same picture. `CAPSTONE_SELECTION` keeps its
+  switch arm for the settings / compendium / feedback overlays.
+- **`continue_ai_teammate` refuses before the game can damage the save.** The action reads `players[].net_id`
+  out of the co-op save and compares it against this host's NetId (the `--clientId` launch argument, 1 when
+  omitted) and against the NetId the teammate would be launched with (host + 1), both **before** the load.
+  Three live runs:
+  - Ids matching (`1,2`, host started with `--clientId 1`): `continue_ai_teammate` returns 200 `completed` on
+    `MULTIPLAYER_LOAD`, the launcher starts the second instance (two game processes), and the log shows the
+    companion handshaking as NetId 2 and receiving `ClientLoadJoinResponseMessage` — the rejoin that used to
+    fail with `NotInSaveGame`.
+  - Host id missing (host `--clientId 2026091099`, save `1,2`): 409 `invalid_action`, `retryable: false`, with
+    `save_player_net_ids: [1, 2]` and `local_player_id: 2026091099` in the details, and a message that names
+    both ids, the consequence and the way out. The save's hash is **unchanged** afterwards, no
+    `*.VAL.corrupt` appears, and no second process is started — the destructive load never runs.
+  - Teammate id missing (host `--clientId 2`, save `1,2`, so the teammate would be 3): 409 `invalid_action`
+    with `companion_client_id: 3`, same unchanged save and single-process evidence.
+- **A throwing console command answers honestly.** In a run, `run_console_command bestiary` is now 409
+  `invalid_action` carrying `Console command failed: NullReferenceException: Object reference not set to an
+  instance of an object.` and `command: bestiary` in the details — where it used to be a bare 500
+  `internal_error` with `details: null`. The run is left untouched (`COMBAT`, same action list).
 
 ### Environment note for isolated runs
 


### PR DESCRIPTION
## 这是什么

补上 #88 与 #89，两处都在隔离实例上实机复验过。基于 `main`（`dev` 已落后 main 154 个提交，近期 PR 也都进 main）。

## #88 暂停菜单不再冒充 capstone

根因是游戏侧事实：承载叠加菜单的容器 `NCapstoneSubmenuStack` 靠自己的 `Type` 区分叠加层，而 `CapstoneSubmenuType` 只有 `None / Settings / Compendium / Feedback / PauseMenu`——**这个版本里已经没有「Boss 战后 capstone 选项屏」**，容器现在只挂菜单。原来只按容器类型匹配，于是暂停菜单被当成 capstone。

- `ResolveNonModalScreen` 在战斗与可见牌格分支**之前**把暂停菜单判成 `PAUSE_MENU`；
- `GetCapstoneButtons` 排除 `PauseMenu`（那份选项里包含「放弃」）；
- `available_actions` 与 `/actions/available` 在暂停期间都返回空——游戏是人按停的，agent 无事可做；
- `CAPSTONE_SELECTION` 的 switch 分支保留给设置/图鉴/反馈叠加层。

## #89 读档前先验 NetId，别让游戏把存档改名吃掉

游戏在 `RunManager.CanonicalizeSave` 里校验存档 `players[].net_id` 是否含本机 player id，失败即 `RenameBrokenMultiplayerRunSave` 把 `current_run_mp.save` 与 `.backup` **改名成 `*.VAL.corrupt` 且不还原**；而接口原本一律报「端口 33771 被占」。

- 新增 `CoopSavePrecheckPolicy`（纯逻辑，可离线单测）与 `CoopSaveProbe`（只读存档，绝不写、绝不改名、不调用游戏的读档方法）；
- `continue_ai_teammate` 在读档**之前**比对「本机 NetId」（离线主机即 `--clientId`，未传为 1）与「队友 NetId」（主机 + 1），不匹配返回**不可重试**的 409 `invalid_action`，带 `save_player_net_ids` 与 `local_player_id`／`companion_client_id`；
- `DualInstanceCoordinator` 同样的守卫作为非 HTTP 调用的兜底；
- `StartLocalLoadAsync` 的失败文案不再断言成因，改为报告可观测的弹窗类型，端口只作为常见原因。

## 顺带：抛异常的调试命令不再是裸 500

`run_console_command` 的命令实现抛异常（`bestiary` 在局内会 `NullReferenceException`）原本变成 500 `internal_error`、`details` 为 null；现在是 409 `invalid_action`，消息保留异常类型与原文，详情带 `command`。

## 实机复验（同一隔离实例，修复后的构建）

| 场景 | 结果 |
| --- | --- |
| Ids 匹配（host `--clientId 1`，存档 `1,2`） | `continue_ai_teammate` **200 completed** 于 `MULTIPLAYER_LOAD`，第二个实例起来，日志见 NetId 2 握手并收到 `ClientLoadJoinResponseMessage`（原来是 `NotInSaveGame`） |
| 主机 id 不在存档（host `2026091099`） | **409 `invalid_action`**，`retryable:false`，`save_player_net_ids:[1,2]` + `local_player_id:2026091099`；存档哈希**未变**、无 `*.VAL.corrupt`、进程数 1 |
| 队友 id 不在存档（host `2` → 队友 3） | **409 `invalid_action`** 带 `companion_client_id:3`；存档未变、无 `*.VAL.corrupt`、进程数 1 |
| 暂停菜单 | `/state` 报 **`PAUSE_MENU`**、`available_actions=[]`、`capstone=null`；`/actions/available` 为空；`choose_capstone_option` **409**；ESC 回到原屏幕；队友 bootstrap 日志同为 `PAUSE_MENU|-|` |
| 局内 `bestiary` | **409 `invalid_action`**：`Console command failed: NullReferenceException: ...`，详情带 `command`（原为 500 `internal_error`） |

## 检查

- `dotnet run --project STS2AIAgent.Tests/STS2AIAgent.Tests.csproj -c Release` — **364 PASS / 0 FAIL**（比之前多 7 条：6 条 NetId 前置检查 + 1 条暂停菜单契约）
- `cd mcp_server; uv run --locked python -m unittest discover -s tests` — **165 OK**
- `python scripts/check_verification_gates.py` — 7 道 gate 全绿
- `powershell -ExecutionPolicy Bypass -File scripts/preflight-release.ps1` — exit 0
- 玩家 Steam 存档哈希与本轮开始前逐文件一致；未花任何真实模型额度（模型调用走本地桩）

Fixes #88. Fixes #89.

## Summary by Sourcery

Protect co-op saves during continuation and accurately expose paused game state and command failures through the agent API.

Bug Fixes:
- Prevent pause overlays from being reported as capstone decision screens and suppress agent actions while the game is paused.
- Validate multiplayer save player NetIds before loading to prevent incompatible saves from being renamed or damaged.
- Return actionable 409 invalid_action responses when console command implementations throw exceptions.

Enhancements:
- Improve multiplayer load failure messages by reporting the observed modal instead of assuming a port conflict.
- Add read-only co-op save probing and fail-open NetId validation for both HTTP and coordinator load paths.

Documentation:
- Document the PAUSE_MENU state, its lack of available actions, and the pre-load NetId validation behavior and error responses.

Tests:
- Add offline coverage for save NetId parsing, mismatch handling, fail-open behavior, and pause-menu screen/action contracts.