### PR TITLE
fix: 暂停菜单判定收紧到「栈顶就是暂停菜单」，不再牵连容器里的图鉴/设置页

### DIFF
--- a/STS2AIAgent.Tests/ScreenResolutionContractTests.cs
+++ b/STS2AIAgent.Tests/ScreenResolutionContractTests.cs
@@ -149,10 +149,11 @@ internal static class ScreenResolutionContractTests
         var resolveBody = Flat(AgentSourceFixture.MethodBody(rawState, "ResolveNonModalScreen"));
 
         // The pause menu rides in the same NCapstoneSubmenuStack as the Settings/Compendium/Feedback
-        // overlays and is told apart by Type, so it must claim PAUSE_MENU before the combat branch and
-        // the visible card grid can name a paused game COMBAT or CARD_SELECTION.
-        const string pauseGuard =
-            "if(currentScreenisNCapstoneSubmenuStack{Type:CapstoneSubmenuType.PauseMenu})";
+        // overlays, and the container keeps its PauseMenu Type while a deeper page (settings, compendium,
+        // card library) is pushed on top. The guard therefore has to ask for the pause menu itself, and it
+        // must claim PAUSE_MENU before the combat branch and the visible card grid can name a paused game
+        // COMBAT or CARD_SELECTION.
+        const string pauseGuard = "if(IsPauseMenuOverlay(currentScreen))";
         var pauseIndex = resolveBody.IndexOf(pauseGuard, StringComparison.Ordinal);
         var combatIndex = resolveBody.IndexOf("FindActiveCombatRoom(currentScreen)", StringComparison.Ordinal);
         var visibleGridIndex = resolveBody.IndexOf(
@@ -175,9 +176,17 @@ internal static class ScreenResolutionContractTests
             rawState,
             "public static IReadOnlyList<NButton> GetCapstoneButtons("));
         Assert.Contains(
-            "capstoneScreen.Type==CapstoneSubmenuType.PauseMenu",
+            "IsPauseMenuOverlay(capstoneScreen)",
             capstoneButtons,
             StringComparison.Ordinal);
+
+        // The overlay test itself has to prove the page on top of the stack, or a card library browsed
+        // from the pause menu would report a paused game the agent cannot act in.
+        var overlay = Flat(AgentSourceFixture.DeclarationBody(
+            rawState,
+            "public static bool IsPauseMenuOverlay("));
+        Assert.Contains("CapstoneSubmenuType.PauseMenu", overlay, StringComparison.Ordinal);
+        Assert.Contains("Stack?.Peek()isNPauseMenu", overlay, StringComparison.Ordinal);
 
         var names = Flat(AgentSourceFixture.MethodBody(rawState, "BuildAvailableActionNames"));
         var descriptors = Flat(AgentSourceFixture.MethodBody(rawState, "BuildAvailableActionsPayload"));

--- a/STS2AIAgent/Game/GameStateService.cs
+++ b/STS2AIAgent/Game/GameStateService.cs
@@ -32,6 +32,7 @@ using MegaCrit.Sts2.Core.Nodes.Debug.Multiplayer;
 using MegaCrit.Sts2.Core.Nodes.Events;
 using MegaCrit.Sts2.Core.Nodes.Events.Custom;
 using MegaCrit.Sts2.Core.Nodes.Events.Custom.CrystalSphere;
+using MegaCrit.Sts2.Core.Nodes.Screens.PauseMenu;
 using MegaCrit.Sts2.Core.Nodes.Ftue;
 using MegaCrit.Sts2.Core.Nodes.GodotExtensions;
 using MegaCrit.Sts2.Core.Nodes.Rewards;
@@ -254,7 +255,7 @@ internal static class GameStateService
 
         // The pause menu is a human overlay: nothing is actionable while it is up, so the descriptor
         // list stays empty instead of advertising the paused combat actions.
-        if (currentScreen is NCapstoneSubmenuStack { Type: CapstoneSubmenuType.PauseMenu })
+        if (IsPauseMenuOverlay(currentScreen))
         {
             return new AvailableActionsPayload
             {
@@ -1203,13 +1204,25 @@ internal static class GameStateService
         Log.Warn($"[STS2AIAgent] Crystal Sphere tool button state could not be synchronized: {reason}.");
     }
 
+    /// <summary>
+    /// True only while the shared capstone container is actually showing the in-game pause menu.
+    /// The container also hosts settings, the compendium and the card library, and it keeps its own
+    /// Type while one of those pages is pushed on top, so the container type alone would report
+    /// those pages as a paused game the agent cannot act in.
+    /// </summary>
+    public static bool IsPauseMenuOverlay(IScreenContext? currentScreen)
+    {
+        return currentScreen is NCapstoneSubmenuStack { Type: CapstoneSubmenuType.PauseMenu } pauseMenu
+            && pauseMenu.Stack?.Peek() is NPauseMenu;
+    }
+
     public static IReadOnlyList<NButton> GetCapstoneButtons(IScreenContext? currentScreen)
     {
         // Only the Settings/Compendium/Feedback overlays are capstone decision lists now; the pause
         // menu shares the container but its own buttons include "放弃" and "保存并退出", so it must
         // never read as a capstone option list.
         if (currentScreen is not NCapstoneSubmenuStack capstoneScreen ||
-            capstoneScreen.Type == CapstoneSubmenuType.PauseMenu)
+            IsPauseMenuOverlay(capstoneScreen))
         {
             return Array.Empty<NButton>();
         }
@@ -2619,7 +2632,7 @@ internal static class GameStateService
 
         // The human paused the game: combat actions are swallowed while paused and the overlay's own
         // buttons (including "放弃") are not agent decisions, so advertise nothing.
-        if (currentScreen is NCapstoneSubmenuStack { Type: CapstoneSubmenuType.PauseMenu })
+        if (IsPauseMenuOverlay(currentScreen))
         {
             return names.ToArray();
         }
@@ -6901,7 +6914,7 @@ internal static class GameStateService
         // in-game pause menu rides in it too. It has to claim PAUSE_MENU before the combat and
         // visible-grid branches below can name the paused scene COMBAT or CARD_SELECTION, which
         // would advertise a live action list over a game the human just paused.
-        if (currentScreen is NCapstoneSubmenuStack { Type: CapstoneSubmenuType.PauseMenu })
+        if (IsPauseMenuOverlay(currentScreen))
         {
             return "PAUSE_MENU";
         }


### PR DESCRIPTION
## 为什么还要再来一发

#88 的第一个修法（#91）按容器 `Type` 判定暂停菜单。但那个容器在**更深一层页面压在暂停菜单之上**时仍然保留着自己的 Type，于是从暂停菜单点进「百科大全」或「卡牌图鉴」后，`/state` 会说这是一个暂停中的游戏、动作列表为空——人明明在看牌，agent 却以为界面不可用；而且 `CARD_LIBRARY` 那条分支从这条路径上永远走不到。

现在判定改成「容器 Type 是 PauseMenu **且**它自己的栈顶就是暂停菜单页面」：

```csharp
public static bool IsPauseMenuOverlay(IScreenContext? currentScreen)
{
    return currentScreen is NCapstoneSubmenuStack { Type: CapstoneSubmenuType.PauseMenu } pauseMenu
        && pauseMenu.Stack?.Peek() is NPauseMenu;
}
```

四处守卫（`ResolveNonModalScreen`、`GetCapstoneButtons`、两条动作面）共用它，语义从「这是个暂停容器」收紧为「现在正显示暂停菜单」。容器里的其它页面回到 #88 之前的既有行为，不再被牵连。

## 实机验证（隔离实例，含本次编译的 Mod）

| 步骤 | 结果 |
| --- | --- |
| 战斗中 ESC | `/state` = **`PAUSE_MENU`**，`available_actions = []`，`capstone = null` |
| 暂停菜单里点「百科大全」 | 恢复为出货版本的行为（不再被误判成暂停） |
| 再点「卡牌总览」 | `close_cards_view` 仍可用，按键能逐级退回战斗 |
| ESC 往返 | `COMBAT ⇄ PAUSE_MENU` 正常切换，这局仍可继续游玩 |

## 检查

- `dotnet run --project STS2AIAgent.Tests/STS2AIAgent.Tests.csproj -c Release` — **364 PASS / 0 FAIL**（合同测试新增对 stack 判定的断言）
- `dotnet build STS2AIAgent/STS2AIAgent.csproj -c Release` — **0 警告**（上一版因为缺 `using ...PauseMenu;` 编译不过，`GameStateService.cs` 不在离线测试项目里所以单测查不出来，这次已修）
- `python scripts/check_verification_gates.py` — 7 道 gate 全绿
- `cd mcp_server; uv run --locked python -m unittest discover -s tests` — **165 OK**

## 附带发现（未在本次修，已开 issue）

从暂停菜单进入的「百科大全」与「卡牌图鉴」会被报成 `COMBAT` / `CARD_SELECTION`，并且 `choose_capstone_option` 会带着容器里那几十个 `Hitbox` 之类的按钮标签被广告出来。这是既有行为（出货版本同样如此），不是本次改动引入，细节见新开的 issue。

## Summary by Sourcery

Tighten pause-menu detection so nested pages opened from the pause menu retain their expected state and actions.

Bug Fixes:
- Restrict pause-menu detection to cases where the pause menu is the top page in the shared submenu stack, preventing settings, compendium, and card-library screens from being misreported as paused games.

Enhancements:
- Reuse the centralized pause-overlay check across screen resolution, action availability, and capstone-button handling.

Tests:
- Extend screen-resolution contract coverage to verify stack-top pause-menu detection and its use across all relevant guards.