### PR TITLE
fix(state): name the in-run menu pages and give them one way back (#93)

### DIFF
--- a/STS2AIAgent.Tests/ScreenResolutionContractTests.cs
+++ b/STS2AIAgent.Tests/ScreenResolutionContractTests.cs
@@ -143,64 +143,94 @@ internal static class ScreenResolutionContractTests
         Assert.Contains("return currentScreen is not NCardsViewScreen;", closed, StringComparison.Ordinal);
     }
 
-    public static void PauseMenuIsNotADecisionScreen()
+    public static void CapstoneContainerPagesAreNamedAndNotDecisionScreens()
     {
         var rawState = AgentSourceFixture.Read("STS2AIAgent/Game/GameStateService.cs");
         var resolveBody = Flat(AgentSourceFixture.MethodBody(rawState, "ResolveNonModalScreen"));
 
-        // The pause menu rides in the same NCapstoneSubmenuStack as the Settings/Compendium/Feedback
-        // overlays, and the container keeps its PauseMenu Type while a deeper page (settings, compendium,
-        // card library) is pushed on top. The guard therefore has to ask for the pause menu itself, and it
-        // must claim PAUSE_MENU before the combat branch and the visible card grid can name a paused game
-        // COMBAT or CARD_SELECTION.
-        const string pauseGuard = "if(IsPauseMenuOverlay(currentScreen))";
-        var pauseIndex = resolveBody.IndexOf(pauseGuard, StringComparison.Ordinal);
+        // The container keeps its own Type while a page is pushed on top of the one that opened it, so the
+        // page on its stack is what has to be named. Naming the container instead reported the run
+        // underneath (COMBAT while a person browses the card library), so the branch has to come first.
+        const string containerGuard = "if(currentScreenisNCapstoneSubmenuStackcontainer)";
+        var containerIndex = resolveBody.IndexOf(containerGuard, StringComparison.Ordinal);
         var combatIndex = resolveBody.IndexOf("FindActiveCombatRoom(currentScreen)", StringComparison.Ordinal);
         var visibleGridIndex = resolveBody.IndexOf(
             "GetVisibleGridCardHolders(rootNode).Count>0", StringComparison.Ordinal);
 
-        Assert.True(pauseIndex >= 0, "ResolveNonModalScreen must claim PAUSE_MENU for the pause overlay.");
+        Assert.True(containerIndex >= 0, "ResolveNonModalScreen must name the page the container shows.");
         Assert.True(combatIndex >= 0, "The combat branch must remain covered by this contract.");
         Assert.True(visibleGridIndex >= 0, "The visible card-grid fallback must remain covered by this contract.");
-        Assert.True(pauseIndex < combatIndex, "PAUSE_MENU must resolve before FindActiveCombatRoom can report COMBAT.");
-        Assert.True(pauseIndex < visibleGridIndex, "PAUSE_MENU must resolve before the visible grid can report CARD_SELECTION.");
-        Assert.Contains("return\"PAUSE_MENU\";", resolveBody[pauseIndex..combatIndex], StringComparison.Ordinal);
+        Assert.True(containerIndex < combatIndex, "The container page must resolve before FindActiveCombatRoom can report COMBAT.");
+        Assert.True(containerIndex < visibleGridIndex, "The container page must resolve before the visible grid can report CARD_SELECTION.");
+
+        // Every page the container shows gets its own name, and the ones a person reaches from the pause
+        // menu are the pages this test pins. Anything unknown stays on the historical CAPSTONE_SELECTION.
+        var pageSlice = resolveBody[containerIndex..combatIndex];
+        var containerPages = new[]
+        {
+            ("NPauseMenu", "PAUSE_MENU"),
+            ("NSettingsScreen", "SETTINGS"),
+            ("NCompendiumSubmenu", "COMPENDIUM"),
+            ("NCardLibrary", "CARD_LIBRARY"),
+            ("NRelicCollection", "RELIC_COLLECTION"),
+            ("NPotionLab", "POTION_LAB"),
+            ("NBestiary", "BESTIARY"),
+            ("NStatsScreen", "STATS"),
+            ("NRunHistory", "RUN_HISTORY"),
+        };
+        foreach (var (pageType, screenName) in containerPages)
+        {
+            Assert.Contains(pageType + "=>\"" + screenName + "\"", pageSlice, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("_=>\"CAPSTONE_SELECTION\"", pageSlice, StringComparison.Ordinal);
+        Assert.Contains("Stack?.Peek()", pageSlice, StringComparison.Ordinal);
         Assert.Contains(
             "NCapstoneSubmenuStack=>\"CAPSTONE_SELECTION\"",
             resolveBody,
             StringComparison.Ordinal);
 
-        // The pause menu is the one capstone-container type whose buttons are not a decision list, so
-        // the option getter drops it and both action lists stay empty while it is up.
+        // Every page in the container is a menu, so none of their buttons is a capstone option list.
         var capstoneButtons = Flat(AgentSourceFixture.DeclarationBody(
             rawState,
             "public static IReadOnlyList<NButton> GetCapstoneButtons("));
         Assert.Contains(
-            "IsPauseMenuOverlay(capstoneScreen)",
+            "IsKnownCapstoneContainerPage(capstoneScreen.Stack?.Peek())",
             capstoneButtons,
             StringComparison.Ordinal);
 
-        // The overlay test itself has to prove the page on top of the stack, or a card library browsed
-        // from the pause menu would report a paused game the agent cannot act in.
+        // The overlay test has to prove the page on top of the stack, or a page would be reported as a
+        // frozen run the agent cannot act in.
         var overlay = Flat(AgentSourceFixture.DeclarationBody(
             rawState,
-            "public static bool IsPauseMenuOverlay("));
-        Assert.Contains("CapstoneSubmenuType.PauseMenu", overlay, StringComparison.Ordinal);
-        Assert.Contains("Stack?.Peek()isNPauseMenu", overlay, StringComparison.Ordinal);
+            "public static bool IsCapstonePageOverlay("));
+        Assert.Contains("IsKnownCapstoneContainerPage(container.Stack?.Peek())", overlay, StringComparison.Ordinal);
+
+        var knownPages = Flat(AgentSourceFixture.DeclarationBody(
+            rawState,
+            "private static bool IsKnownCapstoneContainerPage("));
+        Assert.Contains("pageisNPauseMenu", knownPages, StringComparison.Ordinal);
+        // The predicate has to know every page the mapping names, or one of them would be reported as a
+        // frozen run whose own buttons read as capstone options.
+        foreach (var (pageType, _) in containerPages)
+        {
+            Assert.Contains(pageType, knownPages, StringComparison.Ordinal);
+        }
 
         var names = Flat(AgentSourceFixture.MethodBody(rawState, "BuildAvailableActionNames"));
         var descriptors = Flat(AgentSourceFixture.MethodBody(rawState, "BuildAvailableActionsPayload"));
-        Assert.Contains(pauseGuard, names, StringComparison.Ordinal);
-        Assert.Contains(pauseGuard, descriptors, StringComparison.Ordinal);
+        const string actionGuard = "if(IsCapstonePageOverlay(currentScreen))";
+        Assert.Contains(actionGuard, names, StringComparison.Ordinal);
+        Assert.Contains(actionGuard, descriptors, StringComparison.Ordinal);
 
-        // The pause branch returns ahead of the combat actions, so nothing is advertised while paused.
-        var pauseInNames = names.IndexOf(pauseGuard, StringComparison.Ordinal);
+        // The branch returns ahead of the combat actions, so nothing is advertised while a menu is up.
+        var guardInNames = names.IndexOf(actionGuard, StringComparison.Ordinal);
         var endTurnIndex = names.IndexOf(
             "if(CanEndTurn(currentScreen,combatState,requireButtonReady:false))",
             StringComparison.Ordinal);
         Assert.True(
-            endTurnIndex >= 0 && pauseInNames >= 0 && pauseInNames < endTurnIndex,
-            "The pause branch must return before the combat actions are advertised.");
+            endTurnIndex >= 0 && guardInNames >= 0 && guardInNames < endTurnIndex,
+            "The container-page branch must return before the combat actions are advertised.");
     }
 
     private static (string ScreenType, string ScreenName)[] SwitchMappings(string methodBody)
@@ -215,6 +245,77 @@ internal static class ScreenResolutionContractTests
         return Regex.Matches(slice, "([A-Za-z_][A-Za-z0-9_]*(?: or [A-Za-z_][A-Za-z0-9_]*)*)\\s*=>\\s*\"([A-Z_]+)\"")
             .Select(match => (ScreenType: match.Groups[1].Value, ScreenName: match.Groups[2].Value))
             .ToArray();
+    }
+
+    public static void CapstonePagesOfferOneBackStepAndNeverThePausePage()
+    {
+        var rawState = AgentSourceFixture.Read("STS2AIAgent/Game/GameStateService.cs");
+        var rawAction = AgentSourceFixture.Read("STS2AIAgent/Game/GameActionService.cs");
+
+        // The one action these pages have is backing out one level, and only from above the pause menu:
+        // the pause page is where a person resumes the run, so it is never the agent's to close.
+        var closable = Flat(AgentSourceFixture.DeclarationBody(
+            rawState,
+            "public static NSubmenu? GetClosableCapstonePage("));
+        Assert.Contains("currentScreenisnotNCapstoneSubmenuStackcontainer", closable, StringComparison.Ordinal);
+        Assert.Contains("IsKnownCapstoneContainerPage(page)", closable, StringComparison.Ordinal);
+        Assert.Contains("pageisNPauseMenu", closable, StringComparison.Ordinal);
+        Assert.Contains("returnpage;", closable, StringComparison.Ordinal);
+
+        // The container is not an NSubmenu, so the widened check has to run before that branch.
+        var canClose = Flat(AgentSourceFixture.DeclarationBody(
+            rawState,
+            "public static bool CanCloseMainMenuSubmenu("));
+        var closableIndex = canClose.IndexOf("GetClosableCapstonePage(currentScreen)!=null", StringComparison.Ordinal);
+        var submenuIndex = canClose.IndexOf("currentScreenisnotNSubmenusubmenu", StringComparison.Ordinal);
+        Assert.True(closableIndex >= 0, "close_main_menu_submenu must accept a capstone container page.");
+        Assert.True(submenuIndex >= 0, "The main-menu submenu branch must stay covered by this contract.");
+        Assert.True(closableIndex < submenuIndex, "The container branch has to run before the NSubmenu branch.");
+
+        // The executor pops the container's stack -- the call the game wires to every page's BackButton.
+        var close = Flat(AgentSourceFixture.DeclarationBody(
+            rawAction,
+            "private static async Task<ActionResponsePayload> ExecuteCloseMainMenuSubmenuAsync("));
+        Assert.Contains("currentScreenisNCapstoneSubmenuStackcapstonePageContainer", close, StringComparison.Ordinal);
+        Assert.Contains("GameStateService.GetClosableCapstonePage(capstonePageContainer)", close, StringComparison.Ordinal);
+        Assert.Contains("capstoneStack.Pop();", close, StringComparison.Ordinal);
+        Assert.Contains(
+            "WaitForCapstonePageCloseAsync(capstoneStack,capstonePage,TimeSpan.FromSeconds(10))",
+            close,
+            StringComparison.Ordinal);
+
+        // Both surfaces have to advertise it from inside the guard that suppresses the run actions, or the
+        // action would only be reachable by a client that ignores available_actions.
+        var names = Flat(AgentSourceFixture.MethodBody(rawState, "BuildAvailableActionNames"));
+        var descriptors = Flat(AgentSourceFixture.MethodBody(rawState, "BuildAvailableActionsPayload"));
+        Assert.Contains(
+            "if(CanCloseMainMenuSubmenu(currentScreen)){names.Add(\"close_main_menu_submenu\");}",
+            names,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "if(CanCloseMainMenuSubmenu(currentScreen)){descriptors.Add(newActionDescriptor{name=\"close_main_menu_submenu\","
+            + "requires_target=false,requires_index=false});}",
+            descriptors,
+            StringComparison.Ordinal);
+
+        // "Closed" is the stack no longer holding that page: the container screen itself never changes, so
+        // the main-menu waiter (which asks whether the screen changed) cannot be reused here.
+        var closed = Flat(AgentSourceFixture.DeclarationBody(
+            rawAction,
+            "private static bool IsCapstonePageClosed("));
+        Assert.Contains("!ReferenceEquals(stack.Peek(),page)", closed, StringComparison.Ordinal);
+        Assert.False(
+            closed.Contains("SubmenusOpen", StringComparison.Ordinal),
+            "The container stays open while a page below it is still there, so SubmenusOpen cannot tell a pop apart.");
+
+        // save_and_quit used to execute from a page whose surface never advertised it.
+        var canSave = Flat(AgentSourceFixture.DeclarationBody(
+            rawState,
+            "public static bool CanSaveAndQuit("));
+        var guardIndex = canSave.IndexOf("if(IsCapstonePageOverlay(currentScreen)){returnfalse;}", StringComparison.Ordinal);
+        var permissiveIndex = canSave.IndexOf("returncurrentScreenisnot(NMainMenuor", StringComparison.Ordinal);
+        Assert.True(guardIndex >= 0, "save_and_quit must refuse while a capstone page is up.");
+        Assert.True(permissiveIndex > guardIndex, "The capstone guard has to run before the permissive return.");
     }
 
     private static string Normalize(string source)

--- a/STS2AIAgent.Tests/TestRunner.cs
+++ b/STS2AIAgent.Tests/TestRunner.cs
@@ -414,7 +414,8 @@ internal static class TestRunner
         yield return ("ScreenResolution.FakeMerchant", () => Task.Run(ScreenResolutionContractTests.FakeMerchantOpensThroughTheSharedButton));
         yield return ("ScreenResolution.PatchNotes", () => Task.Run(ScreenResolutionContractTests.PatchNotesClosePathIsWidenedWithoutWeakeningSubmenus));
         yield return ("ScreenResolution.InspectOverlays", () => Task.Run(ScreenResolutionContractTests.InspectOverlaysCloseThroughTheirOwnClose));
-        yield return ("ScreenResolution.PauseMenu", () => Task.Run(ScreenResolutionContractTests.PauseMenuIsNotADecisionScreen));
+        yield return ("ScreenResolution.CapstoneContainerPages", () => Task.Run(ScreenResolutionContractTests.CapstoneContainerPagesAreNamedAndNotDecisionScreens));
+        yield return ("ScreenResolution.CapstonePagesOneBackStep", () => Task.Run(ScreenResolutionContractTests.CapstonePagesOfferOneBackStepAndNeverThePausePage));
         yield return ("TimelineIndex.OneSpace", () => Task.Run(TimelineIndexContractTests.ExecutorIndexesTheSameSlotListTheStateExposes));
         yield return ("TimelineIndex.NonActionableRejected", () => Task.Run(TimelineIndexContractTests.NonActionableSlotsAreRejectedExplicitly));
         yield return ("TimelineIndex.DescriptorFlags", () => Task.Run(TimelineIndexContractTests.CrystalDescriptorsCarryTheirRequirements));

--- a/STS2AIAgent/Game/GameActionService.cs
+++ b/STS2AIAgent/Game/GameActionService.cs
@@ -630,6 +630,22 @@ internal static class GameActionService
 
             stable = await WaitForPatchNotesCloseAsync(patchNotes, TimeSpan.FromSeconds(10));
         }
+        else if (currentScreen is NCapstoneSubmenuStack capstonePageContainer &&
+            GameStateService.GetClosableCapstonePage(capstonePageContainer) is { } capstonePage)
+        {
+            // The page is left the way its own BackButton leaves it: the game wires every submenu's back
+            // button to Stack.Pop(), which closes this page and shows the page below it again. Popping a
+            // page above the pause menu therefore cannot resume the run -- the pause menu is still on top.
+            var capstoneStack = capstonePageContainer.Stack
+                ?? throw new ApiException(503, "state_unavailable", "Capstone submenu stack is unavailable.", new
+                {
+                    action = "close_main_menu_submenu",
+                    screen
+                }, retryable: true);
+
+            capstoneStack.Pop();
+            stable = await WaitForCapstonePageCloseAsync(capstoneStack, capstonePage, TimeSpan.FromSeconds(10));
+        }
         else
         {
             if (currentScreen is not NSubmenu submenu)
@@ -6061,6 +6077,35 @@ internal static class GameActionService
 
         var finalScreen = ActiveScreenContext.Instance.GetCurrentScreen();
         return !ReferenceEquals(finalScreen, submenu) || !submenuStack.SubmenusOpen;
+    }
+
+    /// <summary>
+    /// A capstone container page is closed when the container's own stack no longer holds it. The screen
+    /// context never changes here: the container stays up with the page below it (the pause menu) and only
+    /// closes itself once the stack runs empty, so waiting on the screen would report settled too early.
+    /// </summary>
+    private static bool IsCapstonePageClosed(NSubmenuStack stack, NSubmenu page)
+    {
+        return !GodotObject.IsInstanceValid(page) || !ReferenceEquals(stack.Peek(), page);
+    }
+
+    private static async Task<bool> WaitForCapstonePageCloseAsync(
+        NSubmenuStack stack,
+        NSubmenu page,
+        TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            await WaitForNextFrameAsync();
+
+            if (IsCapstonePageClosed(stack, page))
+            {
+                return true;
+            }
+        }
+
+        return IsCapstonePageClosed(stack, page);
     }
 
     /// <summary>

--- a/STS2AIAgent/Game/GameStateService.cs
+++ b/STS2AIAgent/Game/GameStateService.cs
@@ -46,8 +46,14 @@ using MegaCrit.Sts2.Core.Nodes.Screens.GameOverScreen;
 using MegaCrit.Sts2.Core.Nodes.Screens.InspectScreens;
 using MegaCrit.Sts2.Core.Nodes.Screens.MainMenu;
 using MegaCrit.Sts2.Core.Nodes.Screens.Map;
+using MegaCrit.Sts2.Core.Nodes.Screens.Bestiary;
+using MegaCrit.Sts2.Core.Nodes.Screens.PotionLab;
+using MegaCrit.Sts2.Core.Nodes.Screens.RelicCollection;
+using MegaCrit.Sts2.Core.Nodes.Screens.RunHistoryScreen;
 using MegaCrit.Sts2.Core.Nodes.Screens.ScreenContext;
+using MegaCrit.Sts2.Core.Nodes.Screens.Settings;
 using MegaCrit.Sts2.Core.Nodes.Screens.Shops;
+using MegaCrit.Sts2.Core.Nodes.Screens.StatsScreen;
 using MegaCrit.Sts2.Core.Nodes.Screens.Timeline;
 using MegaCrit.Sts2.Core.Nodes.Screens.Timeline.UnlockScreens;
 using MegaCrit.Sts2.Core.Nodes.Screens.TreasureRoomRelic;
@@ -253,10 +259,22 @@ internal static class GameStateService
             };
         }
 
-        // The pause menu is a human overlay: nothing is actionable while it is up, so the descriptor
-        // list stays empty instead of advertising the paused combat actions.
-        if (IsPauseMenuOverlay(currentScreen))
+        // The container's pages are human menus over a frozen run: nothing in the run is actionable
+        // while one is up, so the descriptor list does not advertise the actions the pause swallows.
+        // Backing out one level is the page's own BackButton, and the only action an agent may take
+        // here; the pause menu itself has none, because resuming is the person's call, not the agent's.
+        if (IsCapstonePageOverlay(currentScreen))
         {
+            if (CanCloseMainMenuSubmenu(currentScreen))
+            {
+                descriptors.Add(new ActionDescriptor
+                {
+                    name = "close_main_menu_submenu",
+                    requires_target = false,
+                    requires_index = false
+                });
+            }
+
             return new AvailableActionsPayload
             {
                 screen = ResolveScreen(currentScreen),
@@ -1205,24 +1223,69 @@ internal static class GameStateService
     }
 
     /// <summary>
-    /// True only while the shared capstone container is actually showing the in-game pause menu.
-    /// The container also hosts settings, the compendium and the card library, and it keeps its own
-    /// Type while one of those pages is pushed on top, so the container type alone would report
-    /// those pages as a paused game the agent cannot act in.
+    /// True while the shared capstone container is showing one of the in-run human menus it exists
+    /// for (pause, settings, compendium, card library and their siblings).
     /// </summary>
-    public static bool IsPauseMenuOverlay(IScreenContext? currentScreen)
+    public static bool IsCapstonePageOverlay(IScreenContext? currentScreen)
     {
-        return currentScreen is NCapstoneSubmenuStack { Type: CapstoneSubmenuType.PauseMenu } pauseMenu
-            && pauseMenu.Stack?.Peek() is NPauseMenu;
+        return currentScreen is NCapstoneSubmenuStack container
+            && IsKnownCapstoneContainerPage(container.Stack?.Peek());
+    }
+
+    /// <summary>
+    /// The pages this build pushes into the container. Every one of them is a menu the player opened
+    /// (the container is only ever shown by the top-bar pause button), so none is a decision list and
+    /// the run underneath is frozen while one is up.
+    /// </summary>
+    private static bool IsKnownCapstoneContainerPage(NSubmenu? page)
+    {
+        return page is NPauseMenu
+            or NSettingsScreen
+            or NCompendiumSubmenu
+            or NCardLibrary
+            or NRelicCollection
+            or NPotionLab
+            or NBestiary
+            or NStatsScreen
+            or NRunHistory;
+    }
+
+    /// <summary>
+    /// The page on the container's stack that <c>close_main_menu_submenu</c> may pop, or null when
+    /// there is nothing an agent should close from here. Every page in the container is left by its own
+    /// BackButton, which the game wires to <c>Stack.Pop()</c>, so backing out one level is exactly what
+    /// the person sitting there would do. The pause menu itself is never one of them: that page is where
+    /// a person resumes the run, and the agent does not unpause a game on their behalf.
+    /// </summary>
+    public static NSubmenu? GetClosableCapstonePage(IScreenContext? currentScreen)
+    {
+        if (currentScreen is not NCapstoneSubmenuStack container)
+        {
+            return null;
+        }
+
+        var page = container.Stack?.Peek();
+        if (page == null || !IsKnownCapstoneContainerPage(page) || page is NPauseMenu || !page.IsVisibleInTree())
+        {
+            return null;
+        }
+
+        return page;
     }
 
     public static IReadOnlyList<NButton> GetCapstoneButtons(IScreenContext? currentScreen)
     {
-        // Only the Settings/Compendium/Feedback overlays are capstone decision lists now; the pause
-        // menu shares the container but its own buttons include "放弃" and "保存并退出", so it must
-        // never read as a capstone option list.
-        if (currentScreen is not NCapstoneSubmenuStack capstoneScreen ||
-            IsPauseMenuOverlay(capstoneScreen))
+        if (currentScreen is not NCapstoneSubmenuStack capstoneScreen)
+        {
+            return Array.Empty<NButton>();
+        }
+
+        // The container's pages are menus, not option lists: their buttons are navigation tiles,
+        // filter tickboxes and the pause menu's own "放弃", none of which is an agent decision. This
+        // build has no boss-reward option screen (CapstoneSubmenuType carries no such value), so the
+        // descendant scan only runs for a page this build does not know, which is what a real option
+        // screen would need if the game grows one back.
+        if (IsKnownCapstoneContainerPage(capstoneScreen.Stack?.Peek()))
         {
             return Array.Empty<NButton>();
         }
@@ -1433,6 +1496,14 @@ internal static class GameStateService
             return false;
         }
 
+        // A page of the in-run capstone container is a person's menu over a frozen run, and both action
+        // surfaces stay empty while one is up. The executor has to refuse the same surface -- the pause
+        // menu's own "save and quit" button belongs to the person sitting there, not to the agent.
+        if (IsCapstonePageOverlay(currentScreen))
+        {
+            return false;
+        }
+
         if (NGame.Instance == null || !GodotObject.IsInstanceValid(NGame.Instance))
         {
             return false;
@@ -1496,6 +1567,14 @@ internal static class GameStateService
         if (currentScreen is NPatchNotesScreen patchNotes)
         {
             return GodotObject.IsInstanceValid(patchNotes) && patchNotes.IsVisibleInTree();
+        }
+
+        // The in-run human pages are pages of the capstone container rather than NSubmenu screens of
+        // their own, so the submenu branch below never sees them; the container's stack is the thing to
+        // pop, and only while a page above the pause menu is the one being shown.
+        if (GetClosableCapstonePage(currentScreen) != null)
+        {
+            return true;
         }
 
         if (currentScreen is not NSubmenu submenu || !submenu.IsVisibleInTree())
@@ -2630,10 +2709,17 @@ internal static class GameStateService
             return names.ToArray();
         }
 
-        // The human paused the game: combat actions are swallowed while paused and the overlay's own
-        // buttons (including "放弃") are not agent decisions, so advertise nothing.
-        if (IsPauseMenuOverlay(currentScreen))
+        // A human menu is over a frozen run: the combat actions are swallowed while it is up and none
+        // of the page's own buttons (including the pause menu's "放弃") is an agent decision.
+        if (IsCapstonePageOverlay(currentScreen))
         {
+            // The page's own BackButton is the one action a human menu leaves an agent, and only for the
+            // pages above the pause menu. The pause page offers nothing: a person resumes that one.
+            if (CanCloseMainMenuSubmenu(currentScreen))
+            {
+                names.Add("close_main_menu_submenu");
+            }
+
             return names.ToArray();
         }
 
@@ -6910,13 +6996,27 @@ internal static class GameStateService
 
     private static string ResolveNonModalScreen(IScreenContext? currentScreen)
     {
-        // The capstone container hosts every overlay and tells them apart by its own Type; the
-        // in-game pause menu rides in it too. It has to claim PAUSE_MENU before the combat and
-        // visible-grid branches below can name the paused scene COMBAT or CARD_SELECTION, which
-        // would advertise a live action list over a game the human just paused.
-        if (IsPauseMenuOverlay(currentScreen))
+        // The capstone container hosts the in-run human menus and keeps its own Type while a page is
+        // pushed on top of the one that opened it, so the page on its stack is what has to be named.
+        // Naming the container instead reported the run underneath -- browsing the card library from a
+        // pause menu read as COMBAT, and the compendium hub as whatever room the run stood in -- while
+        // the combat and visible-grid branches below handed the model a live action list and a page's
+        // own furniture as capstone options. This has to run before both of them.
+        if (currentScreen is NCapstoneSubmenuStack container)
         {
-            return "PAUSE_MENU";
+            return container.Stack?.Peek() switch
+            {
+                NPauseMenu => "PAUSE_MENU",
+                NSettingsScreen => "SETTINGS",
+                NCompendiumSubmenu => "COMPENDIUM",
+                NCardLibrary => "CARD_LIBRARY",
+                NRelicCollection => "RELIC_COLLECTION",
+                NPotionLab => "POTION_LAB",
+                NBestiary => "BESTIARY",
+                NStatsScreen => "STATS",
+                NRunHistory => "RUN_HISTORY",
+                _ => "CAPSTONE_SELECTION",
+            };
         }
 
         if (currentScreen is NUnlockScreen)

--- a/docs/api.md
+++ b/docs/api.md
@@ -81,6 +81,13 @@
 | `BUNDLE_SELECTION` | 开局卡包选择界面（用 `choose_bundle` / `confirm_bundle`） |
 | `CAPSTONE_SELECTION` | Capstone 选项界面（用 `choose_capstone_option`） |
 | `PAUSE_MENU` | 暂停菜单叠加层（人工按下暂停；agent 在此期间没有可用动作，也拿不到 capstone 选项） |
+| `SETTINGS` | 设置页（暂停菜单里的「设置」；只有 `close_main_menu_submenu` 可退回上一级） |
+| `COMPENDIUM` | 百科大全 hub（暂停菜单里的「百科大全」，通向下面这些图鉴页） |
+| `RELIC_COLLECTION` | 遗物收集页（「百科大全」→「遗物收集」） |
+| `POTION_LAB` | 药水研究所页（「百科大全」→「药水研究所」） |
+| `BESTIARY` | 怪物图鉴页（「百科大全」→ 怪物图鉴）。hub 只在 `NBestiary.CanBeShown()` 为真时才画出这块磁贴 |
+| `STATS` | 角色数据页（「百科大全」→「角色数据」） |
+| `RUN_HISTORY` | 历史记录页（「百科大全」→「历史记录」） |
 | `MAP` | 地图界面 |
 | `COMBAT` | 战斗中 |
 | `EVENT` | 事件交互 |
@@ -104,7 +111,11 @@
 | `FEEDBACK` | 反馈提交页；不提供关闭动作，仅用于诊断 |
 | `UNKNOWN` | 无法识别的界面 |
 
-暂停菜单是人按下暂停后出现的叠加层（游戏用同一个 `NCapstoneSubmenuStack` 容器承载它，靠 `Type == PauseMenu` 区分）。暂停期间 agent 没有可用动作：`available_actions` 与 `/actions/available` 都为空，`capstone` 也不会出现。
+人按下暂停后出现的暂停菜单，以及从它进入的设置页与百科大全各页（卡牌总览、遗物收集、药水研究所、怪物图鉴、角色数据、历史记录）都由同一个 `NCapstoneSubmenuStack` 容器承载。`screen` 报的是容器栈顶那个页面的名字——`PAUSE_MENU`、`SETTINGS`、`COMPENDIUM`、`CARD_LIBRARY`、`RELIC_COLLECTION`、`POTION_LAB`、`BESTIARY`、`STATS`、`RUN_HISTORY`——而不是被这些页面盖住的房间；容器里出现未知页面时仍落到 `CAPSTONE_SELECTION`。
+
+这些都是人工菜单，被暂停吞掉的房间动作不再出现：`end_turn`、`play_card`、`choose_map_node`、`resolve_rewards`、`save_and_quit` 一律不广告，直接调用会得到 409 `invalid_action`；`capstone` 同样不出现——容器里的按钮是导航磁贴、筛选勾选框和控件命中区（`Hitbox`），不是 agent 的选项列表，所以 `choose_capstone_option` 既不广告也调用不了。
+
+除暂停菜单本身以外，这些页面各留一个动作：`close_main_menu_submenu` 退回上一级（等同页面自己的返回按钮 `Stack.Pop()`），例如 `CARD_LIBRARY` → `COMPENDIUM` → `PAUSE_MENU`；退到暂停菜单为止，那一页不再提供任何动作——恢复游戏是人的事，agent 不替人点「继续」。`close_cards_view` 在这里不适用，它只认战斗里的看牌屏与牌堆。
 
 ## Action Status
 

--- a/docs/live-validation-checklist.md
+++ b/docs/live-validation-checklist.md
@@ -99,6 +99,37 @@ All three were re-run against the patched build on the same isolated instance.
   instance of an object.` and `command: bestiary` in the details — where it used to be a bare 500
   `internal_error` with `details: null`. The run is left untouched (`COMBAT`, same action list).
 
+### In-run menu pages (issue #93)
+
+The capstone container's pages used to be reported as the room underneath them: the pause menu's compendium hub
+read as `COMBAT`, the card library as `CARD_SELECTION`, and both handed the model the run's own actions plus
+the page's furniture as `capstone.options`. Verified live in two passes on one isolated instance, polling
+`/state` after every click:
+
+- **Before the fix** (shipped v0.12.0 and the #91 / #92 build): pause menu -> compendium hub reported `COMBAT`
+  with `available_actions = [end_turn, play_card, save_and_quit, choose_capstone_option]`; the card library
+  reported `CARD_SELECTION` with 51 capstone options whose first 25 labels were `Hitbox`.
+- **After the fix**: `PAUSE_MENU`, `SETTINGS`, `COMPENDIUM`, `CARD_LIBRARY`, `RELIC_COLLECTION`, `POTION_LAB`,
+  `STATS` and `RUN_HISTORY` each report their own name. None of them advertises a room action or
+  `save_and_quit`, `capstone` stays null, and `choose_capstone_option` answers 409 `invalid_action` on every
+  one of them. `close_main_menu_submenu` steps back one page (`CARD_LIBRARY` -> `COMPENDIUM` -> `PAUSE_MENU`)
+  and is 409 on the pause menu itself, which is where a person resumes. Escape returned the run to `COMBAT`
+  with `end_turn` / `play_card` offered again.
+- **The live run corrected the issue's own assumption about the way out.** The issue claimed `close_cards_view`
+  still worked on the card library because it looks for a `BackButton` regardless of type. It does not: the page
+  sits in the container rather than on a card-viewer screen, so both it and `close_main_menu_submenu` were 409,
+  before and after the naming fix, and an agent that followed the skill's "use `close_main_menu_submenu` inside
+  a run" line had nothing that worked. The fix widens `close_main_menu_submenu` to the container's stack
+  (`Stack.Pop()`, the call the game wires to every page's own BackButton) and deliberately excludes the pause
+  page, since popping that one resumes a paused run.
+- **Second live find: `save_and_quit` executed from a page whose surfaces advertised nothing.** #91 emptied both
+  action surfaces over the pause menu, but `CanSaveAndQuit` only excluded the main menu, game over, character
+  select and multiplayer, so the action still worked there and saved-and-quit the run during this session's
+  probing. The capstone overlay is now part of that predicate, so the executor refuses what the surface never
+  offered.
+- `BESTIARY` was not opened live: this profile's compendium hub draws no bestiary tile (`NBestiary.CanBeShown()`
+  gates it). The mapping and the exclusion from decision screens exist for the build that shows it.
+
 ### Environment note for isolated runs
 
 A brand-new `--clientId` directory gets a default `settings.save` whose `mod_settings` is `null`, and the

--- a/scripts/run_sts2_validation.py
+++ b/scripts/run_sts2_validation.py
@@ -1249,8 +1249,8 @@ def dismiss_blocking_modal(client: ApiClient, state: dict[str, Any] | None = Non
 # Screen coverage for the run-progression helpers below.
 #
 # GameStateService.ResolveNonModalScreen is the single producer of state["screen"] (the docs/api.md
-# "Screen 枚举" table mirrors it) and can return 24 names. This block records how each one is reached
-# so a screen without a branch here reads as a deliberate choice, not a gap.
+# "Screen 枚举" table mirrors it, and the api-facts gate keeps the two in step). This block records how
+# each one is reached, so a screen without a branch here reads as a deliberate choice, not a gap.
 #
 # Consumed through the Mod API by the helpers below and the suites that call them:
 #   MAIN_MENU         settle_main_menu / settle_game_over / continue_from_main_menu_if_needed /
@@ -1279,6 +1279,10 @@ def dismiss_blocking_modal(client: ApiClient, state: dict[str, Any] | None = Non
 #                                            settle_main_menu already drives that action
 #   FEEDBACK                                 user-triggered only; nothing closes it, and these
 #                                            scripts must not enter it
+#   PAUSE_MENU, SETTINGS, COMPENDIUM, CARD_LIBRARY, RELIC_COLLECTION, POTION_LAB, BESTIARY, STATS,
+#   RUN_HISTORY                              in-run human menus (the shared capstone container). A
+#                                            person opens one and leaves it with ESC, and the mod
+#                                            offers no action while one is up
 
 
 def settle_game_over(client: ApiClient, *, attempts: int, delay_ms: int) -> dict[str, Any]:

--- a/scripts/test-multiplayer-lobby-flow.ps1
+++ b/scripts/test-multiplayer-lobby-flow.ps1
@@ -652,6 +652,12 @@ function Invoke-LocalRunProgressionStep {
         return $null
     }
 
+    # The shared in-run capstone container (NCapstoneSubmenuStack): a person opened one of its menu pages
+    # over a frozen run, and the mod offers no action while one is up, so let the caller wait it out.
+    if ($State.screen -in @("PAUSE_MENU", "SETTINGS", "COMPENDIUM", "CARD_LIBRARY", "RELIC_COLLECTION", "POTION_LAB", "BESTIARY", "STATS", "RUN_HISTORY")) {
+        return $null
+    }
+
     switch ($State.screen) {
         "BUNDLE_SELECTION" {
             if ($actions -contains "confirm_bundle") {

--- a/skills/sts2-mcp-player/SKILL.md
+++ b/skills/sts2-mcp-player/SKILL.md
@@ -118,6 +118,8 @@ Do not trust memory over the current payload. The game mutates screens in place,
 - `CARD_PILE`: a combat card pile (draw / discard / exhaust). `close_cards_view` returns to combat.
 - `CARD_INSPECT` / `RELIC_INSPECT`: inspect overlays. The same `close_cards_view` action that closes the card list also closes these.
 - `FEEDBACK`: the feedback form. No mod action closes it yet, so only open it when the task asks and let the player finish it.
+- `PAUSE_MENU`, `SETTINGS`, `COMPENDIUM`, `RELIC_COLLECTION`, `POTION_LAB`, `BESTIARY`, `STATS`, `RUN_HISTORY` (and `CARD_LIBRARY` when it is opened from inside a run): the pages shown over a frozen run when a person presses pause. Room actions are suppressed and `capstone` is null on all of them; `close_main_menu_submenu` is the only action advertised, and it steps back one page (`CARD_LIBRARY` -> `COMPENDIUM` -> `PAUSE_MENU`). The pause menu itself offers nothing - a person resumes that one, so wait instead of trying to act.
+
 
 For detailed per-screen sequences and pitfalls, read [references/screen-playbooks.md](references/screen-playbooks.md).
 

--- a/skills/sts2-mcp-player/references/screen-playbooks.md
+++ b/skills/sts2-mcp-player/references/screen-playbooks.md
@@ -140,6 +140,12 @@ Use this reference when the active screen is clear and you need the exact action
 - Screen `FEEDBACK` is the feedback form.
 - No mod action closes it yet, so it is user-triggered only: do not enter it during autonomous play, and if the player opened it, wait instead of guessing an action.
 
+## In-Run Menu Pages (PAUSE_MENU, SETTINGS, COMPENDIUM, ...)
+
+- `PAUSE_MENU`, `SETTINGS`, `COMPENDIUM`, `CARD_LIBRARY` (opened from inside a run), `RELIC_COLLECTION`, `POTION_LAB`, `BESTIARY`, `STATS` and `RUN_HISTORY` are the pages a person opens from the in-run pause menu. They ride in one container, so `screen` names the page on top of it, not the room it covers.
+- While one is up the run is frozen: room actions and `save_and_quit` are gone from `available_actions`, `capstone` is null, and calling any of them answers 409 `invalid_action`.
+- `close_main_menu_submenu` is the only action here, and it steps back one page: `CARD_LIBRARY` -> `COMPENDIUM` -> `PAUSE_MENU`. Once the pause menu is on top, nothing is offered - do not try to resume the run, and wait for the person to leave the menu.
+
 ## Potion Targeting
 
 - `AnyEnemy`: requires `target_index`.


### PR DESCRIPTION
## 这个 PR 修什么

#93：从暂停菜单进入的图鉴 / 设置页被报成下面的房间（`COMBAT` / `CARD_SELECTION`），并且带出一串 `Hitbox` 当 capstone 选项。

容器 `NCapstoneSubmenuStack` 在页面压到暂停菜单之上时仍保留自己的 `Type`，所以这些页面过去都按底下那个房间报：百科大全 hub 报 `COMBAT`，卡牌总览报 `CARD_SELECTION`，动作面同时给出被暂停吞掉的战斗动作，`capstone.options` 则把页面自己的按钮（卡牌总览屏上 51 个，前 25 个标签全是 `Hitbox`）当成 agent 的选项。

## 改法

- `ResolveNonModalScreen` 在 `currentScreen` 是容器时按 `Stack.Peek()` 的真实类型命名：`PAUSE_MENU` / `SETTINGS` / `COMPENDIUM` / `CARD_LIBRARY` / `RELIC_COLLECTION` / `POTION_LAB` / `BESTIARY` / `STATS` / `RUN_HISTORY`，未知页面仍落 `CAPSTONE_SELECTION`。这个分支排在战斗分支与可见牌格分支之前。
- `GetCapstoneButtons` 对已知容器页面一律返回空，导航磁贴 / 筛选勾选框 / `Hitbox` 不再作为选项出现。
- 这些页面是「冻结局面之上的人工菜单」，所以两条动作面收敛成一个 `close_main_menu_submenu`：它 `Stack.Pop()` —— 正是游戏给每个页面 `BackButton` 接的那一下（`CARD_LIBRARY` → `COMPENDIUM` → `PAUSE_MENU`）。暂停菜单那一页永远不可关：pop 掉它等于替人继续游戏。

## 实机验收（隔离实例，每次点击后轮询 `/state`）

| 步骤 | 结果 |
| --- | --- |
| 战斗中 ESC | `PAUSE_MENU`，动作空，`capstone=null`；`close_main_menu_submenu` / `save_and_quit` / `choose_capstone_option` 全部 409 `invalid_action` |
| 点「设置」 | `SETTINGS`，无被吞的战斗动作，只有 `close_main_menu_submenu`；退回 `PAUSE_MENU` |
| 点「百科大全」 | `COMPENDIUM`（修前是 `COMBAT`） |
| 「卡牌总览」/「遗物收集」/「药水研究所」/「角色数据」/「历史记录」 | 各自报到 `CARD_LIBRARY` / `RELIC_COLLECTION` / `POTION_LAB` / `STATS` / `RUN_HISTORY`；每屏都只广告 `close_main_menu_submenu`，`choose_capstone_option` 都是 409，退一级回到 `COMPENDIUM` |
| 退回暂停菜单后 | 那一页不再提供任何动作，`close_main_menu_submenu` 409 |
| ESC 恢复 | 回到 `COMBAT`，`end_turn` / `play_card` 重新出现 |

验收脚本：`build/validation-2026-09-13/verify-capstone-pages.ps1`，逐条日志在 `build/validation-2026-09-13/verify-capstone-pages.log`，**FAILURES: 0**。记录同时写进了 `docs/live-validation-checklist.md`。

> `BESTIARY` 这一轮没能实机打开：本 profile 的百科大全 hub 不画怪物图鉴磁贴（`NBestiary.CanBeShown()` 决定）。映射与「不当作决策屏」的处理仍然在，等游戏画出这块磁贴的存档再验。

## 实机推翻的两个假设

1. **`close_cards_view` 在图鉴屏上并不好用。** #93 里写的「它按 BackButton 查找，不看类型，因此返回路径仍可用」是错的：实机在同一屏上 `close_cards_view` 与 `close_main_menu_submenu` **都是 409**（页面在容器里，既不是 `NSubmenu` 也不是看牌屏）。也就是说改名前 agent **根本没有出路**，技能里那句「局内用 `close_main_menu_submenu` 返回 `CARD_LIBRARY`」当时是错的。本 PR 把容器栈接进 `close_main_menu_submenu` 才真正修好。
2. **`save_and_quit` 在这些页面上仍然可执行。** #91 把两条动作面清空，但 `CanSaveAndQuit` 只排除了主菜单 / 结算 / 选角色 / 联机，所以它照样能执行（本轮实机就这么把局存了并退回主菜单）。现在 capstone 页也进了这个判断，执行器拒绝的东西与动作面广告的东西一致。

## 检查

- `dotnet run --project STS2AIAgent.Tests/STS2AIAgent.Tests.csproj -c Release` — **365 PASS / 0 FAIL**（新增 `ScreenResolution.CapstonePagesOneBackStep`：九个页面映射、容器分支先于 `NSubmenu` 分支、执行器 pop 栈、`SubmenusOpen` 不能用来判断 pop、两条动作面在守卫内广告、暂停页被排除、`save_and_quit` 守卫先于宽松 return）
- `dotnet build STS2AIAgent/STS2AIAgent.csproj -c Release` — 0 警告
- `python scripts/check_verification_gates.py` — 7 道 gate 全绿
- `cd mcp_server; uv run --locked python -m unittest discover -s tests` — **165 OK**

## 顺带

- `scripts/test-multiplayer-lobby-flow.ps1` 的 run-progression switch 之前遇到 `PAUSE_MENU` 会抛 `Unsupported run progression state`（`PAUSE_MENU` 早就存在），现在与其它局内菜单页一起按「等人工离开」处理。
- `docs/api.md` 的 Screen 枚举表补上 7 个新名字与这些页面的动作规则（api-facts gate 会跟着校）；`scripts/run_sts2_validation.py` 的覆盖注释补上这批页面。
- 技能（`skills/sts2-mcp-player/SKILL.md` + `references/screen-playbooks.md`，两者都嵌进 Mod 提示词）把「局内菜单页没有动作、等人工离开」改成实情：只有 `close_main_menu_submenu` 退一级，暂停菜单那一页什么都没有。

## Summary by Sourcery

Name in-run menu pages accurately and provide a safe one-level back action without allowing agents to resume or modify the paused run.

New Features:
- Expose distinct screen names for in-run pause-menu pages, including settings, compendium, card library, collections, statistics, and run history.
- Allow agents to step back one level from in-run submenu pages with close_main_menu_submenu while keeping the pause menu agent-inaccessible.

Bug Fixes:
- Prevent paused in-run menus from being reported as the underlying combat or card-selection screen and from exposing combat actions, save-and-quit, or page controls as capstone options.
- Reject unsupported actions consistently while in-run menu pages are open, including save_and_quit.

Enhancements:
- Update screen handling, action guidance, validation coverage, and multiplayer progression logic for the expanded in-run menu states.

Documentation:
- Document the new in-run screen states, action restrictions, and one-level back-navigation behavior in the API and player guidance.

Tests:
- Add contract coverage for screen naming, menu-page action suppression, stack-based back navigation, pause-menu protection, and save-and-quit guards.