### PR TITLE
Release v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 > Release attribution is recorded against tags or release commits. Post-tag maintenance is listed separately; current validation limits are maintained in [PRODUCT_PLAN_CURRENT.md](https://github.com/CharTyr/STS2-Agent/blob/main/PRODUCT_PLAN_CURRENT.md).
 
+## v0.12.1 - 2026-09-13
+
+> The pause boundary: once a person presses pause, the agent no longer reads the run underneath. The pause menu and every page reached from it report their own screen, their action surfaces stay closed, and no page's own furniture — the pause menu's "abandon" entry among it — arrives as a capstone option any more.
+
+### Fixed
+
+- The in-game pause menu is no longer mistaken for an open capstone screen (#88, `31296bd`). The menu rides in the same `NCapstoneSubmenuStack` container the capstone path matches, so `/state.screen` stayed `COMBAT`, `capstone.options` listed the menu's own buttons (`继续` / `设置` / `放弃` / `保存并退出` / `BackButton`) and `choose_capstone_option` was advertised on a screen where it did nothing — one of those options abandons the run. The container now resolves to `PAUSE_MENU` before the combat and visible-grid branches, `GetCapstoneButtons` excludes it, and both action surfaces stay empty while it is up. Live: pausing in a fight reports `PAUSE_MENU` with an empty action list and a null `capstone`, and Escape resumes.
+- `continue_ai_teammate` refuses before a mismatched `--clientId` can destroy the co-op save (#89, `31296bd`). The game canonicalizes the run it loads against the loading process's player id and, on a mismatch, renames `current_run_mp.save` and its backup to `*.VAL.corrupt` without restoring them. The action now reads `players[].net_id` from the save and compares this host's NetId and the NetId the teammate would be launched with before it loads anything: a mismatch is 409 `invalid_action` naming both ids, the save is left byte-identical, and no second process is started.
+- The pages reached from the pause menu report themselves instead of the room underneath (#93, `04748f6`): the compendium hub read as `COMBAT` and the card library as `CARD_SELECTION`, each carrying the run's own actions and the page's furniture as `capstone.options` — 51 entries on the card library screen, the first 25 of them labelled `Hitbox`. `SETTINGS`, `COMPENDIUM`, `CARD_LIBRARY`, `RELIC_COLLECTION`, `POTION_LAB`, `BESTIARY`, `STATS` and `RUN_HISTORY` now name themselves when the container's stack holds them, none advertises a room action or `save_and_quit`, `capstone` stays null, and `choose_capstone_option` answers 409 `invalid_action` on every one of them.
+- Those pages have a working way out again: `close_main_menu_submenu` pops the container's stack, which is the call the game wires to each page's own BackButton (`CARD_LIBRARY` → `COMPENDIUM` → `PAUSE_MENU`). The action the play skill documented for them, `close_cards_view`, was 409 there — the page sits in the container rather than on a card-viewer screen — so an agent that followed the skill had nothing it could do. The pause page itself is never closable: popping it resumes a run a person paused.
+- `save_and_quit` no longer executes from a page whose surface never offered it (`04748f6`). The pause overlay emptied both action lists, but the availability predicate still allowed the action, so it saved and quit the run. The capstone overlay is now part of that predicate.
+- A deeper page pushed above the pause menu is no longer reported as a frozen game (#92, `3cf347a`). Matching the container's type alone reported `PAUSE_MENU` for the compendium and the card library opened from it, which also hid the `CARD_LIBRARY` branch behind an inert screen.
+- A throwing console command answers honestly: `run_console_command bestiary` is 409 `invalid_action` carrying `Console command failed: NullReferenceException: …` and the command name, where it used to be a bare 500 `internal_error` with `details: null` for a command the game had accepted.
+
+### Changed
+
+- `docs/api.md` documents the new screen names and what those pages offer; `docs/live-validation-checklist.md` records the two live passes that found and confirmed the behaviour, including the two defects the issue had assumed were fine (the documented `close_cards_view` return and the reachable `save_and_quit`).
+- The play skill — `skills/sts2-mcp-player/SKILL.md` and its screen playbooks, both embedded in the mod's own prompt — now states what the in-run menu pages really offer instead of claiming a return path that returned 409.
+- `scripts/test-multiplayer-lobby-flow.ps1` treats the in-run menu pages as "wait for the human" instead of failing with `Unsupported run progression state`; `PAUSE_MENU` had always thrown there. `scripts/run_sts2_validation.py`'s screen-coverage note names the pages too.
+
+
 ## v0.12.0 - 2026-09-13
 
 > Co-op is the headline: a saved multiplayer run can be continued with the AI teammate, and the teammate's character can be left for you to pick. The rest is a trust pass over the agent-facing state — every signal it surfaces now matches what the executor accepts, and no game-side wait can hang a request. Release and Workshop upload: [release-v0.12.0_2026-09-13.md](history/release-v0.12.0_2026-09-13.md).

--- a/STS2AIAgent/Server/Router.cs
+++ b/STS2AIAgent/Server/Router.cs
@@ -15,7 +15,7 @@ internal static class Router
 {
     private const string ServiceName = "sts2-ai-agent";
     private const string ProtocolVersion = "2026-03-11-v1";
-    internal const string ModVersion = "0.12.0";
+    internal const string ModVersion = "0.12.1";
     private const string LogPrefix = "[STS2AIAgent.Router]";
 
     private static long _requestCounter;

--- a/STS2AIAgent/mod_id.json
+++ b/STS2AIAgent/mod_id.json
@@ -3,7 +3,7 @@
   "name": "STS2 AI Agent",
   "author": "CharTyr",
   "description": "带一个 AI 一起爬塔。你打自己的角色，同一台电脑上 AI 可以打另一个。还在开发中，欢迎反馈。",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "min_game_version": "0.111.0",
   "has_pck": true,
   "has_dll": true,

--- a/STS2AIAgent/mod_manifest.json
+++ b/STS2AIAgent/mod_manifest.json
@@ -4,7 +4,7 @@
   "name": "STS2 AI Agent",
   "author": "CharTyr",
   "description": "带一个 AI 一起爬塔。你打自己的角色，同一台电脑上 AI 可以打另一个。还在开发中，欢迎反馈。",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "min_game_version": "0.111.0",
   "has_pck": true,
   "has_dll": true,

--- a/docs/api.md
+++ b/docs/api.md
@@ -141,7 +141,7 @@
   "request_id": "req_20260911_121549_7955_4",
   "data": {
     "service": "sts2-ai-agent",
-    "mod_version": "0.12.0",
+    "mod_version": "0.12.1",
     "protocol_version": "2026-03-11-v1",
     "game_version": "v0.111.0",
     "status": "ready",

--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sts2-ai-agent-mcp"
-version = "0.12.0"
+version = "0.12.1"
 description = "FastMCP wrapper for the local STS2 AI Agent mod"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/mcp_server/uv.lock
+++ b/mcp_server/uv.lock
@@ -1194,7 +1194,7 @@ wheels = [
 
 [[package]]
 name = "sts2-ai-agent-mcp"
-version = "0.12.0"
+version = "0.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/steam-workshop/workshop.json
+++ b/steam-workshop/workshop.json
@@ -1,7 +1,7 @@
 {
   "title": "STS2 AI Agent",
   "visibility": "public",
-  "changeNote": "v0.12.0: continue a saved co-op run with the AI teammate, and let the teammate leave the character pick to you",
+  "changeNote": "v0.12.1: pausing is safe again. The pause menu and the pages opened from it (compendium, card library, settings) no longer read as a live room, so the agent stops offering actions the pause swallows and a page's own buttons stop arriving as options; a wrong --clientId can no longer eat a co-op save",
   "tags": [
     "Tools & APIs",
     "Utility",


### PR DESCRIPTION
## v0.12.1

暂停的安全边界：人按下暂停之后，AI 不再把这局当成还在进行。暂停菜单与从它进入的每个页面都报出自己的屏幕名、动作面收敛、并且不再把页面自己的按钮当成 agent 的选项——**暂停菜单此前会作为一个「开着的 capstone」出现，选项列表里就有「放弃」**。联机存档也不再会被一个写错的 `--clientId` 吃掉。

版本五处同步到 `0.12.1`（`mod_manifest.json` / `mod_id.json` / `Router.cs` / `pyproject.toml` / `uv.lock`，最后一项由 `uv lock` 重生成），`docs/api.md` 的 `mod_version` 示例与工坊 changeNote 一并更新。

### 相对 v0.12.0 的内容

- **暂停菜单不再被当成 capstone 决策屏**（#88 / `31296bd`）：以前它报 `COMBAT`，`capstone.options` 是该菜单自己的按钮（`继续` / `设置` / `放弃` / `保存并退出` / `BackButton`），并广告 `choose_capstone_option` —— 其中一个是「放弃这局」。现在报 `PAUSE_MENU`，两条动作面为空，`capstone` 为 null。
- **`continue_ai_teammate` 在读档前就拒绝不匹配的 `--clientId`**（#89 / `31296bd`）：游戏会把读档进程玩家 id 与存档做规范化比对，不匹配时把 `current_run_mp.save` 及其备份改名成 `*.VAL.corrupt` 且不还原。现在先读存档 `players[].net_id` 比对（含队友的 NetId），不匹配直接 409 `invalid_action`，存档哈希不变、不拉起第二个进程。
- **从暂停菜单进入的图鉴/设置各页报自己**（#93 / `04748f6`）：百科大全 hub 以前报 `COMBAT`、卡牌总览报 `CARD_SELECTION`，并带出页面自己的控件（卡牌总览屏 51 个选项，前 25 个标签是 `Hitbox`）。现在 `SETTINGS` / `COMPENDIUM` / `CARD_LIBRARY` / `RELIC_COLLECTION` / `POTION_LAB` / `BESTIARY` / `STATS` / `RUN_HISTORY` 各自报名字，`choose_capstone_option` 在这些屏上都是 409。
- **这些页面重新有了出路**：`close_main_menu_submenu` 退一级（`CARD_LIBRARY` → `COMPENDIUM` → `PAUSE_MENU`）。技能里原本写的 `close_cards_view` 在实机上是 409（页面在容器里，不在看牌屏上），也就是说改名前 agent 根本没有可用动作。暂停菜单那一页永远不可关——关掉它等于替人继续游戏。
- **`save_and_quit` 不再能从没有广告它的页面执行**（`04748f6`）：#91 清空了动作面，但执行判定仍允许它，实机探针真就这么存了局退出去了。现在 capstone 覆盖也进了判定。
- **更深一层页面压上来时不再被误报成「暂停中的游戏」**（#92 / `3cf347a`）。
- 抛异常的调试命令给出真实错误：`run_console_command bestiary` 从裸 500 `internal_error`（`details: null`）变成 409 `invalid_action` 并带上异常文本。

### 检查

- `scripts/preflight-release.ps1` — 全部步骤 OK（含 `check_release_metadata.py` 五处版本一致、7 道 gate、gate 自检、native 失败传播）
- C# 单测 **365 PASS / 0 FAIL**；MCP 单测 **165 OK**；`dotnet build` 0 警告
- 实机验收（v0.12.1 之前的修复轮，隔离实例）：暂停菜单 / 设置 / 百科大全 / 卡牌总览 / 遗物收集 / 药水研究所 / 角色数据 / 历史记录 逐个核对，**FAILURES: 0**，记录见 `docs/live-validation-checklist.md` 的 `### In-run menu pages (issue #93)`

### 已知限制

- `BESTIARY` 未做实机开屏（当前存档的百科大全 hub 不画怪物图鉴磁贴，`NBestiary.CanBeShown()` 决定）；映射与「不当作决策屏」的处理已在位。
- 工坊的**简体中文列表仍是旧版**（自 v0.11.0 起未更新），正文在 `steam-workshop/description.zh-CN.txt`，需要在工坊页面手工粘贴。

需要《杀戮尖塔 2》v0.111.0 或更新版本。

## Summary by Sourcery

Release v0.12.1 with safer pause-state boundaries, protected multiplayer save continuation, and accurate in-game menu reporting.

Bug Fixes:
- Prevent pause menus and pages opened from them from being exposed as active gameplay or capstone decisions, including removing invalid actions and restoring valid navigation back to the pause menu.
- Reject mismatched multiplayer client IDs before loading or modifying cooperative save files.
- Return actionable 409 errors for unsupported or failing console commands instead of opaque internal errors.

Enhancements:
- Update agent skills and screen-state handling to reflect in-run menu pages and their available actions.
- Treat paused in-run menu pages as human-wait states in multiplayer validation flows.

Build:
- Synchronize the mod, MCP package, lockfile, and Workshop versions to 0.12.1.

Documentation:
- Update API version examples and document the revised screen behavior, navigation, and live validation results.

Tests:
- Record validation coverage for pause and in-run menu pages.