### PR TITLE
feat(coop): let an external agent take over the teammate window (#85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 > Release attribution is recorded against tags or release commits. Post-tag maintenance is listed separately; current validation limits are maintained in [PRODUCT_PLAN_CURRENT.md](https://github.com/CharTyr/STS2-Agent/blob/main/PRODUCT_PLAN_CURRENT.md).
 
+## Unreleased
+
+> Issue #85: the player who wants to fight their own character while an outside agent drives the
+> teammate window no longer has to fake a passing model test to get there. Inviting a teammate now
+> picks its route from whether the play model is verified, and the supported control entry moved to
+> the host window. Live: [docs/live-validation-checklist.md](docs/live-validation-checklist.md).
+
+### Added
+
+- `POST /teammate/control` on the host window starts or pauses the teammate, with no companion session
+  token: the host already holds that token and uses it against the companion’s own `POST /companion/control`
+  (#85). `{"running": true|false}` returns `phase` / `play_running` / `play_phase` / `companion_auto_play`;
+  it is loopback-only and host-only (403 `local_only`, 409 `not_host`), and a control that cannot be
+  confirmed is 409 `teammate_control_failed`. Until now the teammate could only be started or paused from
+  the in-game overlay, so an external agent had no supported way to do it.
+- `GET /health` carries a `companion` block on the host once a teammate is connected
+  (`api_host` / `api_port` / `process_id` / `auto_play`), so a caller can find the teammate’s own
+  `GET /state` and `POST /action` instead of guessing the port. The session token is not part of it.
+- `docs/api.md` documents the two co-op routes side by side, the new endpoint, and the new field; both
+  READMEs gained an “Option C: hand the teammate window to an external agent”.
+
+### Changed
+
+- **Inviting a teammate no longer requires a verified play model.** The route is chosen by
+  `FirstRunSetup.Evaluate(settings).ReadyToInvite`, which is the same signal the overlay already used: with a
+  verified play model the teammate auto-plays exactly as before, and without one it still joins the lobby and
+  starts the run, then parks — its process gets `STS2_AGENT_AUTOPLAY=0`, so it plays nothing and, more to the
+  point, never calls a model at all (#85). `invite_ai_teammate` and `continue_ai_teammate` share this switch,
+  and the launch status line now says which route is running instead of promising auto-play either way.
+- The conditions both routes still enforce are unchanged and are now a named policy
+  (`CoopLaunchPolicy.GetStructuralError`): not the companion instance, no auto-play already running on this
+  character, main menu. The split is scoped to the model gate and is not a way around those.
+
+### Fixed
+
+- The reported co-op route described the launch that was *attempted*, not the teammate that is *running*: a
+  rejected retry — usually “the teammate window is already running” — overwrote the flag before the launch
+  check, so `/health` could report `auto_play: false` for a teammate the in-process loop was actively playing,
+  inviting an external agent to take over a seat already in use.
+- `/health` stopped advertising a companion API port after that process exited.
+- `teammate_control_failed` is `retryable: true`, matching what the docs already said; its causes (a launch in
+  progress, an unfinished previous control, an unconfirmed pause) all clear on their own.
+
 ## v0.12.1 - 2026-09-13
 
 > The pause boundary: once a person presses pause, the agent no longer reads the run underneath. The pause menu and every page reached from it report their own screen, their action surfaces stay closed, and no page's own furniture — the pause menu's "abandon" entry among it — arrives as a capstone option any more. Release and Workshop upload: [release-v0.12.1_2026-09-13.md](history/release-v0.12.1_2026-09-13.md).

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This mod is still in development. Some things may be unfinished or break. Please
    4. Click **Test Connection** (sends a request to your configured service). Chat success is not play success.
    5. Click **Save Settings**. Unsaved edits are saved when you leave the tab so they are not dropped silently.
 3. Thinking intensity, vision, and session budgets are under **Show advanced options**.
-4. Invite a teammate only after the play model shows connectivity success.
+4. Invite a teammate only after the play model shows connectivity success. That requirement belongs to the auto-play route: a teammate invited without a verified play model still launches, it just waits to be taken over from outside. See **Option C** below.
 
 ### Step 4: Play!
 
@@ -87,6 +87,14 @@ This mod is still in development. Some things may be unfinished or break. Please
 - Use team chat to coordinate in plain English or Chinese.
 - By default the teammate takes the preselected character and readies up by itself. To pick its character yourself (in the teammate window, or through the companion API with `select_character` then `embark`), set `companionAutoSelectCharacter` to `false` in the mod's `settings.json`; the teammate then waits on the character screen without a timeout.
 
+#### Option C: Hand The Teammate Window To An External Agent
+- You do not need to configure or verify any model to invite a teammate on this route: it never calls a model, so a missing or broken model cannot make it fail. The teammate still launches, joins the lobby, and readies up on its own.
+- When the run starts, the teammate stops where it is and plays nothing by itself: its `/health` reports `play_phase: "paused"` with `session_requests: 0`, because this route never calls a model.
+- Drive that character from outside with the teammate instance's own `GET /state` and `POST /action`. Find its HTTP API through `data.companion.api_port` on the main window's `GET /health` (that port is usually not 8080). The teammate can only act for its own character; acting outside it returns 403 `forbidden_actor`. On this route `data.companion.auto_play` is `false`.
+- Start and pause it with `POST /teammate/control` on the **main window**, body `{"running": true|false}`. This is the supported entry point and it needs no session token (the main window holds the teammate session token itself). `running: true` still requires a verified play model, exactly like the in-game **Continue Auto-Play** button; `running: false` works at any time.
+
+Both routes enforce the same structural conditions (you are on the main menu, this is not the teammate instance, and the character has no auto-play already running); only the model gate differs. Full contract: [docs/api.md](docs/api.md).
+
 ---
 
 ## 🎮 Core Features
@@ -97,6 +105,7 @@ This mod is still in development. Some things may be unfinished or break. Please
 - **Real-Time Counters**: The overlay displays prompt, completion, total tokens, and request counts live.
 
 ### 2. Dual-Instance Local Co-op
+- **Two Co-op Routes**: With a verified play model the teammate auto-plays as before; with no model it still launches and joins, but stops and waits to be taken over from outside (see **Option C**).
 - **Zero-Collision Isolation**: Propagates `--force-steam off` and increments `clientId` in offline mode. Automatically derives and clones `settings.companion.json` so both instances never write over each other's configurations or save slots.
 - **Team Conversation**:
   - Chat directly with the AI teammate during multiplayer runs.
@@ -148,14 +157,15 @@ This mod is still in development. Some things may be unfinished or break. Please
 
 The mod runs an embedded HTTP server on `http://127.0.0.1:8080` (with dynamic fallback on port contention):
 
-- `GET /health`: Health check, returns `api_port`, `instance_role`, `mcp_enabled`, and process PID.
+- `GET /health`: Health check, returns `api_port`, `instance_role`, `mcp_enabled`, and process PID. On the main window, once this co-op session has connected to a teammate, it also returns a `companion` block: the teammate's `api_host`, `api_port`, and `process_id`, plus this route's `auto_play` flag.
 - `GET /state`: Full raw game state JSON.
 - `GET /actions/available`: Currently available legal actions and schema.
 - `GET /events/stream`: Real-time SSE stream for game events.
 - `POST /action`: Dispatch an action (e.g., `play_card`, `choose_map_node`, `proceed`).
 - `GET /data/{collection}`: Export a bundled game metadata collection (`cards`, `relics`, `monsters`, `potions`, `events`, `powers`, `characters`).
 - `POST /session/control`: Start or pause autoplay for this instance (`{"running": true|false}`).
-- `POST /companion/control` / `POST /companion/message`: Control or message the AI teammate instance (local dual-instance only).
+- `POST /teammate/control`: Start or pause the AI teammate from the **main window** (`{"running": true|false}`). Loopback only and main-window only; this is the supported entry point for an external agent (see **Option C** above).
+- `POST /companion/control` / `POST /companion/message`: Control or message the AI teammate instance (local dual-instance only). These are the teammate instance's own controlled endpoints, called by the main process with this session's token; external callers should use `POST /teammate/control` instead.
 - `POST /mcp`: Optional MCP (Streamable HTTP). Off by default; enable it on the overlay Connect tab.
 
 ### Which MCP entry to use

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -70,7 +70,7 @@ https://github.com/user-attachments/assets/89353468-a299-4315-9516-e520bcbfbd4b
    4. 点 **测试连接**（会向配置的服务发测试请求）。对话通过 ≠ 游玩已通过。
    5. 点 **保存设置**。未保存的编辑切页时会自动保存，避免悄悄丢失。
 3. 思考强度、视觉、会话预算在 **显示高级选项** 里。
-4. 游玩模型显示「连通成功」后，再去 **「AI 队友」** 邀请。
+4. 游玩模型显示「连通成功」后，再去 **「AI 队友」** 邀请。这个前提只属于自走路线：未验证游玩模型时邀请队友，队友照样会拉起，只是会停在原地等待外部接管。见下方 **选项 C**。
 
 ### 第 4 步：开始体验！
 
@@ -87,6 +87,14 @@ https://github.com/user-attachments/assets/89353468-a299-4315-9516-e520bcbfbd4b
 - 可以直接用文字和队友商量路线与集火策略。
 - 队友默认拿大厅预选的角色并自动准备。想自己给它选角（在队友窗口里选，或通过队友 API 先 `select_character` 再 `embark`），把 mod 的 `settings.json` 里 `companionAutoSelectCharacter` 设为 `false`；此时队友会停在选角界面等你，没有超时。
 
+#### 选项 C：把队友窗口交给外部 Agent
+- 这条路线不需要配置或验证任何模型就能拉起队友——它根本不调用模型，所以没有模型也不会失败。队友照常拉起、照常加入大厅、照常准备。
+- 进图后队友会停在原地，不会自己出牌：它的 `/health` 报 `play_phase: "paused"` 与 `session_requests: 0`，因为这条路线根本不调用模型。
+- 从外部用队友实例自己的 `GET /state` 与 `POST /action` 驱动那个角色。通过主窗口 `GET /health` 的 `data.companion.api_port` 找到它的 HTTP API（该端口通常不是 8080）。队友只能操作自己的角色，越界会返回 403 `forbidden_actor`；这条路线下 `data.companion.auto_play` 为 `false`。
+- 用**主窗口**的 `POST /teammate/control`（请求体 `{"running": true|false}`）开始 / 暂停它。这是受支持入口，不需要会话令牌（主窗口自己持有队友会话令牌）。`running: true` 仍然需要已验证的游玩模型，与游戏内「继续游玩」按钮是同一道门禁；`running: false` 随时可用。
+
+两条路线共用同一组结构条件（必须在主菜单、这是人玩的窗口、当前角色没有正在跑的自动游玩），只有模型这一档不同。完整契约见 [docs/api.md](docs/api.md)。
+
 ---
 
 ## 🎮 核心玩法详解
@@ -97,6 +105,7 @@ https://github.com/user-attachments/assets/89353468-a299-4315-9516-e520bcbfbd4b
 - **实时看板**：游玩页面实时显示当前会话消耗的 Prompt Tokens、Completion Tokens、总 Token 数以及请求次数。
 
 ### 2. 双人本地联机 (Co-op Companion)
+- **两条组队路线**：游玩模型已验证时，队友直接自走；没有模型时，队友照样拉起并入队，但会停住等待外部接管（见 **选项 C**）。
 - **零干扰隔离启动**：离线模式下自动继承 `--force-steam off` 并分配增量 `clientId`；启动器自动为副实例派生并首次克隆独立的 `settings.companion.json` 配置文件。彻底杜绝两个实例共用存档或并发写入配置导致的踩踏与冲突。
 - **队伍交流机制 (Team Conversation)**：
   - 在人类窗口直接向 AI 队友发起讨论（如：“这回合我全力防御，你来输出”、“下层我们走问号房”）。
@@ -148,14 +157,15 @@ https://github.com/user-attachments/assets/89353468-a299-4315-9516-e520bcbfbd4b
 
 Mod 默认在本地启动 HTTP 服务（默认端口 `8080`，遇冲突自动动态选择）：
 
-- `GET /health`：服务健康检查，返回 `api_port`、`instance_role`、`mcp_enabled` 与进程 PID。
+- `GET /health`：服务健康检查，返回 `api_port`、`instance_role`、`mcp_enabled` 与进程 PID。在主窗口、且本次组队已连上队友时，还会额外返回 `companion` 块：队友的 `api_host`、`api_port`、`process_id`，以及本条路线的 `auto_play`。
 - `GET /state`：获取完整原始游戏状态 JSON。
 - `GET /actions/available`：获取当前所有合法动作清单与参数 Schema。
 - `GET /events/stream`：订阅游戏状态转换的 SSE 长连接流。
 - `POST /action`：执行具体游戏动作（例如 `play_card`、`choose_map_node`、`proceed` 等）。
 - `GET /data/{collection}`：导出打包的游戏元数据集合（`cards`、`relics`、`monsters`、`potions`、`events`、`powers`、`characters`）。
 - `POST /session/control`：启动 / 暂停本机角色的自动游玩（`{"running": true|false}`）。
-- `POST /companion/control` / `POST /companion/message`：控制 AI 队友实例 / 给队友发消息（仅本地双开）。
+- `POST /teammate/control`：在**主窗口**上开始 / 暂停 AI 队友（`{"running": true|false}`）。仅 loopback、仅主窗口；这是外部 agent 受支持的控制入口（对应选项 C）。
+- `POST /companion/control` / `POST /companion/message`：控制 AI 队友实例 / 给队友发消息（仅本地双开）。这是队友实例自身的受控端点，由主进程带本次会话令牌调用；外部调用方改用 `POST /teammate/control`。
 - `POST /mcp`：可选 MCP（Streamable HTTP）。默认关闭，在悬浮窗「接入」页打开。
 
 ### MCP 怎么选

--- a/STS2AIAgent.Tests/CoopRouteTests.cs
+++ b/STS2AIAgent.Tests/CoopRouteTests.cs
@@ -1,0 +1,110 @@
+using STS2AIAgent.Config;
+using STS2AIAgent.Multiplayer;
+
+namespace STS2AIAgent.Tests;
+
+/// <summary>
+/// Issue #85: the "invite an AI teammate" preconditions are split into two routes. Auto-play needs
+/// a play model that passed 测试连接; handing the teammate window to an external agent never calls
+/// that model at all, so that route has to launch with nothing configured and come up paused.
+/// </summary>
+internal static class CoopRouteTests
+{
+    /// <summary>
+    /// The model gate is the only thing the external-takeover route drops. Everything that keeps a
+    /// launch safe on this machine -- not the companion window, no auto-play already running, main
+    /// menu -- still applies, so the split cannot be used to bypass those.
+    /// </summary>
+    public static void UnverifiedPlayModelLaunchesForExternalTakeoverOnly()
+    {
+        var settings = AgentSettings.CreateDefault();
+        Assert.True(!FirstRunSetup.Evaluate(settings).ReadyToInvite);
+
+        // Auto-play route: unchanged, the unverified play model still refuses the launch.
+        Assert.Contains("验证", CoopLaunchPolicy.GetError(false, false, "MAIN_MENU", settings));
+        // External-takeover route: the same settings launch, they just do not start the loop.
+        Assert.True(
+            CoopLaunchPolicy.GetError(false, false, "MAIN_MENU", settings, requireVerifiedPlayModel: false) == null);
+
+        // Nothing configured at all is the case the issue was filed for: still a launch.
+        var empty = new AgentSettings();
+        Assert.Contains("设置", CoopLaunchPolicy.GetError(false, false, "MAIN_MENU", empty));
+        Assert.True(CoopLaunchPolicy.GetError(false, false, "MAIN_MENU", empty, requireVerifiedPlayModel: false) == null);
+
+        // Only the model gate is skipped; the structural conditions still hold on both routes.
+        Assert.Contains(
+            "主窗口",
+            CoopLaunchPolicy.GetError(true, false, "MAIN_MENU", empty, requireVerifiedPlayModel: false));
+        Assert.Contains(
+            "暂停",
+            CoopLaunchPolicy.GetError(false, true, "MAIN_MENU", empty, requireVerifiedPlayModel: false));
+        Assert.Contains(
+            "主菜单",
+            CoopLaunchPolicy.GetError(false, false, "COMBAT", empty, requireVerifiedPlayModel: false));
+        Assert.Contains("模型", CoopLaunchPolicy.GetError(false, false, "MAIN_MENU", empty));
+
+        // A verified play model collapses the two routes: the same settings now auto-play.
+        ModelRoleProbe.Upsert(settings, ModelRoleProbe.FromSuccess(ModelRoleNames.Play, settings.TryResolvePlayModel()!));
+        Assert.True(CoopLaunchPolicy.GetError(false, false, "MAIN_MENU", settings) == null);
+    }
+
+    /// <summary>
+    /// Contract for the wiring: the route boolean is derived before the precondition check, reaches
+    /// the child as STS2_AGENT_AUTOPLAY, and the supported control entry is the host window's
+    /// /teammate/control rather than the companion's private session token.
+    /// </summary>
+    public static void CompanionRouteReachesTheSupportedSurfaces()
+    {
+        var launcher = AgentSourceFixture.Read("STS2AIAgent/Multiplayer/LocalDualInstanceLauncher.cs");
+        Assert.Contains("bool companionAutoPlay = true", launcher);
+        Assert.Contains("""STS2_AGENT_AUTOPLAY"] = companionAutoPlay ? "1" : "0";""", launcher);
+        Assert.Contains("LaunchCoreAsync(cancellationToken, companionAutoPlay)", launcher);
+
+        var coordinator = AgentSourceFixture.Read("STS2AIAgent/Multiplayer/DualInstanceCoordinator.cs");
+        Assert.Contains("LaunchCompanionAsync(cancellationToken, companionAutoPlay)", coordinator);
+        Assert.Contains("bool companionAutoPlay = true", coordinator);
+
+        var actions = AgentSourceFixture.Read("STS2AIAgent/Game/GameActionService.cs");
+        Assert.Contains("FirstRunSetup.Evaluate(settings).ReadyToInvite", actions);
+        Assert.Contains("requireVerifiedPlayModel: companionAutoPlay", actions);
+        Assert.Contains("LaunchDualInstanceAsync(settings, companionAutoPlay, CancellationToken.None)", actions);
+        Assert.Contains("ContinueDualInstanceAsync(settings, companionAutoPlay, CancellationToken.None)", actions);
+
+        var runtime = AgentSourceFixture.Read("STS2AIAgent/Agent/AgentRuntime.cs");
+        Assert.Contains("requireVerifiedPlayModel: companionAutoPlay", runtime);
+        Assert.Contains("public bool CompanionAutoPlay => _companionAutoPlay;", runtime);
+        // An idle companion says why it is idle instead of looking stalled.
+        Assert.Contains("等待外部接管", runtime);
+        Assert.Contains("TeammateControlResult", runtime);
+
+        // The reported route has to describe the teammate that is actually running. Recording it
+        // before the attempt would let a rejected retry (the usual one: "the teammate window is
+        // already running") relabel a teammate that the in-process loop is already playing.
+        var core = AgentSourceFixture.MethodBody(runtime, "LaunchDualInstanceCoreAsync");
+        var recorded = core.IndexOf("_companionAutoPlay = companionAutoPlay;", StringComparison.Ordinal);
+        var decided = core.IndexOf("_dualLaunchOutcome = launchResult.Ok", StringComparison.Ordinal);
+        var boundToNewSession = core.IndexOf("ReferenceEquals(previousConnection", StringComparison.Ordinal);
+        Assert.True(recorded > 0, "The launch route must be recorded somewhere.");
+        Assert.True(
+            decided > 0 && recorded > decided && boundToNewSession > 0 && recorded > boundToNewSession,
+            "The launch route must be recorded after the launch result, inside the new-session guard.");
+
+        var router = AgentSourceFixture.Read("STS2AIAgent/Server/Router.cs");
+        Assert.Contains("/teammate/control", router);
+        Assert.Contains("ControlTeammateResultAsync", router);
+        Assert.Contains("companion = BuildCompanionSessionData()", router);
+        Assert.Contains("connection.Port", router);
+        // The token authorizes this process alone, so the discovery payload must never carry it.
+        var discovery = AgentSourceFixture.MethodBody(router, "BuildCompanionSessionData");
+        Assert.False(
+            discovery.Contains("token", StringComparison.OrdinalIgnoreCase),
+            "The /health companion block must not carry the companion session token.");
+
+        // The new entry point stays loopback-only and host-only, like the control it wraps.
+        var endpoint = router.IndexOf("/teammate/control", StringComparison.Ordinal);
+        Assert.True(endpoint >= 0, "Router.cs must route /teammate/control.");
+        var routeBody = router.Substring(endpoint, Math.Min(1200, router.Length - endpoint));
+        Assert.Contains("request.IsLocal", routeBody);
+        Assert.Contains("InstanceRole.IsCompanion", routeBody);
+    }
+}

--- a/STS2AIAgent.Tests/DualLaunchOutcomeTests.cs
+++ b/STS2AIAgent.Tests/DualLaunchOutcomeTests.cs
@@ -114,7 +114,7 @@ internal static class DualLaunchOutcomeTests
         Assert.Contains("return (false,", structured);
         Assert.Contains("return (true,", structured);
         Assert.Contains("catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)", structured);
-        Assert.Contains("await HostLocalCoopResultAsync(cancellationToken)", legacy);
+        Assert.Contains("await HostLocalCoopResultAsync(cancellationToken, companionAutoPlay)", legacy);
         Assert.Contains("return result.Message;", legacy);
     }
 

--- a/STS2AIAgent.Tests/TestRunner.cs
+++ b/STS2AIAgent.Tests/TestRunner.cs
@@ -192,6 +192,8 @@ internal static class TestRunner
         yield return ("CoopStartup.HumanChoiceHoldsClock", () => Task.Run(CompanionStartupTests.BootstrapHoldsTheClockOnlyWhileAHumanChooses));
         yield return ("CoopStartup.Identity", () => Task.Run(CompanionStartupTests.HealthRequiresExactCompanionIdentity));
         yield return ("CoopStartup.Preconditions", () => Task.Run(CompanionStartupTests.LaunchPreconditionsProtectHumanRun));
+        yield return ("CoopRoute.ExternalTakeover", () => Task.Run(CoopRouteTests.UnverifiedPlayModelLaunchesForExternalTakeoverOnly));
+        yield return ("CoopRoute.SupportedSurfaces", () => Task.Run(CoopRouteTests.CompanionRouteReachesTheSupportedSurfaces));
         yield return ("CoopSave.ReadNetIds", () => Task.Run(CoopSavePrecheckTests.ReadsPlayerNetIdsFromTheSave));
         yield return ("CoopSave.NumericStringNetIds", () => Task.Run(CoopSavePrecheckTests.ReadsNumericStringNetIds));
         yield return ("CoopSave.UnreadableSaves", () => Task.Run(CoopSavePrecheckTests.UnreadableSavesYieldNoIds));

--- a/STS2AIAgent/Agent/AgentRuntime.cs
+++ b/STS2AIAgent/Agent/AgentRuntime.cs
@@ -8,6 +8,13 @@ using STS2AIAgent.Server;
 
 namespace STS2AIAgent.Agent;
 
+/// <summary>
+/// Outcome of a teammate start/pause request. <see cref="Phase"/> is the companion's own play phase
+/// ("running", "paused", "stopping") or a transport-level word ("busy", "refused"); <see cref="Ok"/>
+/// is the field to branch on, because <see cref="Message"/> is localized display text.
+/// </summary>
+internal readonly record struct TeammateControlResult(bool Ok, string Phase, string Message);
+
 internal sealed class AgentRuntime
 {
     private const string LogPrefix = "[STS2AIAgent.Runtime]";
@@ -36,6 +43,7 @@ internal sealed class AgentRuntime
     private string? _teamControlStatus;
     private volatile bool _companionReady;
     private volatile bool _companionAutoStartSuppressed;
+    private volatile bool _companionAutoPlay = true;
     private AgentSettings _settings;
     private readonly AgentLoop _loop;
     private string? _status;
@@ -97,13 +105,35 @@ internal sealed class AgentRuntime
     public bool PlayRunning => _playSession.IsActive;
     public string PlayPhase => _playSession.Phase;
     public bool TeamControlPending => _teamControlPending;
+
+    /// <summary>
+    /// False when the running teammate was launched for an external agent instead of for auto-play,
+    /// which is what an unverified play model selects. Reported on /health so a caller can tell
+    /// "paused on purpose, waiting for me" from "stopped by itself".
+    /// </summary>
+    public bool CompanionAutoPlay => _companionAutoPlay;
+
     // The idle wording is resolved on read rather than stored, so switching the game language
     // updates it too. Once real progress arrives, the recorded text takes over.
     public string TeamControlStatus => _teamControlStatus ?? Loc.T("队友控制尚未连接。");
 
     public async Task ControlTeammateAsync(bool running, CancellationToken cancellationToken)
     {
-        if (!await _remoteControlGate.WaitAsync(0, cancellationToken)) return;
+        await ControlTeammateResultAsync(running, cancellationToken);
+    }
+
+    /// <summary>
+    /// Asks the teammate window to start or pause. The structured result exists for
+    /// <c>POST /teammate/control</c>: a caller outside this process cannot read the localized
+    /// <see cref="TeamControlStatus"/> to tell a confirmed pause from a refused one.
+    /// </summary>
+    public async Task<TeammateControlResult> ControlTeammateResultAsync(bool running, CancellationToken cancellationToken)
+    {
+        if (!await _remoteControlGate.WaitAsync(0, cancellationToken))
+        {
+            return new TeammateControlResult(false, "busy", Loc.T("上一次队友控制还没有完成，请稍后重试。"));
+        }
+
         _teamControlPending = true;
         _teamControlStatus = running ? Loc.T("正在请求队友继续…") : Loc.T("正在等待队友暂停；已提交的动作会先完成。");
         RaiseChanged();
@@ -132,10 +162,12 @@ internal sealed class AgentRuntime
                 "running" => Loc.T("队友正在自动游玩。"),
                 _ => Loc.T("队友仍在停止当前任务，请稍后再次确认暂停。")
             };
+            return new TeammateControlResult(true, phase, _teamControlStatus);
         }
         catch (Exception ex)
         {
             _teamControlStatus = Loc.T("未确认队友控制结果：{0}", ex.Message);
+            return new TeammateControlResult(false, "refused", ex.Message);
         }
         finally
         {
@@ -520,12 +552,30 @@ internal sealed class AgentRuntime
 
     public Task LaunchDualInstanceAsync(AgentSettings settings, CancellationToken cancellationToken)
     {
-        return Task.Run(() => LaunchDualInstanceCoreAsync(settings, cancellationToken, continueRun: false), cancellationToken);
+        return LaunchDualInstanceAsync(settings, companionAutoPlay: true, cancellationToken);
+    }
+
+    /// <summary>
+    /// <paramref name="companionAutoPlay"/> false is the external-takeover route: the teammate is
+    /// launched for an outside agent, so no play model is required and it comes up paused.
+    /// </summary>
+    public Task LaunchDualInstanceAsync(AgentSettings settings, bool companionAutoPlay, CancellationToken cancellationToken)
+    {
+        return Task.Run(
+            () => LaunchDualInstanceCoreAsync(settings, cancellationToken, continueRun: false, companionAutoPlay),
+            cancellationToken);
     }
 
     public Task ContinueDualInstanceAsync(AgentSettings settings, CancellationToken cancellationToken)
     {
-        return Task.Run(() => LaunchDualInstanceCoreAsync(settings, cancellationToken, continueRun: true), cancellationToken);
+        return ContinueDualInstanceAsync(settings, companionAutoPlay: true, cancellationToken);
+    }
+
+    public Task ContinueDualInstanceAsync(AgentSettings settings, bool companionAutoPlay, CancellationToken cancellationToken)
+    {
+        return Task.Run(
+            () => LaunchDualInstanceCoreAsync(settings, cancellationToken, continueRun: true, companionAutoPlay),
+            cancellationToken);
     }
 
     public void ClearChat()
@@ -717,7 +767,11 @@ internal sealed class AgentRuntime
         }
     }
 
-    private async Task LaunchDualInstanceCoreAsync(AgentSettings settings, CancellationToken cancellationToken, bool continueRun)
+    private async Task LaunchDualInstanceCoreAsync(
+        AgentSettings settings,
+        CancellationToken cancellationToken,
+        bool continueRun,
+        bool companionAutoPlay)
     {
         if (!await _dualLaunchGate.WaitAsync(0, cancellationToken))
         {
@@ -740,7 +794,12 @@ internal sealed class AgentRuntime
                 return;
             }
             var screen = await new GameBridge().GetScreenAsync(cancellationToken);
-            var error = CoopLaunchPolicy.GetError(InstanceRole.IsCompanion, PlayRunning, screen, settings);
+            var error = CoopLaunchPolicy.GetError(
+                InstanceRole.IsCompanion,
+                PlayRunning,
+                screen,
+                settings,
+                requireVerifiedPlayModel: companionAutoPlay);
             if (error != null)
             {
                 _dualStatus = error;
@@ -756,8 +815,8 @@ internal sealed class AgentRuntime
                 : Loc.T("正在邀请 AI 队友，等待游戏窗口连接…");
             RaiseChanged();
             var launchResult = continueRun
-                ? await DualInstanceCoordinator.ContinueLocalCoopResultAsync(cancellationToken)
-                : await DualInstanceCoordinator.HostLocalCoopResultAsync(cancellationToken);
+                ? await DualInstanceCoordinator.ContinueLocalCoopResultAsync(cancellationToken, companionAutoPlay)
+                : await DualInstanceCoordinator.HostLocalCoopResultAsync(cancellationToken, companionAutoPlay);
             _dualStatus = launchResult.Message;
             _dualLaunchOutcome = launchResult.Ok ? DualLaunchOutcome.Succeeded : DualLaunchOutcome.Failed;
         }
@@ -777,6 +836,12 @@ internal sealed class AgentRuntime
         {
             if (!ReferenceEquals(previousConnection, LocalDualInstanceLauncher.Connection))
             {
+                // The route belongs to the teammate session that is actually running, so it is only
+                // recorded when this attempt established a new connection. A rejected retry -- most
+                // often "the teammate window is already running" -- must not relabel a teammate that
+                // was launched the other way, or /health would tell an external agent to take over a
+                // seat that is already being played by the in-process loop.
+                _companionAutoPlay = companionAutoPlay;
                 _teamConversation.Clear();
                 _teamStatus = Loc.T("队伍对话已重置。确认队友连接后，可以商量这次冒险的打法。");
             }
@@ -805,6 +870,15 @@ internal sealed class AgentRuntime
                 string.IsNullOrWhiteSpace(autoPlay)))
             {
                 StartAutoPlay();
+            }
+            else
+            {
+                // External-takeover launch: this process is a seat an outside agent drives. A
+                // companion window has no overlay (ModEntry skips it for companions), so the route is
+                // reported where it can actually be observed: play_phase stays "paused" with zero
+                // model requests, and the host window's dual status names the route.
+                SetStatus(Loc.T("等待外部接管：队友窗口已就绪，未自动开始游玩。"));
+                NoteEvent(Status);
             }
         }
         finally { _companionControlGate.Release(); }

--- a/STS2AIAgent/Game/GameActionService.cs
+++ b/STS2AIAgent/Game/GameActionService.cs
@@ -5217,11 +5217,16 @@ internal static class GameActionService
     private static async Task<ActionResponsePayload> ExecuteContinueAiTeammateAsync()
     {
         var payload = GameStateService.BuildStatePayload();
+        var settings = AgentRuntime.Instance.Settings;
+        // Same route switch as invite_ai_teammate: an unverified play model no longer blocks the
+        // launch, it only means the teammate comes up paused for an external agent.
+        var companionAutoPlay = FirstRunSetup.Evaluate(settings).ReadyToInvite;
         var error = CoopLaunchPolicy.GetError(
             InstanceRole.IsCompanion,
             AgentRuntime.Instance.PlayRunning,
             payload.screen,
-            AgentRuntime.Instance.Settings);
+            settings,
+            requireVerifiedPlayModel: companionAutoPlay);
         if (error != null)
         {
             throw new ApiException(409, "invalid_action", error, new
@@ -5276,7 +5281,7 @@ internal static class GameActionService
             });
         }
 
-        await AgentRuntime.Instance.ContinueDualInstanceAsync(AgentRuntime.Instance.Settings, CancellationToken.None);
+        await AgentRuntime.Instance.ContinueDualInstanceAsync(settings, companionAutoPlay, CancellationToken.None);
         // Same classification as invite_ai_teammate: read the structured outcome, never the localized text.
         var outcome = AgentRuntime.Instance.DualLaunchOutcome;
         var message = AgentRuntime.Instance.DualStatus;
@@ -5365,11 +5370,17 @@ internal static class GameActionService
     private static async Task<ActionResponsePayload> ExecuteInviteAiTeammateAsync()
     {
         var payload = GameStateService.BuildStatePayload();
+        var settings = AgentRuntime.Instance.Settings;
+        // A play model that passed 测试连接 is what makes auto-play possible, so it also picks the
+        // route: without one the teammate still launches, it just waits for an external agent
+        // instead of starting the loop. See the two routes in docs/api.md.
+        var companionAutoPlay = FirstRunSetup.Evaluate(settings).ReadyToInvite;
         var error = CoopLaunchPolicy.GetError(
             InstanceRole.IsCompanion,
             AgentRuntime.Instance.PlayRunning,
             payload.screen,
-            AgentRuntime.Instance.Settings);
+            settings,
+            requireVerifiedPlayModel: companionAutoPlay);
         if (error != null)
         {
             throw new ApiException(409, "invalid_action", error, new
@@ -5379,7 +5390,7 @@ internal static class GameActionService
             });
         }
 
-        await AgentRuntime.Instance.LaunchDualInstanceAsync(AgentRuntime.Instance.Settings, CancellationToken.None);
+        await AgentRuntime.Instance.LaunchDualInstanceAsync(settings, companionAutoPlay, CancellationToken.None);
         // Classify on the structured outcome. DualStatus is localized display text, so matching
         // substrings in it misreports every failure as success in a non-Chinese client.
         var outcome = AgentRuntime.Instance.DualLaunchOutcome;

--- a/STS2AIAgent/Localization/Loc.Strings.Runtime.cs
+++ b/STS2AIAgent/Localization/Loc.Strings.Runtime.cs
@@ -25,7 +25,15 @@ internal static partial class Loc
         map["读档开房失败：{0}"] = "Loading the saved run failed: {0}";
         map["正在继续联机存档，等待队友窗口连回…"] = "Continuing the saved co-op run; waiting for the teammate window to reconnect…";
         map["继续联机存档失败：{0}"] = "Continuing the saved co-op run failed: {0}";
-        map["{0}。已按存档开好本地房，等队友窗口连回来后两边各点一次出发。"] = "{0}. The saved run is hosted locally; once the teammate window reconnects, both sides click Embark once.";
+        map["{0}。已按存档开好本地房，等队友窗口连回来后两边各点一次出发；{1}"] = "{0}. The saved run is hosted locally; once the teammate window reconnects, both sides click Embark once; {1}";
+        map["队友连回来后会自己出牌。"] = "the teammate plays its own cards once it reconnects.";
+        map["队友连回来后停在原地等待外部接管，不会自己出牌。"] =
+            "the teammate waits to be taken over from outside once it reconnects instead of playing its own cards.";
+        // The two halves of the route switch (Agent/AgentRuntime.cs).
+        map["等待外部接管：队友窗口已就绪，未自动开始游玩。"] =
+            "Waiting for an external takeover: the teammate window is ready and has not started playing on its own.";
+        map["上一次队友控制还没有完成，请稍后重试。"] =
+            "The previous teammate control has not finished yet. Try again shortly.";
         map["找不到读档方法 StartLoad。"] = "Could not find the StartLoad method.";
         map["读档开房失败：当前弹窗是 {0}。常见原因是本地直连端口 33771 仍被上一局占着；可重启游戏后再试。"] = "Loading the saved run failed: the open modal is {0}. The usual cause is the local direct port 33771 still held by the previous run; restart the game and try again.";
         map["读档后没有进入多人读档界面。"] = "The multiplayer load screen did not open after loading the save.";

--- a/STS2AIAgent/Localization/Loc.Strings.Support.cs
+++ b/STS2AIAgent/Localization/Loc.Strings.Support.cs
@@ -46,8 +46,12 @@ internal static partial class Loc
 
         // Multiplayer/DualInstanceCoordinator.cs
         map["创建 4 人大厅失败：{0}"] = "Could not create the 4-player lobby: {0}";
-        map["{0}。本机已创建 4 人大厅，请选角色后 Ready 开局。你打自己的角色；AI 会自动加入、点开局并打另一个角色。"] =
-            "{0}. A 4-player local lobby is ready. Pick your character and press Ready to start; you play your own character while the AI joins, starts the run, and plays the other one.";
+        map["{0}。本机已创建 4 人大厅，请选角色后 Ready 开局。你打自己的角色；{1}"] =
+            "{0}. A 4-player local lobby is ready. Pick your character and press Ready to start; you play your own character while {1}";
+        map["AI 会自动加入、点开局并打另一个角色。"] =
+            "the AI joins, starts the run, and plays the other one.";
+        map["AI 会自动加入并点开局，然后停在原地等待外部接管，不会自己出牌。"] =
+            "the AI joins and starts the run, then waits to be taken over from outside instead of playing its own cards.";
         map["找不到 FastHost 命令行参数表。"] = "Could not find the FastHost command-line argument table.";
         map["FastHost 命令行参数表类型无法写入：{0}"] =
             "Cannot write to the FastHost command-line argument table type: {0}";

--- a/STS2AIAgent/Multiplayer/CompanionConnection.cs
+++ b/STS2AIAgent/Multiplayer/CompanionConnection.cs
@@ -23,6 +23,12 @@ internal sealed class CompanionConnection
         _http = http ?? Http;
     }
 
+    /// <summary>Loopback port the companion instance listens on.</summary>
+    public int Port => _port;
+
+    /// <summary>Process id this session was verified against.</summary>
+    public int ProcessId => _pid;
+
     public static string CreateToken() => Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
 
     public static bool IsAuthorized(string? expected, string? supplied)

--- a/STS2AIAgent/Multiplayer/CoopLaunchPolicy.cs
+++ b/STS2AIAgent/Multiplayer/CoopLaunchPolicy.cs
@@ -135,9 +135,50 @@ internal static class CoopLaunchPolicy
 
     public static string? GetError(bool isCompanion, bool autoPlayRunning, string screen, ResolvedModel? model)
     {
+        var structural = GetStructuralError(isCompanion, autoPlayRunning, screen);
+        return structural ?? GetModelError(model);
+    }
+
+    public static string? GetError(bool isCompanion, bool autoPlayRunning, string screen, AgentSettings settings)
+    {
+        return GetError(isCompanion, autoPlayRunning, screen, settings, requireVerifiedPlayModel: true);
+    }
+
+    /// <summary>
+    /// The preconditions a launch request must meet. <paramref name="requireVerifiedPlayModel"/> is
+    /// the switch between the two supported routes: auto-play needs a play model that passed
+    /// 测试连接, while handing the window to an external agent never calls the model at all, so only
+    /// the structural conditions apply and the teammate comes up paused.
+    /// </summary>
+    public static string? GetError(
+        bool isCompanion,
+        bool autoPlayRunning,
+        string screen,
+        AgentSettings settings,
+        bool requireVerifiedPlayModel)
+    {
+        var structural = GetStructuralError(isCompanion, autoPlayRunning, screen);
+        if (structural != null) return structural;
+        if (!requireVerifiedPlayModel) return null;
+
+        var model = GetModelError(settings.TryResolvePlayModel());
+        if (model != null) return model;
+        var firstRun = FirstRunSetup.Evaluate(settings);
+        if (!firstRun.ReadyToInvite) return firstRun.Hint;
+        return null;
+    }
+
+    /// <summary>Conditions that hold for both routes: who is asking, from where, and into what.</summary>
+    public static string? GetStructuralError(bool isCompanion, bool autoPlayRunning, string screen)
+    {
         if (isCompanion) return Loc.T("当前窗口已是 AI 队友。请在你的主窗口邀请队友。");
         if (autoPlayRunning) return Loc.T("请先暂停当前角色的自动游玩，再邀请 AI 队友。");
         if (screen != "MAIN_MENU") return Loc.T("请先回到主菜单，再邀请 AI 队友组队。");
+        return null;
+    }
+
+    private static string? GetModelError(ResolvedModel? model)
+    {
         if (model == null || string.IsNullOrWhiteSpace(model.Model.Model)) return FirstRunSetup.SettingsHint;
         if (!Uri.TryCreate(model.Endpoint.BaseUrl, UriKind.Absolute, out var endpoint) ||
             endpoint.Scheme is not ("http" or "https"))
@@ -145,15 +186,6 @@ internal static class CoopLaunchPolicy
             return Loc.T("模型端点地址无效，请在设置中填写完整的 HTTP 或 HTTPS 地址。");
         }
 
-        return null;
-    }
-
-    public static string? GetError(bool isCompanion, bool autoPlayRunning, string screen, AgentSettings settings)
-    {
-        var structural = GetError(isCompanion, autoPlayRunning, screen, settings.TryResolvePlayModel());
-        if (structural != null) return structural;
-        var firstRun = FirstRunSetup.Evaluate(settings);
-        if (!firstRun.ReadyToInvite) return firstRun.Hint;
         return null;
     }
 

--- a/STS2AIAgent/Multiplayer/DualInstanceCoordinator.cs
+++ b/STS2AIAgent/Multiplayer/DualInstanceCoordinator.cs
@@ -12,9 +12,9 @@ internal static class DualInstanceCoordinator
 {
     private const string LogPrefix = "[STS2AIAgent.DualInstance]";
 
-    public static async Task<string> HostLocalCoopAsync(CancellationToken cancellationToken)
+    public static async Task<string> HostLocalCoopAsync(CancellationToken cancellationToken, bool companionAutoPlay = true)
     {
-        var result = await HostLocalCoopResultAsync(cancellationToken);
+        var result = await HostLocalCoopResultAsync(cancellationToken, companionAutoPlay);
         return result.Message;
     }
 
@@ -24,7 +24,9 @@ internal static class DualInstanceCoordinator
     /// that need to distinguish success from failure must read <c>Ok</c> instead of parsing the
     /// localized message. Cancellation still propagates.
     /// </summary>
-    public static async Task<(bool Ok, string Message)> HostLocalCoopResultAsync(CancellationToken cancellationToken)
+    public static async Task<(bool Ok, string Message)> HostLocalCoopResultAsync(
+        CancellationToken cancellationToken,
+        bool companionAutoPlay = true)
     {
         if (await GetScreenAsync() != "MAIN_MENU")
         {
@@ -45,19 +47,24 @@ internal static class DualInstanceCoordinator
             return (false, Loc.T("创建 4 人大厅失败：{0}", ex.Message));
         }
 
-        var launch = await LocalDualInstanceLauncher.LaunchCompanionAsync(cancellationToken);
+        var launch = await LocalDualInstanceLauncher.LaunchCompanionAsync(cancellationToken, companionAutoPlay);
         if (!launch.Ok)
         {
             return (false, launch.Message);
         }
 
-        return (true, Loc.T("{0}。本机已创建 4 人大厅，请选角色后 Ready 开局。你打自己的角色；AI 会自动加入、点开局并打另一个角色。", launch.Message));
+        var howItPlays = companionAutoPlay
+            ? Loc.T("AI 会自动加入、点开局并打另一个角色。")
+            : Loc.T("AI 会自动加入并点开局，然后停在原地等待外部接管，不会自己出牌。");
+        return (true, Loc.T("{0}。本机已创建 4 人大厅，请选角色后 Ready 开局。你打自己的角色；{1}", launch.Message, howItPlays));
     }
 
     /// <summary>
     /// Host side: inject fastmp so the saved multiplayer run is hosted over local ENet, load it, then launch the companion to rejoin.
     /// </summary>
-    public static async Task<(bool Ok, string Message)> ContinueLocalCoopResultAsync(CancellationToken cancellationToken)
+    public static async Task<(bool Ok, string Message)> ContinueLocalCoopResultAsync(
+        CancellationToken cancellationToken,
+        bool companionAutoPlay = true)
     {
         if (await GetScreenAsync() != "MAIN_MENU")
         {
@@ -101,13 +108,16 @@ internal static class DualInstanceCoordinator
             return (false, Loc.T("读档开房失败：{0}", ex.Message));
         }
 
-        var launch = await LocalDualInstanceLauncher.LaunchCompanionAsync(cancellationToken);
+        var launch = await LocalDualInstanceLauncher.LaunchCompanionAsync(cancellationToken, companionAutoPlay);
         if (!launch.Ok)
         {
             return (false, launch.Message);
         }
 
-        return (true, Loc.T("{0}。已按存档开好本地房，等队友窗口连回来后两边各点一次出发。", launch.Message));
+        var howItPlays = companionAutoPlay
+            ? Loc.T("队友连回来后会自己出牌。")
+            : Loc.T("队友连回来后停在原地等待外部接管，不会自己出牌。");
+        return (true, Loc.T("{0}。已按存档开好本地房，等队友窗口连回来后两边各点一次出发；{1}", launch.Message, howItPlays));
     }
 
     public static async Task<bool> RunCompanionBootstrapAsync(CancellationToken cancellationToken)

--- a/STS2AIAgent/Multiplayer/LocalDualInstanceLauncher.cs
+++ b/STS2AIAgent/Multiplayer/LocalDualInstanceLauncher.cs
@@ -148,7 +148,12 @@ internal static class LocalDualInstanceLauncher
         }
     }
 
-    public static async Task<DualLaunchResult> LaunchCompanionAsync(CancellationToken cancellationToken)
+    /// <summary>
+    /// <paramref name="companionAutoPlay"/> is written to the child as <c>STS2_AGENT_AUTOPLAY</c>.
+    /// False is the external-takeover route: the companion joins the run and then waits, because
+    /// nothing in that route calls the play model.
+    /// </summary>
+    public static async Task<DualLaunchResult> LaunchCompanionAsync(CancellationToken cancellationToken, bool companionAutoPlay = true)
     {
         if (!await LaunchGate.WaitAsync(0, cancellationToken))
         {
@@ -170,7 +175,7 @@ internal static class LocalDualInstanceLauncher
             _companionProcess?.Dispose();
             _companionProcess = null;
             Connection = null;
-            return await LaunchCoreAsync(cancellationToken);
+            return await LaunchCoreAsync(cancellationToken, companionAutoPlay);
         }
         finally
         {
@@ -178,7 +183,7 @@ internal static class LocalDualInstanceLauncher
         }
     }
 
-    private static async Task<DualLaunchResult> LaunchCoreAsync(CancellationToken cancellationToken)
+    private static async Task<DualLaunchResult> LaunchCoreAsync(CancellationToken cancellationToken, bool companionAutoPlay)
     {
         cancellationToken.ThrowIfCancellationRequested();
         var exe = ResolveGameExe();
@@ -265,7 +270,7 @@ internal static class LocalDualInstanceLauncher
         startInfo.Environment["STS2_MULTIPLAYER_HOST_IP"] = "127.0.0.1";
         startInfo.Environment["STS2_MULTIPLAYER_NET_ID"] = companionClientId
             .ToString(System.Globalization.CultureInfo.InvariantCulture);
-        startInfo.Environment["STS2_AGENT_AUTOPLAY"] = "1";
+        startInfo.Environment["STS2_AGENT_AUTOPLAY"] = companionAutoPlay ? "1" : "0";
         startInfo.Environment["STS2_AGENT_SETTINGS_PATH"] = companionSettingsPath;
         var sessionToken = CompanionConnection.CreateToken();
         startInfo.Environment[CompanionConnection.TokenEnvironment] = sessionToken;

--- a/STS2AIAgent/Server/Router.cs
+++ b/STS2AIAgent/Server/Router.cs
@@ -138,6 +138,55 @@ internal static class Router
                 return;
             }
 
+            if (request.HttpMethod == "POST" && request.Url?.AbsolutePath == "/teammate/control")
+            {
+                if (!request.IsLocal)
+                {
+                    throw new ApiException(403, "local_only", "Teammate control is only available on loopback.");
+                }
+
+                if (InstanceRole.IsCompanion)
+                {
+                    throw new ApiException(409, "not_host", "Only the host window can control the AI teammate.");
+                }
+
+                if (request.ContentLength64 < 0 || request.ContentLength64 > 16000)
+                {
+                    throw new ApiException(400, "invalid_request", "A bounded JSON body is required.");
+                }
+
+                var teammateControl = await ReadJsonBodyAsync<SessionControlRequest>(request, cancellationToken);
+                if (teammateControl?.running is null)
+                {
+                    throw new ApiException(400, "invalid_request", "running must be a boolean.");
+                }
+
+                var control = await AgentRuntime.Instance.ControlTeammateResultAsync(
+                    teammateControl.running.Value, cancellationToken);
+                if (!control.Ok)
+                {
+                    // Retryable on purpose: the usual causes are a launch still in progress, a
+                    // previous control that has not finished, or a pause the teammate has not
+                    // confirmed yet -- all of which clear on their own.
+                    throw new ApiException(409, "teammate_control_failed", control.Message, retryable: true);
+                }
+
+                await WriteJsonAsync(response, 200, new
+                {
+                    ok = true,
+                    request_id = requestId,
+                    data = new
+                    {
+                        phase = control.Phase,
+                        play_running = AgentRuntime.Instance.PlayRunning,
+                        play_phase = AgentRuntime.Instance.PlayPhase,
+                        companion_auto_play = AgentRuntime.Instance.CompanionAutoPlay
+                    }
+                });
+                statusCode = 200;
+                return;
+            }
+
             if (IsMcpPath(request.Url?.AbsolutePath))
             {
                 var mcp = NativeMcpServer.Runtime;
@@ -296,8 +345,35 @@ internal static class Router
             session_requests = AgentRuntime.Instance.SessionRequests,
             companion_process_alive = LocalDualInstanceLauncher.CompanionProcessAlive,
             companion_process_exited = LocalDualInstanceLauncher.CompanionProcessExited,
+            companion = BuildCompanionSessionData(),
             dual_status = AgentRuntime.Instance.DualStatus,
             team_control_status = AgentRuntime.Instance.TeamControlStatus
+        };
+    }
+
+    /// <summary>
+    /// Present on the host window once a teammate session exists, so a caller can find the
+    /// companion API and tell which route this launch took. The session token is deliberately
+    /// absent: it authorizes control from this process only, and POST /teammate/control is the
+    /// supported path for everyone else.
+    /// </summary>
+    private static object? BuildCompanionSessionData()
+    {
+        var connection = InstanceRole.IsCompanion ? null : LocalDualInstanceLauncher.Connection;
+        // The launcher keeps the last session handle so a retry cannot start a third window; that
+        // handle must not outlive the process it points at, or /health would advertise an API port
+        // nobody is listening on.
+        if (connection == null || LocalDualInstanceLauncher.CompanionProcessExited)
+        {
+            return null;
+        }
+
+        return new
+        {
+            api_host = "127.0.0.1",
+            api_port = connection.Port,
+            process_id = connection.ProcessId,
+            auto_play = AgentRuntime.Instance.CompanionAutoPlay
         };
     }
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -60,6 +60,8 @@
 | `local_only` | 403 | 该端点只接受本机（loopback）请求 | 否 |
 | `companion_session_required` | 403 | 需要有效的 AI 队友会话令牌（见下） | 否 |
 | `companion_not_ready` | 409 | 队友实例尚未就绪，无法响应控制 | 是 |
+| `not_host` | 409 | 在 `companion` 实例上调用了只属于主窗口的 `POST /teammate/control` | 否 |
+| `teammate_control_failed` | 409 | `POST /teammate/control` 未能确认队友的开始 / 暂停：还没有组队、队友进程已退出、上一条控制未完成，或队友没有确认。失败原因在 `error.message` 里 | 是 |
 | `invite_failed` | 409 | 邀请 AI 队友失败（主菜单状态或配置不满足） | 是 |
 | `continue_failed` | 409 | 读档开房流程启动后失败（读档界面没打开，或本地直连端口 33771 仍被上一局占用，重启游戏后可重试）；前置条件不满足（不在主菜单、没有联机存档、模型未验证）仍返回 `invalid_action` | 是 |
 | `invalid_action`（`continue_ai_teammate` 的 NetId 前置检查） | 409 | 读档**之前**的只读比对不通过：本机 NetId 不在联机存档 `players[].net_id` 里（游戏会拒绝读档，并把这局存档改名成 `*.VAL.corrupt` 挪走且不还原），或本次要拉起的 AI 队友 NetId 不在存档里（加入会被 `NotInSaveGame` 拒绝）。详情带 `save_player_net_ids`，以及 `local_player_id` 或 `companion_client_id` | 否 |
@@ -157,6 +159,7 @@
     "session_requests": 12,
     "companion_process_alive": false,
     "companion_process_exited": false,
+    "companion": null,
     "dual_status": "尚未启动双开。",
     "team_control_status": "队友控制尚未连接。"
   }
@@ -179,6 +182,7 @@
 | `stop_kind` | string\|null | 上次自动游玩停止的类别，未停止过为 `null` |
 | `session_requests` | integer | 本会话已消耗的模型请求次数（可由「重置本会话统计」清零） |
 | `companion_process_alive` / `companion_process_exited` | boolean | AI 队友进程是否在运行 / 是否已退出 |
+| `companion` | object\|null | 仅主窗口、且本次组队的队友进程仍在运行时存在（队友退出后回到 `null`）。`api_host` / `api_port` / `process_id` 是队友实例的 HTTP API，用来直接对队友的 `GET /state` 与 `POST /action` 编程；`auto_play` 说明这次组队走的是 AI 自走（`true`）还是外部接管（`false`）。队友会话令牌**不会**出现在任何响应里 |
 | `dual_status` / `team_control_status` | string | 双开与队友控制的人类可读状态 |
 
 ### `stop_kind` 取值
@@ -1099,9 +1103,11 @@ compact 里的位置与 `/state` 不同，但同名同源、同为新增键；`/
 - `confirm_modal` — 确认阻塞弹窗
 - `dismiss_modal` — 关闭阻塞弹窗
 - `return_to_main_menu` — 返回主菜单
-- `invite_ai_teammate` — 邀请 AI 队友
+- `invite_ai_teammate` — 邀请 AI 队友（拉起第二个游戏实例）。游玩模型已验证时队友自动打；未配置或未验证时队友照常拉起、照常进图，但停在原地等外部接管，见「两条组队路线」。
 - `continue_ai_teammate` — 继续上次的联机存档并重新拉起 AI 队友（仅主机主菜单且存在联机存档时出现在 `available_actions`；读档流程失败返回 `continue_failed`）。读档前会只读比对存档 `players[].net_id` 与本机 NetId（离线／`-fastmp` 主机即启动参数 `--clientId`，未传为 1）和队友 NetId（主机 id + 1）：任一不匹配返回**不可重试**的 `invalid_action`，以免触发游戏把该存档改名成 `*.VAL.corrupt` 的破坏性读档。
 <!-- END ACTION CONTRACT -->
+
+这两个动作共用同一档拆分：游玩模型未验证时，`invite_ai_teammate` 与 `continue_ai_teammate` 照常拉起队友，只是队友不自动开始游玩，等你接管。两条路线各自的前置要求见「两条组队路线」。
 
 ### 请求体
 
@@ -1210,6 +1216,64 @@ data: }
 | `available_actions_changed` | 可用动作集合变化 |
 
 2026-09-11 在隔离副本上实测：45 秒窗口内收到 `: stream opened`、2 次 `: heartbeat` 与 123 行帧内容，事件类型覆盖 `stream_ready`、`screen_changed`（SHOP→COMBAT）、`combat_started`、`player_action_window_opened`、`available_actions_changed`。证据 `build/validation-2026-09-11/sse-frames.jsonl`（gitignore）。
+
+---
+
+## 两条组队路线
+
+「邀请 AI 队友」有两条路线，前置要求不同。走哪条由**游玩模型是否已验证**决定（代码里就是 `FirstRunSetup.Evaluate(settings).ReadyToInvite`），调用方不需要额外参数。
+
+| | AI 自走 | 外部接管 |
+| --- | --- | --- |
+| 前置要求 | 主菜单、本窗口不是队友实例、当前角色没有自动游玩，**并且**游玩模型已配置、端点合法、`测试连接` 已通过 | 只要前三条结构条件；**模型可以完全没配** |
+| 队友进程 | 加入大厅 → 点开局 → 进图后自动出牌 | 加入大厅 → 点开局 → 进图后**停在原地**：子进程拿到 `STS2_AGENT_AUTOPLAY=0`，`/health` 报 `play_phase: "paused"` 与 `session_requests: 0`，从不出牌也从不调用模型 |
+| 谁在打 | 队友进程里的模型循环 | 外部 agent 自己调队友实例的 `GET /state` 与 `POST /action` |
+| 开始 / 暂停 | 主窗口的「暂停队友 / 继续游玩」，或 `POST /teammate/control` | 同上；之后若补齐并验证了游玩模型，`running: true` 会让队友开始自己打 |
+| 怎么识别 | `/health` 的 `companion.auto_play` 为 `true` | 同一字段为 `false` |
+
+两条路线共用同一组结构条件，所以拆分只在模型这一档，不构成绕过：不是队友实例、当前角色没有正在跑的自动游玩、必须在主菜单，缺一条都拉不起来。
+
+外部接管路线下，队友自己的 `POST /action` 一直可用，并且只作用于**它自己的角色**（`CompanionActPolicy`，越界返回 403 `forbidden_actor`）。队友起来后也不会因为没有模型而报错：这条路线根本不调用模型。
+
+```powershell
+# 未配置任何模型也能拉起队友；它起来后停在原地等接管
+Invoke-RestMethod -Uri 'http://127.0.0.1:8080/action' -Method POST -ContentType 'application/json' `
+  -Body '{"action":"invite_ai_teammate"}'
+
+# 找到队友实例的 HTTP API（端口通常不是 8080，以响应为准）
+(Invoke-RestMethod -Uri 'http://127.0.0.1:8080/health').data.companion
+
+# 让队友开始 / 暂停自动游玩：走主窗口，不需要队友会话令牌
+Invoke-RestMethod -Uri 'http://127.0.0.1:8080/teammate/control' -Method POST -ContentType 'application/json' `
+  -Body '{"running":true}'
+```
+
+---
+
+## `POST /teammate/control`
+
+主窗口上的受支持队友控制入口：外部 agent 用它开始 / 暂停本次组队的队友实例，**不需要**持有 `X-STS2-Companion-Session`——主窗口自己拿着该令牌，并由它去调队友实例的 `POST /companion/control`。
+
+- 鉴权：仅 loopback（非本机 403 `local_only`），且仅主窗口（在 `companion` 实例上 409 `not_host`）。与其他本机端点同级；令牌不下发给调用方，也不出现在任何响应里。
+- 请求体：`{"running": true|false}`，`running` 必须是布尔值
+- 响应：`data.phase` 是队友回报的阶段（`running` / `paused` / `stopping`），`data.play_running` / `data.play_phase` 是主窗口视角，`data.companion_auto_play` 是本次组队的路线
+- 失败：未组队、队友进程已退出、上一条控制未完成、或队友没有确认时返回 409 `teammate_control_failed`（可重试）
+- `running: true` 需要已验证的游玩模型，与游戏内「继续游玩」按钮同一道门禁；未验证时该请求失败，队友保持暂停
+
+### 响应示例
+
+```json
+{
+  "ok": true,
+  "request_id": "req_20260913_101500_0001_7",
+  "data": {
+    "phase": "paused",
+    "play_running": false,
+    "play_phase": "paused",
+    "companion_auto_play": false
+  }
+}
+```
 
 ---
 

--- a/docs/live-validation-checklist.md
+++ b/docs/live-validation-checklist.md
@@ -130,6 +130,52 @@ the page's furniture as `capstone.options`. Verified live in two passes on one i
 - `BESTIARY` was not opened live: this profile's compendium hub draws no bestiary tile (`NBestiary.CanBeShown()`
   gates it). The mapping and the exclusion from decision screens exist for the build that shows it.
 
+### External-takeover route (issue #85)
+
+Verified 2026-09-13 against a build carrying the issue-#85 change, on the same isolated offline host
+(`--windowed --force-steam off --clientId 2026091001`, API on `18080`) driven entirely over HTTP, with
+a settings file whose endpoint points at a **dead** port (`127.0.0.1:18199`) and **no `roleTests` entries
+at all** — nothing configured and nothing verified. Script: `build/validation-2026-09-13/verify-takeover.ps1`,
+evidence `takeover-evidence.jsonl` (both gitignored). Every step below is one run of that script; the
+invite was a real call, not a resumed session.
+
+- **`invite_ai_teammate` launches with nothing verified.** It returned 200 `completed` on the first call,
+  the second process came up as `role=companion` on `18081`, and its message no longer promises auto-play:
+  「第二实例已就绪…本机已创建 4 人大厅，请选角色后 Ready 开局。你打自己的角色；AI 会自动加入并点开局，
+  然后停在原地等待外部接管，不会自己出牌。」 The model gate is what the route switch drops, not the launch.
+- **The host discovers the companion API.** `GET /health` on the host carried
+  `"companion": {"api_host":"127.0.0.1","api_port":18081,"process_id":64872,"auto_play":false}`, and that port
+  answered `role=companion` / `status=ready`. No session token appears anywhere in the response.
+- **The teammate really is idle, and really never called a model.** After the shared run was reached
+  (`MAP`) and 20 s of dwell: `play_running=false`, `play_phase="paused"`, `session_requests=0`,
+  `stop_kind=null`. Zero requests is the part that matters — the endpoint was dead, so a single model call
+  would have shown up as a config/network stop instead of passing quietly.
+- **It is drivable by an outside agent.** The companion advertised `choose_map_node` on `MAP`, so the
+  external path is `GET /state` + `POST /action` against `18081`, exactly as the issue described.
+- **`POST /teammate/control` is the supported start/pause.** `{"running":false}` → 200 with
+  `phase:"paused"`, `play_running:false`, `play_phase:"paused"`, `companion_auto_play:false`.
+  `{"running":true}` → 409 `teammate_control_failed` naming the unverified play model, which is the
+  intended behaviour: this route can park the teammate, and starting the in-process loop still needs the
+  verified model the in-game “Resume” button requires. `{"running":"yes"}` → 400 `invalid_request`.
+- **The companion window has no overlay at all** (`ModEntry` skips it for companions), which is why the
+  route is reported on `/health` and the host status line rather than in the second window.
+- **After the companion process is killed**, `/health` drops the `companion` block back to `null` while
+  `companion_process_exited` turns `true` — the discovery block never points at a dead port.
+
+### Found in this session
+
+- **The route flag was recorded before the attempt, not after it.** A rejected retry — the usual one being
+  “the teammate window is already running” — overwrote `_companionAutoPlay` before the launch was even
+  attempted, so `/health` would report `auto_play:false` for a teammate that the in-process loop was
+  actively playing, inviting an external agent to take over a seat already in use. The flag is now written
+  only when the attempt established a new connection (`CoopRoute.SupportedSurfaces` pins the ordering).
+- **`teammate_control_failed` was documented retryable but returned `retryable:false`.** The usual causes
+  (a launch still in progress, an unfinished previous control, an unconfirmed pause) all clear on their own,
+  so the code now sets `retryable: true` to match the documented contract.
+- **`/health` kept advertising a companion port after that process exited.** The launcher deliberately keeps
+  the last session handle so a retry cannot start a third window, and the discovery block inherited that
+  persistence. It now returns `null` once `CompanionProcessExited` is set.
+
 ### Environment note for isolated runs
 
 A brand-new `--clientId` directory gets a default `settings.save` whose `mod_settings` is `null`, and the


### PR DESCRIPTION
Closes #85.

Inviting a teammate used to require a play model that had passed the connection test, so a player who
wanted to fight their own character while an outside agent drove the teammate window had to fake a
passing model first — which is exactly the workaround the issue was filed about.

## What changed

**The precondition is split by route.** Both routes still require the same structural conditions (not the
companion instance, no auto-play already running on this character, main menu) — those are now a named
policy, `CoopLaunchPolicy.GetStructuralError`, so the split is visibly scoped to the model gate:

| | AI auto-play | External takeover |
| --- | --- | --- |
| Chosen when | the play model passed the connection test | it did not (missing, unverified, or failed) |
| Preconditions | structural + model configured, endpoint valid, verified | structural only — **nothing configured at all works** |
| Teammate | joins, starts the run, plays its own character | joins, starts the run, then parks |
| Model calls | the in-process loop | none — the child gets `STS2_AGENT_AUTOPLAY=0` |
| How to tell | `/health.companion.auto_play` is `true` | `false` |

`invite_ai_teammate` and `continue_ai_teammate` share the switch; the launch status line now says which
route is running instead of promising auto-play either way.

**A supported control entry for an outside agent.** #85 pointed out the only two companion endpoints are
gated by a session token that never leaves the host process. The host window therefore gains
`POST /teammate/control` — it starts or pauses the teammate using the token it already holds, so the caller
never needs it. Loopback-only and host-only, matching the existing local endpoints rather than being weaker.

**Discovery instead of a guessed port.** `GET /health` on the host reports
`companion: { api_host, api_port, process_id, auto_play }` once a teammate is connected, so a caller can
drive the teammate’s own `GET /state` + `POST /action` without guessing that the port is host + 1. The
session token is deliberately not part of it.

## Three defects found while verifying live (all fixed here)

- The route flag was recorded **before** the launch check, so a rejected retry — usually “the teammate
  window is already running” — could report `auto_play: false` for a teammate the in-process loop was
  actively playing, inviting an outside agent to take over a seat already in use. It is now written only
  when the attempt establishes a new connection, and `CoopRoute.SupportedSurfaces` pins that ordering.
- `/health` kept advertising a companion API port after that process exited; it now returns `null` while
  `companion_process_exited` turns `true`.
- `teammate_control_failed` was documented retryable but returned `retryable: false`.

## Live acceptance

Isolated offline host (`--windowed --force-steam off --clientId 2026091001`, API `18080`) driven entirely
over HTTP, with an endpoint pointing at a **dead** port and **no role-test records at all**:

- `invite_ai_teammate` → 200 `completed` on the first call; companion came up as `role=companion` on `18081`;
- `/health` carried `companion: {api_port: 18081, auto_play: false}`;
- after reaching the shared run and 20 s of dwell: `play_running=false`, `play_phase="paused"`,
  `session_requests=0`, `stop_kind=null` — zero model requests, which is the point, since the dead endpoint
  would have turned any model call into a visible config/network stop;
- the companion advertised `choose_map_node`, so it is drivable through its own API;
- `POST /teammate/control {"running":false}` → 200; `{"running":true}` → 409 naming the unverified model;
  `{"running":"yes"}` → 400.

The real Steam profile’s 183 save files were compared byte-for-byte before and after and are unchanged.
Note recorded in `docs/live-validation-checklist.md`: the companion window has **no** overlay at all
(`ModEntry` skips it for companions), so this route is reported on `/health` and the host status line.

## Checks

- `dotnet build STS2AIAgent/STS2AIAgent.csproj -c Release` — 0 warnings, 0 errors
- `STS2AIAgent.Tests` — 367 pass / 0 fail (2 new: `CoopRoute.ExternalTakeover`, `CoopRoute.SupportedSurfaces`)
- `python scripts/check_verification_gates.py` — 7/7
- `mcp_server` unittest — 165 OK
- `python scripts/check_release_package.py --source-root .` — OK

## Docs

`docs/api.md` documents the two routes side by side, `POST /teammate/control` (status codes, error codes,
body, response fields), and the new `/health` field; both READMEs gained an “Option C: hand the teammate
window to an external agent”. The action contract block is unchanged (no action names added), so the
`api-doc` gate still matches at 56 actions.

## Summary by Sourcery

Enable verified-model co-op auto-play or model-free external takeover while providing a supported host control and discovery path for the teammate window.

New Features:
- Add an external-takeover co-op route that launches a teammate without a verified play model and leaves it paused for outside control.
- Add host-side teammate control and companion API discovery through the health endpoint without exposing session tokens.

Bug Fixes:
- Correct co-op route reporting so health data reflects the teammate session that actually launched.
- Stop advertising companion API details after the companion process exits.
- Mark teammate control failures as retryable.

Enhancements:
- Split co-op launch validation into shared structural checks and route-specific model requirements.
- Expose route-specific status and behavior for both invite and continue teammate flows.

Documentation:
- Document the two co-op routes, host teammate control endpoint, companion discovery data, and external-agent usage in English and Chinese README and API documentation.
- Record live validation results for the external-takeover route.

Tests:
- Add coverage for route-specific launch gates and supported control and discovery surfaces.

Chores:
- Add unreleased changelog entries for external teammate takeover and related fixes.