### PR TITLE
fix(coop): share one model gate across every start entry, and record the external-agent run (#85)

### DIFF
--- a/STS2AIAgent.Tests/CoopRouteTests.cs
+++ b/STS2AIAgent.Tests/CoopRouteTests.cs
@@ -107,4 +107,35 @@ internal static class CoopRouteTests
         Assert.Contains("request.IsLocal", routeBody);
         Assert.Contains("InstanceRole.IsCompanion", routeBody);
     }
+
+    /// <summary>
+    /// Every way of starting the in-process loop is one decision, so all of them answer to the same
+    /// model gate. The companion's own /session/control used to skip it, which left a caller able to
+    /// start a model loop that the host's Resume button, /companion/control and /teammate/control all
+    /// refuse. Pausing stays ungated: nothing should be stuck unable to stop it.
+    /// </summary>
+    public static void EveryStartEntryPointSharesTheModelGate()
+    {
+        var runtime = AgentSourceFixture.Read("STS2AIAgent/Agent/AgentRuntime.cs");
+        var companion = AgentSourceFixture.MethodBody(runtime, "SetCompanionRunningAsync");
+
+        var gate = companion.IndexOf("FirstRunSetup.Evaluate(Settings)", StringComparison.Ordinal);
+        var start = companion.IndexOf("StartAutoPlay()", StringComparison.Ordinal);
+        var pause = companion.IndexOf("RequestPause()", StringComparison.Ordinal);
+        Assert.True(gate > 0, "The companion control path must check the play model before it starts the loop.");
+        Assert.True(start > gate, "The model gate must come before StartAutoPlay on the companion.");
+        Assert.True(pause > 0, "Pausing must stay available on the companion.");
+        Assert.False(
+            companion.IndexOf("FirstRunSetup.Evaluate(Settings)", pause, StringComparison.Ordinal) > 0 &&
+                companion.LastIndexOf("FirstRunSetup.Evaluate(Settings)", StringComparison.Ordinal) > pause,
+            "The pause branch must not be behind the model gate.");
+
+        // The two other starts keep their gates; a regression there is the same bug from the host side.
+        var host = AgentSourceFixture.MethodBody(runtime, "ControlTeammateResultAsync");
+        Assert.True(
+            host.IndexOf("FirstRunSetup.Evaluate(Settings)", StringComparison.Ordinal) > 0,
+            "POST /teammate/control must keep its model gate.");
+        var overlay = AgentSourceFixture.Read("STS2AIAgent/Ui/AgentOverlayHost.cs");
+        Assert.Contains("AgentRuntime.Instance.ControlTeammateAsync(true", overlay);
+    }
 }

--- a/STS2AIAgent.Tests/TestRunner.cs
+++ b/STS2AIAgent.Tests/TestRunner.cs
@@ -194,6 +194,7 @@ internal static class TestRunner
         yield return ("CoopStartup.Preconditions", () => Task.Run(CompanionStartupTests.LaunchPreconditionsProtectHumanRun));
         yield return ("CoopRoute.ExternalTakeover", () => Task.Run(CoopRouteTests.UnverifiedPlayModelLaunchesForExternalTakeoverOnly));
         yield return ("CoopRoute.SupportedSurfaces", () => Task.Run(CoopRouteTests.CompanionRouteReachesTheSupportedSurfaces));
+        yield return ("CoopRoute.SharedModelGate", () => Task.Run(CoopRouteTests.EveryStartEntryPointSharesTheModelGate));
         yield return ("CoopSave.ReadNetIds", () => Task.Run(CoopSavePrecheckTests.ReadsPlayerNetIdsFromTheSave));
         yield return ("CoopSave.NumericStringNetIds", () => Task.Run(CoopSavePrecheckTests.ReadsNumericStringNetIds));
         yield return ("CoopSave.UnreadableSaves", () => Task.Run(CoopSavePrecheckTests.UnreadableSavesYieldNoIds));

--- a/STS2AIAgent/Agent/AgentRuntime.cs
+++ b/STS2AIAgent/Agent/AgentRuntime.cs
@@ -187,6 +187,13 @@ internal sealed class AgentRuntime
             if (running)
             {
                 if (!_companionReady) throw new InvalidOperationException(Loc.T("队友尚未完成组队，请稍后继续。"));
+                // Starting the in-process loop is one decision no matter who asks for it, so the
+                // companion answers to the same model gate as the host's Resume button and
+                // POST /teammate/control. Without this, the companion's own /session/control was a
+                // way to start a model loop that every other entry point refuses. Pausing is always
+                // allowed: no caller should be stuck unable to stop it.
+                var firstRun = FirstRunSetup.Evaluate(Settings);
+                if (!firstRun.ReadyToInvite) throw new InvalidOperationException(firstRun.Hint);
                 StartAutoPlay();
             }
             else

--- a/docs/api.md
+++ b/docs/api.md
@@ -1142,7 +1142,7 @@ compact 里的位置与 `/state` 不同，但同名同源、同为新增键；`/
 
 - 仅接受 loopback 请求，非本机来源返回 403 `local_only`
 - 请求体 `{"running": true}` 启动，`{"running": false}` 暂停；字段缺失或不是布尔值返回 400 `invalid_request`
-- 在 `companion` 实例上等价于控制该实例自身，见下方 `/companion/control`
+- 在 `companion` 实例上等价于控制该实例自身，见下方 `/companion/control`。`running: true` 与游戏内「继续游玩」、`POST /teammate/control` 是同一道门禁：游玩模型未验证时返回 409 `session_not_ready`，消息就是「测试连接」那条提示；`running: false` 任何时候都可用，暂停不受门禁影响
 
 ### 响应示例
 

--- a/docs/live-validation-checklist.md
+++ b/docs/live-validation-checklist.md
@@ -176,6 +176,55 @@ invite was a real call, not a resumed session.
   the last session handle so a retry cannot start a third window, and the discovery block inherited that
   persistence. It now returns `null` once `CompanionProcessExited` is set.
 
++### External-takeover route driven by a real external agent (issue #85)
+
+Verified 2026-09-13 on the same isolated dual-instance host (dead model endpoint on `127.0.0.1:18199`,
+`roleTests` empty), but this pass answers the stronger question: not "can a script poke the API" but
+"can an outside agent actually play the seat". An external agent (Grok 4.6, its own model and its own
+context — not the mod's in-process loop) was given only the repository's MCP tool surface and the
+bundled play skill, and told to fight the teammate's character itself.
+
+Driver: `build/validation-2026-09-13/mcp-call.py` — a thin caller over the bundled MCP server's tool
+surface (`create_server()` + `call_tool`), i.e. the same tools Cursor / Claude / Codex would get, not
+the raw `/action` endpoint. Evidence: `external-agent-log.jsonl` (84 lines), `external-agent-final-state.json`.
+
+- **A full battle was played and won by the outside agent.** Teammate side, all through MCP: 16 ×
+  `play_card` + 6 × `end_turn` + 4 × `confirm_modal` (the FTUE popups), plus `choose_map_node` to enter
+  and to leave. `FUZZY_WURM_CRAWLER` went `121/121` → dead over 7 turns, `screen` went `COMBAT` →
+  `REWARD` → `MAP`, gold `99` → `110`, and a second fight (`SHRINKER_BEETLE`) was already under way when
+  the session stopped.
+- **The teammate never took a turn by itself, and never called a model.** Across the whole run its
+  `/health` read `play_running=false`, `play_phase="paused"`, `session_requests=0`, `stop_kind=null`; the
+  host reported `companion.auto_play=false`. Every decision came from outside the game process.
+- **The two seats stayed independent.** The host window was driven alongside the teammate (same map vote,
+  `end_turn` each turn) because the run cannot advance otherwise; each side acted only for its own
+  character, which is `CompanionActPolicy` doing its job rather than a shared trigger.
+- **The supported entry really is the MCP surface.** No `/teammate/control`, no `/session/control`, no
+  `run_console_command` appears anywhere in the 84-line log — checked mechanically, not by reading.
+
+### Found in this session
+
+- **The companion's own `POST /session/control` skipped the play-model gate.** `POST /teammate/control`
+  and the overlay's Resume button both refuse to start the loop without a verified model, but the
+  companion instance accepted `{"running":true}` and started one. Live confirmation after the fix:
+  teammate `/session/control {running:true}` → 409 `session_not_ready` carrying the unverified-model hint,
+  while `{running:false}` stayed 200 — pausing is deliberately never gated. All start entries now share
+  `FirstRunSetup.ReadyToInvite`; `CoopRoute.SharedModelGate` pins the ordering.
+- **Three FTUE popups cost three `confirm_modal` calls each on the companion.** `NCombatRulesFtue`
+  returned `status=pending` twice before accepting, and at that moment the host window was already in
+  `COMBAT` with cards to play. The companion is not stuck (the third call lands), but an external agent
+  that treats the first `pending` as failure would stall there. Not changed in this pass.
+- **`get_relevant_game_data` needs `collection` and `item_ids`**, while
+  `skills/sts2-mcp-player/SKILL.md` describes it as scene-aware and callable without arguments. Calling
+  it the documented way fails with fastmcp `missing_argument`. Documentation gap, not a mod defect.
+- **Monster metadata does not carry multiplayer scaling.** `get_relevant_game_data monsters
+  FUZZY_WURM_CRAWLER` reported `min_hp=55 / max_hp=57`, while the live enemy was `121/121`. The skill
+  already says to trust live state; this is a concrete case where the metadata alone would mislead.
+- **On the companion instance, `/health`'s `dual_status` and `team_control_status` still read
+  「尚未启动双开」/「队友控制尚未连接」.** Those two fields describe the *host's* dual-launch bookkeeping, so
+  they are inert on a companion; the fields that matter there (`instance_role`, `play_running`,
+  `play_phase`, `session_requests`) are correct.
+
 ### Environment note for isolated runs
 
 A brand-new `--clientId` directory gets a default `settings.save` whose `mod_settings` is `null`, and the


### PR DESCRIPTION
Follow-up to #85 (merged as #97). Two things: the one gate gap that pass left open, and the acceptance that was still missing.

## The gate gap

The companion instance accepted `POST /session/control {"running": true}` and started the in-process loop with no verified play model, while the host's Resume button, `POST /companion/control` and `POST /teammate/control` all refused the same request. That was the one start entry that skipped `FirstRunSetup.ReadyToInvite`, so it was a way to start a model loop every other entry rejects.

`SetCompanionRunningAsync` now checks the gate before it starts anything. **Pausing stays ungated on purpose** — nothing should be stuck unable to stop the loop — and `CoopRoute.SharedModelGate` pins both the ordering (gate before `StartAutoPlay`) and the fact that the pause branch sits outside it.

Live: teammate `/session/control {running:true}` → 409 `session_not_ready` carrying the unverified-model hint; `{running:false}` → 200.

## The acceptance

The earlier pass proved the HTTP route works (invite, park, discovery, control). It did **not** prove that an outside agent can actually play the seat. This one does: an external agent — its own model, its own context, given only the bundled MCP tool surface plus the play skill, not the mod's in-process loop — took over the teammate window and fought the battle itself.

| | |
| --- | --- |
| Teammate actions (all over MCP) | 16 × `play_card`, 6 × `end_turn`, 4 × `confirm_modal`, plus the map votes |
| First fight | `FUZZY_WURM_CRAWLER` `121/121` → dead over 7 turns, `COMBAT` → `REWARD` → `MAP` |
| Run progress | gold `99` → `110`, floor `0` → `2`, second fight (`SHRINKER_BEETLE`) under way at stop |
| Companion throughout | `play_running=false`, `play_phase="paused"`, `session_requests=0`, `stop_kind=null` |
| Forbidden calls | 0 hits for `/teammate/control`, `/session/control`, `run_console_command` — checked mechanically across all 84 log lines |

Zero model requests is the load-bearing number: the configured endpoint is a dead port, so any model call would have surfaced as a config/network stop instead of passing quietly. The teammate never took a turn by itself; every decision came from outside the process.

Evidence: `build/validation-2026-09-13/external-agent-log.jsonl` (84 lines), `external-agent-final-state.json`, driver `mcp-call.py` (a thin `create_server()` + `call_tool` caller, i.e. the same tools Cursor / Claude / Codex get). Real Steam save: 183 files byte-identical before and after.

## Recorded, not changed

- `NCombatRulesFtue` costs three `confirm_modal` calls on the companion (`pending` twice) while the host is already in `COMBAT` with cards to play. The companion is not stuck — the third call lands — but an external agent that reads the first `pending` as failure stalls there.
- `get_relevant_game_data` requires `collection` + `item_ids`, while `skills/sts2-mcp-player/SKILL.md` describes it as scene-aware and callable without arguments.
- Monster metadata carries no multiplayer scaling: `FUZZY_WURM_CRAWLER` reported `min_hp=55 / max_hp=57` against a live `121/121`.
- On a companion instance `/health`'s `dual_status` and `team_control_status` still read 「尚未启动双开」/「队友控制尚未连接」; they describe the host's bookkeeping, so they are inert there.

## Checks

- `dotnet build STS2AIAgent/STS2AIAgent.csproj -c Release` — 0 warnings, 0 errors
- `STS2AIAgent.Tests` — 368 pass / 0 fail (1 new)
- `python scripts/check_verification_gates.py` — 7/7
- `mcp_server` unittest — 165 OK

## Summary by Sourcery

Ensure every autoplay start path uses the verified play-model gate and record successful external-agent control of a teammate session.

Bug Fixes:
- Apply the verified play-model gate to companion session starts while keeping pause requests available regardless of model readiness.

Enhancements:
- Add coverage ensuring every in-process autoplay start entry point shares the same model gate and ordering.
- Document the shared session-control gating behavior and record external-agent multiplayer takeover validation and its observed limitations.

Documentation:
- Expand the live validation checklist with evidence that an external agent can play the teammate seat through the MCP surface without the in-process loop.

Tests:
- Add a regression test for the companion route's shared model gate and ungated pause behavior.