### PR TITLE
fix(state): settle the three live findings and keep both id derivations honest

### DIFF
--- a/STS2AIAgent.Tests/EnemyBaseHpContractTests.cs
+++ b/STS2AIAgent.Tests/EnemyBaseHpContractTests.cs
@@ -1,0 +1,54 @@
+namespace STS2AIAgent.Tests;
+
+/// <summary>
+/// Contract for the enemy base-HP bridge.
+///
+/// Monster metadata (monsters.min_hp/max_hp) reports the single-player base roll, while the live
+/// combat state reports MaxHp after multiplayer scaling. Without the unscaled roll in the payload the
+/// two numbers look contradictory (for example FUZZY_WURM_CRAWLER 55/57 metadata vs 121/121 live).
+/// GameStateService.cs is not compiled into this project, so these tests pin the source contract: the
+/// base roll is emitted on both the raw and the compact enemy payload, it comes from
+/// Creature.MonsterMaxHpBeforeModification, and the existing max_hp assignment is untouched.
+/// </summary>
+internal static class EnemyBaseHpContractTests
+{
+    private const string StateSourcePath = "STS2AIAgent/Game/GameStateService.cs";
+
+    public static void RawEnemyPayloadCarriesTheBaseRoll()
+    {
+        var buildEnemy = AgentSourceFixture.WithoutWhitespace(
+            AgentSourceFixture.MethodBody(AgentSourceFixture.Read(StateSourcePath), "BuildEnemyPayload"));
+
+        // The base roll is read straight off the creature; the field is nullable, so a player, a pet or
+        // a creature whose value is not yet set yields null rather than a fallback to the scaled MaxHp.
+        Assert.Contains("base_max_hp=enemy.MonsterMaxHpBeforeModification", buildEnemy, StringComparison.Ordinal);
+
+        // The pre-existing live value is unchanged: same source property, no fallback or rewrite.
+        Assert.Contains("max_hp=enemy.MaxHp,", buildEnemy, StringComparison.Ordinal);
+        Assert.False(
+            buildEnemy.Contains(",max_hp=enemy.MonsterMaxHpBeforeModification", StringComparison.Ordinal),
+            "max_hp must stay the scaled live value, not the unscaled base roll");
+    }
+
+    public static void CompactEnemyPayloadMirrorsTheBaseRoll()
+    {
+        var compactCombat = AgentSourceFixture.WithoutWhitespace(
+            AgentSourceFixture.MethodBody(AgentSourceFixture.Read(StateSourcePath), "BuildAgentCombatPayload"));
+
+        // The compact view exposes the same key name as the raw payload, forwarded verbatim.
+        Assert.Contains("base_max_hp=enemy.base_max_hp", compactCombat, StringComparison.Ordinal);
+        // The live hp line is unchanged.
+        Assert.Contains("hp=$\"{enemy.current_hp}/{enemy.max_hp}\"", compactCombat, StringComparison.Ordinal);
+    }
+
+    public static void EnemyPayloadTypeDeclaresNullableBaseMaxHp()
+    {
+        var payload = AgentSourceFixture.WithoutWhitespace(AgentSourceFixture.DeclarationBody(
+            AgentSourceFixture.Read(StateSourcePath), "internal sealed class CombatEnemyPayload"));
+
+        // New field only: the base roll is a nullable int so "unset" stays distinguishable from zero.
+        Assert.Contains("publicint?base_max_hp{get;init;}", payload, StringComparison.Ordinal);
+        // Backward compatibility: the existing live field keeps its type and name.
+        Assert.Contains("publicintmax_hp{get;init;}", payload, StringComparison.Ordinal);
+    }
+}

--- a/STS2AIAgent.Tests/FtueModalPolicyTests.cs
+++ b/STS2AIAgent.Tests/FtueModalPolicyTests.cs
@@ -62,4 +62,26 @@ internal static class FtueModalPolicyTests
         Assert.True(!kick.Contains("AfterAllPlayersReadyToEndTurn"));
         Assert.True(!kick.Contains("method.Invoke"));
     }
+
+    /// <summary>
+    /// The combat-rules FTUE is paged: one confirm advances a page and leaves the modal open, so the
+    /// response has to explain the next click instead of looking like the action stalled. Every other
+    /// FTUE (and a non-FTUE) is not paged, and the generic transition message must survive unchanged.
+    /// </summary>
+    public static void MultiPageFtueKeepsTheModalOpen()
+    {
+        Assert.True(FtueModalPolicy.IsMultiPageFtue("NCombatRulesFtue"));
+        Assert.True(FtueModalPolicy.IsMultiPageFtue("ncombatrulesftue"));
+        Assert.False(FtueModalPolicy.IsMultiPageFtue("NRelicRewardFtue"));
+        Assert.False(FtueModalPolicy.IsMultiPageFtue("NCanPlayCardsFtue"));
+        Assert.False(FtueModalPolicy.IsMultiPageFtue("NVerticalPopup"));
+        Assert.False(FtueModalPolicy.IsMultiPageFtue(null));
+        Assert.False(FtueModalPolicy.IsMultiPageFtue(""));
+
+        var actionSource = AgentSourceFixture.Read("STS2AIAgent/Game/GameActionService.cs");
+        var confirmModal = AgentSourceFixture.MethodBody(actionSource, "ExecuteModalButtonAsync");
+        Assert.Contains("IsMultiPageFtue", confirmModal);
+        Assert.Contains("Tutorial page advanced; the modal is still open. Call confirm_modal again.", confirmModal);
+        Assert.Contains("Action queued but state is still transitioning.", confirmModal);
+    }
 }

--- a/STS2AIAgent.Tests/GameDataFilterItemSourceTests.cs
+++ b/STS2AIAgent.Tests/GameDataFilterItemSourceTests.cs
@@ -1,0 +1,221 @@
+using System.Text.Json;
+using STS2AIAgent.Agent;
+
+namespace STS2AIAgent.Tests;
+
+/// <summary>
+/// Behavioural tests for <see cref="GameDataFilter.DeriveRelevantItemIds"/>: the ids
+/// <c>get_relevant_game_data</c> looks up when the caller omits them. These call the production
+/// code directly (GameDataFilter.cs is compiled into this project); they do not read its source.
+/// </summary>
+internal static class GameDataFilterItemSourceTests
+{
+    /// <summary>
+    /// On the combat screen the card ids come from <c>combat.hand[]</c> in hand order and the
+    /// monster ids from <c>combat.enemies[]</c> in enemy order, not from a run-level list.
+    /// </summary>
+    public static void CombatHandAndEnemyIdsFollowTheSurfaceOrder()
+    {
+        using var doc = JsonDocument.Parse("""
+        {
+          "screen": "COMBAT",
+          "combat": {
+            "hand": [
+              {"card_id": "STRIKE_IRONCLAD"},
+              {"card_id": "DEFEND_IRONCLAD"},
+              {"card_id": "BASH"}
+            ],
+            "enemies": [
+              {"enemy_id": "FUZZY_WURM_CRAWLER"},
+              {"enemy_id": "SHRINKER_BEETLE"}
+            ]
+          },
+          "run": {"deck": [{"card_id": "FALLBACK_CARD"}]}
+        }
+        """);
+
+        Assert.Equal("STRIKE_IRONCLAD,DEFEND_IRONCLAD,BASH",
+            string.Join(",", GameDataFilter.DeriveRelevantItemIds("COMBAT", "cards", doc.RootElement)));
+        Assert.Equal("FUZZY_WURM_CRAWLER,SHRINKER_BEETLE",
+            string.Join(",", GameDataFilter.DeriveRelevantItemIds("COMBAT", "monsters", doc.RootElement)));
+    }
+
+    /// <summary>
+    /// The combat powers source names two paths, so the answer merges the player's powers first and
+    /// then each enemy's powers in enemy order; order matters because that is the surface order.
+    /// </summary>
+    public static void CombatPowersMergePlayerPowersThenEnemyPowers()
+    {
+        using var doc = JsonDocument.Parse("""
+        {
+          "screen": "COMBAT",
+          "combat": {
+            "player": {"powers": [{"power_id": "STRENGTH"}, {"power_id": "DEXTERITY"}]},
+            "enemies": [
+              {"enemy_id": "E1", "powers": [{"power_id": "VULNERABLE"}]},
+              {"enemy_id": "E2", "powers": [{"power_id": "WEAK"}]}
+            ]
+          }
+        }
+        """);
+
+        Assert.Equal("STRENGTH,DEXTERITY,VULNERABLE,WEAK",
+            string.Join(",", GameDataFilter.DeriveRelevantItemIds("COMBAT", "powers", doc.RootElement)));
+    }
+
+    /// <summary>
+    /// A null potion id in the state is not an error: the collection simply derives no ids, and the
+    /// caller gets an empty list rather than a failure.
+    /// </summary>
+    public static void NullPotionIdYieldsNoIdsInsteadOfAnError()
+    {
+        using var doc = JsonDocument.Parse("""
+        {
+          "screen": "COMBAT",
+          "run": {"potions": [{"potion_id": null}]}
+        }
+        """);
+
+        var ids = GameDataFilter.DeriveRelevantItemIds("COMBAT", "potions", doc.RootElement);
+        Assert.NotNull(ids);
+        Assert.Equal(0, ids.Count);
+    }
+
+    /// <summary>
+    /// A screen that is about something else declares no card source, so the lookup falls back to
+    /// the deck the player already owns instead of answering with nothing.
+    /// </summary>
+    public static void NonCombatScreenFallsBackToTheDeck()
+    {
+        using var doc = JsonDocument.Parse("""
+        {
+          "screen": "MAP",
+          "combat": {"hand": [{"card_id": "NOT_IN_HAND_NOW"}]},
+          "run": {"deck": [{"card_id": "BASH"}, {"card_id": "STRIKE_IRONCLAD"}]}
+        }
+        """);
+
+        Assert.Equal("BASH,STRIKE_IRONCLAD",
+            string.Join(",", GameDataFilter.DeriveRelevantItemIds("MAP", "cards", doc.RootElement)));
+    }
+
+    /// <summary>
+    /// An unknown collection derives nothing rather than guessing a nearby source.
+    /// </summary>
+    public static void UnknownCollectionYieldsNoIds()
+    {
+        using var doc = JsonDocument.Parse("""
+        {
+          "screen": "COMBAT",
+          "combat": {"hand": [{"card_id": "BASH"}]}
+        }
+        """);
+
+        var ids = GameDataFilter.DeriveRelevantItemIds("COMBAT", "nonsense", doc.RootElement);
+        Assert.NotNull(ids);
+        Assert.Equal(0, ids.Count);
+    }
+
+    /// <summary>
+    /// A card that sits in hand twice is looked up once, and it keeps the position of its first
+    /// appearance so the derived list stays in surface order.
+    /// </summary>
+    public static void DuplicateIdsAppearOnceInFirstSeenOrder()
+    {
+        using var doc = JsonDocument.Parse("""
+        {
+          "screen": "COMBAT",
+          "combat": {"hand": [
+            {"card_id": "STRIKE_IRONCLAD"},
+            {"card_id": "BASH"},
+            {"card_id": "STRIKE_IRONCLAD"}
+          ]}
+        }
+        """);
+
+        Assert.Equal("STRIKE_IRONCLAD,BASH",
+            string.Join(",", GameDataFilter.DeriveRelevantItemIds("COMBAT", "cards", doc.RootElement)));
+    }
+
+    /// <summary>
+    /// Scene and collection matching is case-insensitive, so a caller that sends "combat"/"Cards"
+    /// reaches the same sources as the canonical spelling.
+    /// </summary>
+    public static void CollectionAndScreenMatchingIsCaseInsensitive()
+    {
+        using var doc = JsonDocument.Parse("""
+        {
+          "screen": "COMBAT",
+          "combat": {"hand": [{"card_id": "STRIKE_IRONCLAD"}, {"card_id": "BASH"}]},
+          "run": {"deck": [{"card_id": "FALLBACK_CARD"}]}
+        }
+        """);
+
+        Assert.Equal("STRIKE_IRONCLAD,BASH",
+            string.Join(",", GameDataFilter.DeriveRelevantItemIds("combat", "Cards", doc.RootElement)));
+    }
+
+    /// <summary>
+    /// An empty id string is skipped, exactly like the Python mirror: it must not be looked up and
+    /// must not enter the dedup set, so it never appears in the derived list.
+    /// </summary>
+    public static void EmptyStringIdsAreSkipped()
+    {
+        using var doc = JsonDocument.Parse("""
+        {
+          "screen": "COMBAT",
+          "combat": {"hand": [
+            {"card_id": ""},
+            {"card_id": "STRIKE_IRONCLAD"},
+            {"card_id": ""}
+          ]}
+        }
+        """);
+
+        var ids = GameDataFilter.DeriveRelevantItemIds("COMBAT", "cards", doc.RootElement);
+        Assert.Equal(1, ids.Count);
+        Assert.Equal("STRIKE_IRONCLAD", ids[0]);
+    }
+
+    /// <summary>
+    /// Combat declares no relic source, so a relic lookup on that screen falls back to the run
+    /// relics the player already owns, in the order the run lists them.
+    /// </summary>
+    public static void CombatRelicsFallBackToTheRunRelics()
+    {
+        using var doc = JsonDocument.Parse("""
+        {
+          "screen": "COMBAT",
+          "run": {"relics": [{"relic_id": "BURNING_BLOOD"}, {"relic_id": "RING_OF_THE_SNAKE"}]}
+        }
+        """);
+
+        Assert.Equal("BURNING_BLOOD,RING_OF_THE_SNAKE",
+            string.Join(",", GameDataFilter.DeriveRelevantItemIds("COMBAT", "relics", doc.RootElement)));
+    }
+
+    /// <summary>
+    /// A screen can classify into a scene whose payload is absent on that very screen: FAKE_MERCHANT
+    /// reads as shop, but the state carries no shop block there because the merchant room the ids
+    /// would come from does not exist. The answer has to fall back to the run-level ids instead of
+    /// reporting nothing, or the tool would silently return an empty map on that screen.
+    /// </summary>
+    public static void SceneSourceWithoutItsPayloadFallsBack()
+    {
+        using var doc = JsonDocument.Parse("""
+        {
+          "screen": "FAKE_MERCHANT",
+          "shop": null,
+          "run": {
+            "deck": [{"card_id": "STRIKE_IRONCLAD"}],
+            "relics": [{"relic_id": "BURNING_BLOOD"}]
+          }
+        }
+        """);
+
+        Assert.Equal("STRIKE_IRONCLAD",
+            string.Join(",", GameDataFilter.DeriveRelevantItemIds("FAKE_MERCHANT", "cards", doc.RootElement)));
+        Assert.Equal("BURNING_BLOOD",
+            string.Join(",", GameDataFilter.DeriveRelevantItemIds("FAKE_MERCHANT", "relics", doc.RootElement)));
+    }
+}

--- a/STS2AIAgent.Tests/TestRunner.cs
+++ b/STS2AIAgent.Tests/TestRunner.cs
@@ -184,6 +184,7 @@ internal static class TestRunner
         yield return ("CoopStartup.JoinBootstrap", () => Task.Run(CompanionStartupTests.CompanionBootstrapJoinsAsExtraPlayerThenReady));
         yield return ("CoopStartup.CombatFtueConfirm", () => Task.Run(CompanionStartupTests.CombatRulesFtueIsConfirmedImmediately));
         yield return ("Ftue.CombatRulesWithoutButton", () => Task.Run(FtueModalPolicyTests.CombatRulesFtueWithoutButtonIsConfirmable));
+        yield return ("Ftue.MultiPageStaysOpen", () => Task.Run(FtueModalPolicyTests.MultiPageFtueKeepsTheModalOpen));
         yield return ("CoopStartup.FirstRunProvider", () => Task.Run(CompanionStartupTests.FirstRunProviderConfigIsReachable));
         yield return ("CoopStartup.ProfileMods", () => Task.Run(CompanionStartupTests.CompanionProfileEnablesTheMod));
         yield return ("CoopStartup.SettingsIsolation", () => Task.Run(CompanionStartupTests.SettingsPathCanBeIsolated));
@@ -245,6 +246,16 @@ internal static class TestRunner
         yield return ("Budget.SettingsCarriesInitialCounters", () => Task.Run(SessionBudgetGuardTests.Settings_CreateBudgetGuard_CarriesInitialCounters));
         yield return ("GameData.DetectScene", () => Task.Run(GameDataFilterTests.DetectScene_MatchesGuidedMcpRules));
         yield return ("GameData.ProjectRelevant", () => Task.Run(GameDataFilterTests.ProjectRelevant_KeepsCombatCardFields));
+        yield return ("GameDataFilter.CombatHandIds", () => Task.Run(GameDataFilterItemSourceTests.CombatHandAndEnemyIdsFollowTheSurfaceOrder));
+        yield return ("GameDataFilter.CombatPowers", () => Task.Run(GameDataFilterItemSourceTests.CombatPowersMergePlayerPowersThenEnemyPowers));
+        yield return ("GameDataFilter.NullPotionId", () => Task.Run(GameDataFilterItemSourceTests.NullPotionIdYieldsNoIdsInsteadOfAnError));
+        yield return ("GameDataFilter.NonCombatDeckFallback", () => Task.Run(GameDataFilterItemSourceTests.NonCombatScreenFallsBackToTheDeck));
+        yield return ("GameDataFilter.UnknownCollection", () => Task.Run(GameDataFilterItemSourceTests.UnknownCollectionYieldsNoIds));
+        yield return ("GameDataFilter.DuplicateIds", () => Task.Run(GameDataFilterItemSourceTests.DuplicateIdsAppearOnceInFirstSeenOrder));
+        yield return ("GameDataFilter.CaseInsensitive", () => Task.Run(GameDataFilterItemSourceTests.CollectionAndScreenMatchingIsCaseInsensitive));
+        yield return ("GameDataFilter.EmptyStringId", () => Task.Run(GameDataFilterItemSourceTests.EmptyStringIdsAreSkipped));
+        yield return ("GameDataFilter.CombatRelicFallback", () => Task.Run(GameDataFilterItemSourceTests.CombatRelicsFallBackToTheRunRelics));
+        yield return ("GameDataFilter.EmptySceneFallsBack", () => Task.Run(GameDataFilterItemSourceTests.SceneSourceWithoutItsPayloadFallsBack));
         yield return ("PlayIntent.Detect", () => Task.Run(PlayIntentTests.DetectsPlayPhrasesAndIgnoresQuestions));
         yield return ("ActIndex.Validate", () => Task.Run(ActIndexValidatorTests.RejectsMissingAndStaleIndexes));
         yield return ("ActIndex.Unsettled", () => Task.Run(ActIndexValidatorTests.DetectsUnsettledActResults));
@@ -462,6 +473,9 @@ internal static class TestRunner
         yield return ("CompactViewFidelity.IntentNumbers", () => Task.Run(CompactViewFidelityTests.IntentNumbersReachTheCompactCombatView));
         yield return ("CompactViewFidelity.CardAndRelicIds", () => Task.Run(CompactViewFidelityTests.CardAndRelicIdsReachTheCompactViews));
         yield return ("CompactViewFidelity.OverlayAndParty", () => Task.Run(CompactViewFidelityTests.OverlayAndPartyReachTheCompactView));
+        yield return ("EnemyBaseHp.RawPayload", () => Task.Run(EnemyBaseHpContractTests.RawEnemyPayloadCarriesTheBaseRoll));
+        yield return ("EnemyBaseHp.CompactView", () => Task.Run(EnemyBaseHpContractTests.CompactEnemyPayloadMirrorsTheBaseRoll));
+        yield return ("EnemyBaseHp.PayloadType", () => Task.Run(EnemyBaseHpContractTests.EnemyPayloadTypeDeclaresNullableBaseMaxHp));
         yield return ("RewardScreen.BranchPrecedesGrid", () => Task.Run(RewardScreenContractTests.RewardOverlayBranchPrecedesTheVisibleGrid));
         yield return ("Parity.PlaySurfaceExcludesHealthCheck", () => Task.Run(HealthCheckParityTests.InGamePlaySurfaceKeepsNoConnectionCheck));
         yield return ("Parity.EmbeddedPromptUsesOnlyPlayTools", () => Task.Run(HealthCheckParityTests.EmbeddedPromptOnlyInstructsPlaySurfaceTools));

--- a/STS2AIAgent/Agent/AgentTools.cs
+++ b/STS2AIAgent/Agent/AgentTools.cs
@@ -47,6 +47,22 @@ internal static class AgentTools
         required = new[] { "collection", "item_ids" }
     };
 
+    /// <summary>
+    /// get_relevant_game_data names its ids optionally: the whole point of the tool is that the
+    /// current scene decides what is relevant, so omitting item_ids is the normal call and the
+    /// server derives them from live state.
+    /// </summary>
+    private static readonly object RelevantDataParameters = new
+    {
+        type = "object",
+        properties = new
+        {
+            collection = new { type = "string", description = "cards, relics, monsters, potions, events, powers, or characters." },
+            item_ids = new { type = "string", description = "Optional comma-separated ids. Omit to use the ids the current scene is about." }
+        },
+        required = new[] { "collection" }
+    };
+
     private static readonly object WaitParameters = new
     {
         type = "object",
@@ -63,7 +79,7 @@ internal static class AgentTools
         Tool("get_available_actions", "List currently legal actions with requires_index / requires_target hints."),
         Tool("get_game_data_item", "Look up one card/relic/monster/potion/event/power/character by id.", CollectionItemParameters),
         Tool("get_game_data_items", "Look up several metadata entities by comma-separated ids.", CollectionItemsParameters),
-        Tool("get_relevant_game_data", "Look up metadata with fields trimmed for the current screen.", CollectionItemsParameters),
+        Tool("get_relevant_game_data", "Look up metadata with fields trimmed for the current screen. Omit item_ids to use the ids this screen is about.", RelevantDataParameters),
         Tool("wait_until_actionable", "Wait until a non-passive action is available, then return fresh compact state. Use during animations and screen transitions.", WaitParameters)
     };
 

--- a/STS2AIAgent/Agent/GameBridge.cs
+++ b/STS2AIAgent/Agent/GameBridge.cs
@@ -145,8 +145,18 @@ internal sealed class GameBridge : IGameBridge
                 return error;
             }
 
-            var screen = GameStateService.BuildStatePayload().screen;
-            return JsonSerializer.Serialize(GameDataFilter.ProjectRelevant(screen, collection, element, itemIds), JsonOptions);
+            var state = GameStateService.BuildStatePayload();
+            // An empty id list is the scene-aware call, not an empty answer: derive the ids this
+            // screen is about so the tool does what its name and description promise when the
+            // caller does not know them yet.
+            IReadOnlyList<string> ids = itemIds;
+            if (ids.Count == 0)
+            {
+                using var document = JsonSerializer.SerializeToDocument(state, JsonOptions);
+                ids = GameDataFilter.DeriveRelevantItemIds(state.screen, collection, document.RootElement);
+            }
+
+            return JsonSerializer.Serialize(GameDataFilter.ProjectRelevant(state.screen, collection, element, ids), JsonOptions);
         });
     }
 

--- a/STS2AIAgent/Agent/GameDataFilter.cs
+++ b/STS2AIAgent/Agent/GameDataFilter.cs
@@ -119,6 +119,159 @@ internal static class GameDataFilter
         return projected;
     }
 
+    /// <summary>
+    /// Scene-scoped id sources for <see cref="DeriveRelevantItemIds"/>: (scene, collection) -> JSON
+    /// paths into the full /state payload, each ending in the collection's id field. This is what
+    /// makes <c>get_relevant_game_data</c> work without the caller naming ids: "the ids this screen
+    /// is about". mcp_server/src/sts2_mcp/server.py mirrors it as _SCENE_ITEM_SOURCES and
+    /// tests/test_scene_field_alignment.py keeps the two equal, the same way SceneFieldSets is kept.
+    /// </summary>
+    internal static readonly IReadOnlyDictionary<string, Dictionary<string, string[]>> SceneItemSources =
+        new Dictionary<string, Dictionary<string, string[]>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["combat"] = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["cards"] = new[] { "combat.hand[].card_id" },
+                ["monsters"] = new[] { "combat.enemies[].enemy_id" },
+                ["powers"] = new[] { "combat.player.powers[].power_id", "combat.enemies[].powers[].power_id" },
+                ["potions"] = new[] { "run.potions[].potion_id" }
+            },
+            ["shop"] = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["cards"] = new[] { "shop.cards[].card_id" },
+                ["relics"] = new[] { "shop.relics[].relic_id" },
+                ["potions"] = new[] { "shop.potions[].potion_id" }
+            },
+            ["event"] = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["events"] = new[] { "event.event_id" }
+            }
+        };
+
+    /// <summary>
+    /// Used when the current scene declares no source for the collection: the run-level ids the
+    /// player already owns, so a deck or relic lookup still answers on a screen that is about
+    /// something else.
+    /// </summary>
+    internal static readonly IReadOnlyDictionary<string, string[]> FallbackItemSources =
+        new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["cards"] = new[] { "run.deck[].card_id" },
+            ["relics"] = new[] { "run.relics[].relic_id" },
+            ["potions"] = new[] { "run.potions[].potion_id" },
+            ["monsters"] = new[] { "combat.enemies[].enemy_id" },
+            ["powers"] = new[] { "combat.player.powers[].power_id", "combat.enemies[].powers[].power_id" },
+            ["events"] = new[] { "event.event_id" }
+        };
+
+    /// <summary>
+    /// The ids <c>get_relevant_game_data</c> should look up for the current screen, in the order the
+    /// surface presents them, deduplicated. The scene decides first, and an empty scene answer --
+    /// an unknown collection, or a screen whose scene payload is absent -- falls back to the
+    /// run-level ids, so the result is empty only when neither source carries one. An empty answer
+    /// is a legitimate "nothing to look up here", not an error.
+    /// </summary>
+    public static IReadOnlyList<string> DeriveRelevantItemIds(string? screen, string collection, JsonElement state)
+    {
+        var scene = DetectScene(screen);
+        string[]? paths = null;
+        if (SceneItemSources.TryGetValue(scene, out var perCollection))
+        {
+            perCollection.TryGetValue(collection, out paths);
+        }
+
+        var ids = CollectIdsFromPaths(state, paths);
+        if (ids.Count == 0 && FallbackItemSources.TryGetValue(collection, out var fallbackPaths))
+        {
+            // A scene can name a source whose payload is absent on that screen: FAKE_MERCHANT is
+            // classified as shop, but the shop payload is null there because the merchant room the
+            // ids come from does not exist. An empty scene answer therefore still falls back to the
+            // run-level ids instead of reporting nothing at all.
+            ids = CollectIdsFromPaths(state, fallbackPaths);
+        }
+
+        return ids;
+    }
+
+    /// <summary>
+    /// Runs every path of one source list over the state, deduplicated and in source order.
+    /// </summary>
+    private static List<string> CollectIdsFromPaths(JsonElement state, IReadOnlyList<string>? paths)
+    {
+        var ids = new List<string>();
+        if (paths == null)
+        {
+            return ids;
+        }
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var path in paths)
+        {
+            CollectIds(state, path.Split('.'), 0, ids, seen);
+        }
+
+        return ids;
+    }
+
+    /// <summary>
+    /// Walks one <c>a.b[].c</c> path. A missing property or a wrong JSON kind ends that branch
+    /// quietly: state shapes vary by screen, and an absent id is not an error.
+    /// </summary>
+    private static void CollectIds(
+        JsonElement node,
+        IReadOnlyList<string> tokens,
+        int index,
+        List<string> ids,
+        HashSet<string> seen)
+    {
+        // A null or scalar node ends the branch: screens carry null payloads (shop on FAKE_MERCHANT,
+        // run.potions slots), and walking into one must not throw. Mirrors the dict guard in
+        // mcp_server/src/sts2_mcp/server.py _collect_path_ids.
+        if (node.ValueKind != JsonValueKind.Object)
+        {
+            return;
+        }
+
+        var token = tokens[index];
+        var isArray = token.EndsWith("[]", StringComparison.Ordinal);
+        var name = isArray ? token[..^2] : token;
+        if (!node.TryGetProperty(name, out var value))
+        {
+            return;
+        }
+
+        if (index == tokens.Count - 1)
+        {
+            if (value.ValueKind == JsonValueKind.String)
+            {
+                var text = value.GetString();
+                if (!string.IsNullOrEmpty(text) && seen.Add(text))
+                {
+                    ids.Add(text);
+                }
+            }
+
+            return;
+        }
+
+        if (isArray)
+        {
+            if (value.ValueKind != JsonValueKind.Array)
+            {
+                return;
+            }
+
+            foreach (var item in value.EnumerateArray())
+            {
+                CollectIds(item, tokens, index + 1, ids, seen);
+            }
+
+            return;
+        }
+
+        CollectIds(value, tokens, index + 1, ids, seen);
+    }
+
     public static IReadOnlyList<string> ParseItemIds(string? raw)
     {
         if (string.IsNullOrWhiteSpace(raw))

--- a/STS2AIAgent/Game/FtueModalPolicy.cs
+++ b/STS2AIAgent/Game/FtueModalPolicy.cs
@@ -15,6 +15,15 @@ internal static class FtueModalPolicy
         return string.Equals(typeName, CombatRulesTypeName, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// The combat-rules FTUE lays its text out over several pages: a confirm click advances one page
+    /// and leaves the modal open, so the caller has to keep confirming until the last page closes it.
+    /// </summary>
+    public static bool IsMultiPageFtue(string? typeName)
+    {
+        return IsCombatRulesFtue(typeName);
+    }
+
     public static bool ExposeConfirm(string? modalTypeName, bool hasUsableConfirmButton)
     {
         return hasUsableConfirmButton || IsFtueType(modalTypeName);

--- a/STS2AIAgent/Game/GameActionService.cs
+++ b/STS2AIAgent/Game/GameActionService.cs
@@ -6550,12 +6550,20 @@ internal static class GameActionService
             stable = await WaitForModalTransitionAsync(previousModal, TimeSpan.FromSeconds(8));
         }
 
+        var message = "Action completed.";
+        if (!stable)
+        {
+            message = FtueModalPolicy.IsMultiPageFtue(previousModal.GetType().Name)
+                ? "Tutorial page advanced; the modal is still open. Call confirm_modal again."
+                : "Action queued but state is still transitioning.";
+        }
+
         return new ActionResponsePayload
         {
             action = actionName,
             status = stable ? "completed" : "pending",
             stable = stable,
-            message = stable ? "Action completed." : "Action queued but state is still transitioning.",
+            message = message,
             state = GameStateService.BuildStatePayload()
         };
     }

--- a/STS2AIAgent/Game/GameStateService.cs
+++ b/STS2AIAgent/Game/GameStateService.cs
@@ -3367,6 +3367,8 @@ internal static class GameStateService
                 enemy_id = enemy.enemy_id,
                 name = enemy.name,
                 hp = $"{enemy.current_hp}/{enemy.max_hp}",
+                // Unscaled base roll (same dimension as monsters.min_hp/max_hp metadata); hp above is scaled live.
+                base_max_hp = enemy.base_max_hp,
                 block = enemy.block,
                 intent = enemy.intent,
                 move_id = enemy.move_id,
@@ -5300,6 +5302,9 @@ internal static class GameStateService
             name = enemy.Name,
             current_hp = enemy.CurrentHp,
             max_hp = enemy.MaxHp,
+            // Unscaled base roll: multiplayer scaling is applied before the live MaxHp is set, so this
+            // value shares its dimension with the monsters.min_hp/max_hp metadata while max_hp is scaled.
+            base_max_hp = enemy.MonsterMaxHpBeforeModification,
             block = enemy.Block,
             is_alive = enemy.IsAlive,
             is_hittable = enemy.IsHittable,
@@ -8061,6 +8066,8 @@ internal sealed class CombatEnemyPayload
     public int current_hp { get; init; }
 
     public int max_hp { get; init; }
+
+    public int? base_max_hp { get; init; }
 
     public int block { get; init; }
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -234,6 +234,7 @@
 | --- | --- | --- |
 | `current_hp` | number | 当前生命值 |
 | `max_hp` | number | 最大生命值 |
+| `base_max_hp` | number \| null | **联机缩放之前**掷出的基础最大生命值，与 `GET /data/monsters` 的 `min_hp` / `max_hp` 同一量纲；`max_hp` 是缩放后的实时值。玩家、宠物或该值尚未设置时为 `null` |
 | `block` | number | 当前格挡值 |
 | `energy` | number | 当前能量 |
 | `stars` | number | 当前星星数 |
@@ -671,6 +672,7 @@ compact 里的位置与 `/state` 不同，但同名同源、同为新增键；`/
 | `combat.player` | `powers` | 己方 Power 短行：`power_id` + 层数，Debuff 追加 `[debuff]` |
 | `combat.enemies[]` | `powers` | 敌方 Power 短行，同上 |
 | `combat.enemies[]` | `intents[]` | 怪物下一招的数值拆解：`i`（意图序号）、`intent_type`、`label`、`damage`、`hits`、`total_damage`、`status_card_count` |
+| `combat.enemies[]` | `base_max_hp` | 联机缩放前的基础血量；元数据的 `min_hp` / `max_hp` 与它同量纲，实况 `max_hp` 是缩放后的值 |
 | `combat.players[]` | `player_id` / `slot_index` / `is_local` / `is_connected` / `character_id` / `character_name` / `current_hp` / `max_hp` / `block` / `energy` / `stars` / `focus` / `is_alive` | 队伍血线（含本地玩家），用于判断队友是否需要救援 |
 | `combat.hand[]` | `card_id` | 手牌内部 ID，用于 `get_game_data_item` 精确查询 |
 | `combat.draw[]` / `combat.discard[]` / `combat.exhaust[]` / `run.deck[]` / `run.piles.*` | `card_ids` | 合并组代表的卡牌 ID（去重、升序）；组内若含不同 ID 会全部列出，`line` 仍带 `*N` 数量后缀 |
@@ -1303,6 +1305,10 @@ AI 队友实例上的受控端点，由宿主进程在本地调用，普通玩�
 | `characters` | 角色：id、名称、初始牌组、初始遗物、初始药水 |
 
 导出需要读取游戏对象，因此经游戏线程执行；数据规模较大（卡牌集合数百 KB），不适合每次决策都拉取。MCP 侧（`sts2_mcp.client.Sts2Client.get_game_data_collection`）会在进程内缓存。
+
+**元数据是单机量纲。** `monsters` 的 `min_hp` / `max_hp` 是该怪掷出的基础血量范围，而联机对局里游戏会按 `玩家数 × 章节系数`（act 0 为 1.1、act 1 为 1.2、act 2 为 1.2，act 2 的 Boss 房为 1.3）放大后再落到实况敌人身上，所以两者常常对不上。要对齐时看实况 `combat.enemies[].base_max_hp`：它与元数据同量纲，`max_hp` 才是缩放后的值。
+
+MCP 侧的 `get_relevant_game_data` 读取这份元数据时，`item_ids` 可以省略：省略后由当前屏幕决定要查哪些 id（战斗看手牌与敌人、商店看货架、事件看当前事件），并把字段裁剪到该场景需要的子集。屏幕归类到某场景但该场景的载荷在这块屏上没有内容时（例如 `FAKE_MERCHANT` 归为商店却没有 `shop` 载荷），回落到牌库 / 遗物 / 药水这些角色级 id；确实没有该集合的 id 时返回 `{}`，不臆造。要问特定 id 时照常传 `item_ids`。
 
 ### 典型用法
 

--- a/docs/live-validation-checklist.md
+++ b/docs/live-validation-checklist.md
@@ -225,6 +225,48 @@ the raw `/action` endpoint. Evidence: `external-agent-log.jsonl` (84 lines), `ex
   they are inert on a companion; the fields that matter there (`instance_role`, `play_running`,
   `play_phase`, `session_requests`) are correct.
 
+### Those three findings, fixed and re-verified in the game (2026-09-13)
+
+Re-run on the isolated offline host (`--clientId 2026091001`, API `18080`) with the patched build
+deployed. The Steam profile's 183 files were hashed before and after and came out identical; nothing
+touched the real save.
+
+- **The paged combat-rules FTUE was correct behaviour; the contract now says so.** `NCombatRulesFtue`
+  really is three pages (`build/sts2-decompiled/MegaCrit.Sts2.Core.Nodes.Ftue/NCombatRulesFtue.cs:165`
+  `_totalPages = 3`, and only the click after the last page calls `CloseFtue`) — so three calls were
+  always the right number. What was missing is that `pending` looked like a stall. A non-final page now
+  answers with `Tutorial page advanced; the modal is still open. Call confirm_modal again.` Live:
+  `modal=NCombatRulesFtue` → click 1 `pending`, click 2 `pending`, click 3 `completed`, after which
+  `modal` was empty and `screen` had moved to `COMBAT`. Every other modal keeps the old
+  `Action queued but state is still transitioning.` wording.
+- **`get_relevant_game_data` no longer needs `item_ids`.** Omitting them derives the ids the current
+  screen is about from live state, in both mirrors (`GameDataFilter.SceneItemSources` and
+  `_SCENE_ITEM_SOURCES`); `tests/test_scene_field_alignment.py` keeps the two tables — keys and paths —
+  equal, the same way the scene field sets are kept. Live in the host's fight, over the bundled MCP tool
+  surface: `{"collection":"monsters"}` returned exactly the three enemies in that room
+  (TWIG_SLIME_S / LEAF_SLIME_M / LEAF_SLIME_S), `{"collection":"cards"}` returned the hand
+  (DEFEND_IRONCLAD / STRIKE_IRONCLAD), and `relics` fell back to the run relic (BURNING_BLOOD). Passing
+  `item_ids` explicitly still answers as before, and a screen with no ids of that collection to offer
+  (combat `potions` with empty slots) answers `{}` rather than inventing one.
+- **The payload separates the base roll from the scaled HP.** `combat.enemies[].base_max_hp` carries
+  `Creature.MonsterMaxHpBeforeModification` — the same dimension as `monsters.min_hp` / `max_hp` — while
+  `max_hp` stays the scaled live value. Live in the two-player run, with both instances reporting the
+  same numbers: TWIG_SLIME_S `base=9` (metadata 7–11) → `max_hp=19`; LEAF_SLIME_M `base=33` (32–35) →
+  `72`; LEAF_SLIME_S `base=13` (11–15) → `28`. Each is `base × players(2) × act-0 factor(1.1)`,
+  truncated. Single-player is the degenerate case — `ScaleMonsterHpForMultiplayer` returns early when
+  `playerCount == 1` — which is why the original report had to come from a co-op fight.
+
+Two things surfaced while verifying the derivation, and both are fixed in the same pass:
+
+- **A scene can classify into a scene whose payload is null on that screen.** `FAKE_MERCHANT` reads as
+  shop (`DetectScene` matches "merchant"), but `BuildShopPayload` answers `null` there because the
+  merchant room it reads does not exist on that screen, so walking `shop.cards[].card_id` stepped into a
+  JSON null. The walk is now kind-guarded like its Python twin, and an empty scene answer falls back to
+  the run-level ids instead of stopping at `{}`.
+- **The two mirrors disagreed on empty ids.** C# accepted an empty-string id that Python skipped; both
+  now skip it (the C# path list is only ever fed by the state, but a divergence here would have shown up
+  as two different answers for the same screen).
+
 ### Environment note for isolated runs
 
 A brand-new `--clientId` directory gets a default `settings.save` whose `mod_settings` is `null`, and the

--- a/mcp_server/src/sts2_mcp/server.py
+++ b/mcp_server/src/sts2_mcp/server.py
@@ -287,6 +287,92 @@ def _load_game_data_collection(collection: str) -> Any:
     return data
 
 
+# Scene-scoped id sources for get_relevant_game_data: (scene, collection) -> JSON paths into the
+# /state payload, each ending in the collection id field. When the caller omits item_ids, these are
+# the ids the current screen is about, so the tool matches its own description instead of requiring
+# the caller to already know them. Mirrors STS2AIAgent/Agent/GameDataFilter.cs SceneItemSources;
+# tests/test_scene_field_alignment.py keeps the two equal.
+_SCENE_ITEM_SOURCES: dict[str, dict[str, list[str]]] = {
+    SCENE_COMBAT: {
+        "cards": ["combat.hand[].card_id"],
+        "monsters": ["combat.enemies[].enemy_id"],
+        "powers": ["combat.player.powers[].power_id", "combat.enemies[].powers[].power_id"],
+        "potions": ["run.potions[].potion_id"],
+    },
+    SCENE_SHOP: {
+        "cards": ["shop.cards[].card_id"],
+        "relics": ["shop.relics[].relic_id"],
+        "potions": ["shop.potions[].potion_id"],
+    },
+    SCENE_EVENT: {
+        "events": ["event.event_id"],
+    },
+}
+
+# Used when the current scene declares no source for the collection: the run-level ids the player
+# already owns, so a deck or relic lookup still answers on a screen that is about something else.
+_FALLBACK_ITEM_SOURCES: dict[str, list[str]] = {
+    "cards": ["run.deck[].card_id"],
+    "relics": ["run.relics[].relic_id"],
+    "potions": ["run.potions[].potion_id"],
+    "monsters": ["combat.enemies[].enemy_id"],
+    "powers": ["combat.player.powers[].power_id", "combat.enemies[].powers[].power_id"],
+    "events": ["event.event_id"],
+}
+
+
+def _collect_path_ids(node: Any, tokens: list[str], ids: list[str], seen: set[str]) -> None:
+    """Walk one a.b[].c path, appending ids in order and skipping what is not there."""
+    if not tokens:
+        return
+    token = tokens[0]
+    is_array = token.endswith("[]")
+    name = token[:-2] if is_array else token
+    if not isinstance(node, dict) or name not in node:
+        return
+    value = node[name]
+    if len(tokens) == 1:
+        if isinstance(value, str) and value and value not in seen:
+            seen.add(value)
+            ids.append(value)
+        return
+    if is_array:
+        if isinstance(value, list):
+            for item in value:
+                _collect_path_ids(item, tokens[1:], ids, seen)
+        return
+    _collect_path_ids(value, tokens[1:], ids, seen)
+
+
+def derive_relevant_item_ids(state: Any, collection: str, screen: str) -> list[str]:
+    """Ids the current screen is about for one collection, deduplicated and in surface order.
+
+    Empty when the collection is unknown or the state carries none of its ids, which is what an
+    unprojected answer looks like rather than an error.
+    """
+    scene = _detect_scene_from_screen(screen)
+    paths = _SCENE_ITEM_SOURCES.get(scene, {}).get(collection)
+    ids = _collect_ids_from_paths(state, paths)
+    if not ids:
+        # A scene can name a source whose payload is absent on that screen: FAKE_MERCHANT is
+        # classified as shop, but the shop payload is null there because the merchant room the ids
+        # come from does not exist. An empty scene answer therefore still falls back to the
+        # run-level ids instead of reporting nothing at all.
+        ids = _collect_ids_from_paths(state, _FALLBACK_ITEM_SOURCES.get(collection))
+    return ids
+
+
+def _collect_ids_from_paths(state: Any, paths: list[str] | None) -> list[str]:
+    """Run every path of one source list over the state, deduplicated and in source order."""
+    if not paths:
+        return []
+    ids: list[str] = []
+    seen: set[str] = set()
+    for path in paths:
+        _collect_path_ids(state, path.split("."), ids, seen)
+    return ids
+
+
 def _add_case_insensitive_item_id(index: dict[str, Any], item_id: str, item: Any) -> None:
     normalized = item_id.strip()
     if not normalized:
@@ -780,14 +866,15 @@ def create_server(client: Sts2Client | None = None, tool_profile: str | None = N
             return _build_game_data_tool_error(collection=collection, exc=exc)
 
     @mcp.tool
-    def get_relevant_game_data(collection: str, item_ids: str) -> dict[str, Any]:
+    def get_relevant_game_data(collection: str, item_ids: str = "") -> dict[str, Any]:
         """Return items with only the most relevant fields for the current game context.
 
         This automatically detects the current scene (combat/shop/event/menu) and returns
         only the fields most useful for AI decision-making in that context, minimizing token usage.
 
         - `collection`: e.g. `cards`, `relics`, `monsters`, `events`
-        - `item_ids`: comma-separated ids
+        - `item_ids`: comma-separated ids. Omit to use the ids this screen is about (the cards in
+          hand, the enemies in combat, the shop stock), which is the usual call.
 
         Recommended for most queries to save tokens and reduce uncertainty.
         """
@@ -795,15 +882,18 @@ def create_server(client: Sts2Client | None = None, tool_profile: str | None = N
         state = sts2.get_state()
         screen = state.get("screen", "")
         scene = _detect_scene_from_screen(screen)
+        resolved_ids = item_ids or ITEM_IDS_SEPARATOR.join(
+            derive_relevant_item_ids(state, collection, screen)
+        )
         try:
             suggested_fields = _SCENE_FIELD_SETS.get(scene, {}).get(collection)
             if not suggested_fields:
                 # Fallback to basic query if no scene-specific fields defined
-                return get_game_data_items(collection=collection, item_ids=item_ids)
+                return get_game_data_items(collection=collection, item_ids=resolved_ids)
 
             return get_game_data_items_fields(
                 collection=collection,
-                item_ids=item_ids,
+                item_ids=resolved_ids,
                 fields=",".join(suggested_fields),
             )
         except (KeyError, RuntimeError, TypeError) as exc:

--- a/mcp_server/tests/test_scene_field_alignment.py
+++ b/mcp_server/tests/test_scene_field_alignment.py
@@ -26,7 +26,12 @@ import re
 import unittest
 from pathlib import Path
 
-from sts2_mcp.server import _SCENE_FIELD_SETS
+from sts2_mcp.server import (
+    _FALLBACK_ITEM_SOURCES,
+    _SCENE_FIELD_SETS,
+    _SCENE_ITEM_SOURCES,
+    derive_relevant_item_ids,
+)
 
 _CSHARP_FILTER = "STS2AIAgent/Agent/GameDataFilter.cs"
 _CSHARP_EXPORT_SCHEMA = "STS2AIAgent/Agent/GameDataExportSchema.cs"
@@ -41,6 +46,14 @@ _QUOTED = re.compile(r'"([^"]*)"')
 
 # public static readonly IReadOnlyDictionary<string, string[]> Collections =
 _EXPORT_TABLE = re.compile(r"\bCollections\s*=\s*new\s+Dictionary<string,\s*string\[\]>")
+
+# public static readonly IReadOnlyDictionary<...> SceneItemSources = new(...)
+# The declaration wraps onto the next line and the type carries generics, so the marker stops at
+# `new` and _initializer_block finds the brace that opens the dictionary.
+_CSHARP_ITEM_SOURCES = re.compile(r"SceneItemSources\s*=\s*new")
+_CSHARP_FALLBACK_SOURCES = re.compile(r"FallbackItemSources\s*=\s*new")
+# ["cards"] = new[] { "combat.hand[].card_id" },
+_PATH_ENTRY = re.compile(r'\["(\w+)"\]\s*=\s*new\[\]\s*\{([^}]*)\}')
 
 
 def _find_source_root() -> Path:
@@ -105,6 +118,52 @@ def _parse_csharp_scene_field_sets(source_root: Path) -> dict[tuple[str, str], l
             pairs[(scene, collection)] = fields
 
     return pairs
+
+
+def _parse_csharp_item_sources(source_root: Path) -> tuple[dict[tuple[str, str], list[str]], dict[str, list[str]]]:
+    """Parse GameDataFilter.SceneItemSources and FallbackItemSources into path lists.
+
+    Returns ((scene, collection) -> paths, collection -> paths). The paths themselves are compared,
+    not just their keys: a source that drifts to a different field is a different answer.
+    """
+    source = (source_root / _CSHARP_FILTER).read_text(encoding="utf-8")
+    block_text = _initializer_block(source, _CSHARP_ITEM_SOURCES, "GameDataFilter.SceneItemSources")
+
+    scene_matches = list(_SCENE_ENTRY.finditer(block_text))
+    if not scene_matches:
+        raise AssertionError(
+            "GameDataFilter.cs SceneItemSources parsed to no scenes; the table shape changed"
+        )
+
+    scenes: dict[tuple[str, str], list[str]] = {}
+    for index, match in enumerate(scene_matches):
+        scene = match.group(1)
+        end = scene_matches[index + 1].start() if index + 1 < len(scene_matches) else len(block_text)
+        entries = _PATH_ENTRY.findall(block_text[match.end() : end])
+        if not entries:
+            raise AssertionError(f"GameDataFilter.cs scene {scene!r} parsed to no id sources")
+        for collection, raw in entries:
+            paths = _QUOTED.findall(raw)
+            if not paths:
+                raise AssertionError(f"GameDataFilter.cs {scene}/{collection} parsed to no paths")
+            scenes[(scene, collection)] = paths
+
+    fallback_block = _initializer_block(source, _CSHARP_FALLBACK_SOURCES, "GameDataFilter.FallbackItemSources")
+    fallback = {name: _QUOTED.findall(raw) for name, raw in _PATH_ENTRY.findall(fallback_block)}
+    if not fallback:
+        raise AssertionError("GameDataFilter.cs FallbackItemSources parsed to no collections")
+
+    return scenes, fallback
+
+
+def _python_item_source_pairs() -> tuple[dict[tuple[str, str], list[str]], dict[str, list[str]]]:
+    scenes = {
+        (scene, collection): list(paths)
+        for scene, collections in _SCENE_ITEM_SOURCES.items()
+        for collection, paths in collections.items()
+    }
+    fallback = {collection: list(paths) for collection, paths in _FALLBACK_ITEM_SOURCES.items()}
+    return scenes, fallback
 
 
 def _parse_csharp_export_schema(source_root: Path) -> dict[str, list[str]]:
@@ -218,6 +277,102 @@ class SceneFieldAlignmentTests(unittest.TestCase):
             diffs,
             "Scene field sets diverge between GameDataFilter.SceneFieldSets (C#) and "
             "_SCENE_FIELD_SETS (Python):\n  - " + "\n  - ".join(diffs),
+        )
+
+    def test_item_sources_match_in_both_directions(self) -> None:
+        csharp_scenes, csharp_fallback = _parse_csharp_item_sources(self.source_root)
+        python_scenes, python_fallback = _python_item_source_pairs()
+
+        only_in_csharp = set(csharp_scenes) - set(python_scenes)
+        only_in_python = set(python_scenes) - set(csharp_scenes)
+        self.assertEqual(
+            set(),
+            only_in_csharp,
+            "(scene, collection) id sources defined in C# but missing from Python "
+            "_SCENE_ITEM_SOURCES: " + ", ".join(f"{s}/{c}" for s, c in sorted(only_in_csharp)),
+        )
+        self.assertEqual(
+            set(),
+            only_in_python,
+            "(scene, collection) id sources defined in Python _SCENE_ITEM_SOURCES but absent "
+            "from C# GameDataFilter.SceneItemSources: "
+            + ", ".join(f"{s}/{c}" for s, c in sorted(only_in_python)),
+        )
+
+        # The paths are the answer, so a pair whose paths differ is a divergence too.
+        diffs = [
+            f"{scene}/{collection}: csharp={csharp_scenes[(scene, collection)]} "
+            f"python={python_scenes[(scene, collection)]}"
+            for scene, collection in sorted(set(csharp_scenes) & set(python_scenes))
+            if csharp_scenes[(scene, collection)] != python_scenes[(scene, collection)]
+        ]
+        self.assertEqual(
+            [],
+            diffs,
+            "Scene item sources diverge between GameDataFilter.SceneItemSources (C#) and "
+            "_SCENE_ITEM_SOURCES (Python):\n  - " + "\n  - ".join(diffs),
+        )
+
+        self.assertEqual(
+            python_fallback,
+            csharp_fallback,
+            "FallbackItemSources diverges between GameDataFilter.cs and _FALLBACK_ITEM_SOURCES",
+        )
+
+        # Both tables must actually carry the ids the earlier tests rely on, so a parse that
+        # silently returned {} cannot make the comparisons above vacuous.
+        self.assertTrue(csharp_scenes, "GameDataFilter.SceneItemSources parsed to nothing")
+        self.assertTrue(python_scenes, "_SCENE_ITEM_SOURCES is empty")
+        self.assertTrue(csharp_fallback, "GameDataFilter.FallbackItemSources parsed to nothing")
+
+    def test_derived_ids_come_from_live_state(self) -> None:
+        # The scene-aware call has to read the ids off the state payload, not off a constant:
+        # the same collection answers differently on the map and in a fight.
+        combat_state = {
+            "screen": "COMBAT",
+            "combat": {
+                "hand": [{"card_id": "STRIKE_IRONCLAD"}, {"card_id": "DEFEND_IRONCLAD"}],
+                "enemies": [{"enemy_id": "FUZZY_WURM_CRAWLER"}, {"enemy_id": "SHRINKER_BEETLE"}],
+                "player": {"powers": []},
+            },
+            "run": {"deck": [{"card_id": "BASH"}], "potions": [{"potion_id": None}]},
+            "shop": None,
+            "event": None,
+        }
+        self.assertEqual(
+            ["STRIKE_IRONCLAD", "DEFEND_IRONCLAD"],
+            derive_relevant_item_ids(combat_state, "cards", "COMBAT"),
+        )
+        self.assertEqual(
+            ["FUZZY_WURM_CRAWLER", "SHRINKER_BEETLE"],
+            derive_relevant_item_ids(combat_state, "monsters", "COMBAT"),
+        )
+        # No potion ids in the state means no ids, not an error.
+        self.assertEqual([], derive_relevant_item_ids(combat_state, "potions", "COMBAT"))
+        # A deck lookup still answers on a screen that is about something else.
+        self.assertEqual(
+            ["BASH"],
+            derive_relevant_item_ids(combat_state, "cards", "MAP"),
+        )
+        # An unknown collection derives nothing rather than guessing.
+        self.assertEqual([], derive_relevant_item_ids(combat_state, "nonsense", "COMBAT"))
+
+        # A screen can classify into a scene whose payload is absent on that screen: FAKE_MERCHANT
+        # reads as shop, but there is no shop block, so the answer must fall back to the run-level
+        # ids instead of coming back empty.
+        shop_less_state = {
+            "screen": "FAKE_MERCHANT",
+            "shop": None,
+            "combat": None,
+            "run": {"deck": [{"card_id": "BASH"}], "relics": [{"relic_id": "BURNING_BLOOD"}]},
+        }
+        self.assertEqual(
+            ["BASH"],
+            derive_relevant_item_ids(shop_less_state, "cards", "FAKE_MERCHANT"),
+        )
+        self.assertEqual(
+            ["BURNING_BLOOD"],
+            derive_relevant_item_ids(shop_less_state, "relics", "FAKE_MERCHANT"),
         )
 
     def test_python_scene_fields_are_exported_by_the_mod(self) -> None:

--- a/skills/sts2-mcp-player/SKILL.md
+++ b/skills/sts2-mcp-player/SKILL.md
@@ -53,7 +53,8 @@ The in-game overlay agent loads the shared play contract below plus references/s
 2. Prefer the guided decision loop: `get_game_state -> get_available_actions -> act`.
    Use `wait_until_actionable` across animations and screen changes. Use `get_raw_game_state` only if compact state is missing a needed field.
 3. For cards, monsters, relics, potions, shop items, and event options, prioritize game-data tools before using memory:
-   `get_relevant_game_data` (default, scene-aware minimal context) ->
+   `get_relevant_game_data` (default, scene-aware minimal context; omit `item_ids` and the current
+   screen decides which ids to look up) ->
    `get_game_data_item` (single-entity lookup) ->
    `get_game_data_items` (batch compare/filter).
    The compact view carries the ids those lookups key on: `combat.hand[].card_id`,
@@ -76,6 +77,9 @@ Do not trust memory over the current payload. The game mutates screens in place,
 
 - Never guess static game facts (card text, potion targeting, monster metadata, relic effects, event option details) from memory when game-data tools are available.
 - Use `get_relevant_game_data` first for current-scene context in combat/shop/event/menu flows.
+  Passing `item_ids` is optional: without it the tool derives the ids the screen is about (the hand
+  in a fight, the shop stock in a shop, the event you are in). Pass them when you want to ask about
+  a specific id instead.
 - Use `get_game_data_item` when you need deep details for one entity id.
 - Use `get_game_data_items` when comparing multiple entities (for example, reward-card choices, shop candidates, potion options).
 - If state and metadata disagree, trust live state for legality and metadata for semantics; then re-read state.


### PR DESCRIPTION
Follow-up to the v0.12.1 acceptance round. That pass recorded three findings and deliberately left them open; this PR settles all three, each with live evidence on the isolated host, and fixes two more defects that surfaced while verifying them.

## 1. The paged combat-rules FTUE was correct — the contract now says so

`NCombatRulesFtue` really is three pages (`build/sts2-decompiled/MegaCrit.Sts2.Core.Nodes.Ftue/NCombatRulesFtue.cs:165` `_totalPages = 3`; only the click after the last page calls `CloseFtue`), so the three `confirm_modal` calls the earlier pass saw were always the right number. What was wrong is that a non-final page answered `pending` with the generic transition wording, which reads like a stall to a caller that treats `pending` as failure.

`FtueModalPolicy.IsMultiPageFtue` now drives the message: a non-final page answers `Tutorial page advanced; the modal is still open. Call confirm_modal again.`, every other modal keeps `Action queued but state is still transitioning.`

| Live (isolated host, `modal=NCombatRulesFtue`) | Result |
| --- | --- |
| click 1 | `pending` — `Tutorial page advanced; the modal is still open. Call confirm_modal again.` |
| click 2 | `pending` — same message |
| click 3 | `completed` — `modal` empty, `screen` back on `COMBAT` |

## 2. `get_relevant_game_data` no longer needs `item_ids`

Omitting `item_ids` is now the normal call: the ids the current screen is about are derived from live state (`GameDataFilter.SceneItemSources`, mirrored as `_SCENE_ITEM_SOURCES` in the MCP server; `test_scene_field_alignment.py` keeps both keys and paths equal, and a behavioural test on each side reads the ids off a real state shape). A scene with nothing to say falls back to the run-level ids.

Live, over the bundled MCP tool surface (not the raw endpoint):

| Call | Answer |
| --- | --- |
| `get_relevant_game_data {"collection":"monsters"}` | exactly the three enemies in that room: TWIG_SLIME_S / LEAF_SLIME_M / LEAF_SLIME_S |
| `get_relevant_game_data {"collection":"cards"}` | the hand: DEFEND_IRONCLAD / STRIKE_IRONCLAD |
| `get_relevant_game_data {"collection":"relics"}` | run-level fallback: BURNING_BLOOD |
| `get_relevant_game_data {"collection":"cards","item_ids":"STRIKE_IRONCLAD"}` | unchanged, explicit ids still win |
| `get_relevant_game_data {"collection":"potions"}` | `{}` — empty slots are an empty answer, not a guess |

## 3. `combat.enemies[].base_max_hp` separates the base roll from the scaled HP

The new field carries `Creature.MonsterMaxHpBeforeModification` — the same dimension as `monsters.min_hp` / `max_hp` — while `max_hp` stays the scaled live value. Scaling runs only when `playerCount != 1` (`ScaleMonsterHpForMultiplayer`), which is why the original report had to come from a co-op fight.

Live in a two-player run, both instances reporting the same numbers:

| Enemy | metadata | `base_max_hp` | live `max_hp` |
| --- | --- | --- | --- |
| TWIG_SLIME_S | 7–11 | 9 | 19 |
| LEAF_SLIME_M | 32–35 | 33 | 72 |
| LEAF_SLIME_S | 11–15 | 13 | 28 |

Each live value is `base × players(2) × act-0 factor(1.1)`, truncated.

## Two defects found while verifying

- **A scene can classify into a scene whose payload is null there.** `FAKE_MERCHANT` reads as shop (`DetectScene` matches "merchant"), but `BuildShopPayload` answers `null` on that screen because the merchant room it reads does not exist, so walking `shop.cards[].card_id` stepped into a JSON null and threw. The walk is now kind-guarded like its Python twin, and an empty scene answer falls back to the run-level ids instead of stopping at `{}`.
- **The two mirrors disagreed on empty-string ids.** C# accepted one that Python skipped; both skip it now.

## Checks

- `dotnet run --project STS2AIAgent.Tests/STS2AIAgent.Tests.csproj` — **382 PASS / 0 FAIL** (new: 9 `GameDataFilter.*` behavioural tests, the FTUE multi-page contract, 3 enemy base-HP contracts)
- `dotnet build STS2AIAgent/STS2AIAgent.csproj -c Release` — 0 warnings, 0 errors
- `cd mcp_server; uv run --locked python -m unittest discover -s tests` — **167 OK**
- `python scripts/check_verification_gates.py` — all seven gates green
- Real Steam save: 183 files, SHA256 identical before and after every live run (0 changed)

Evidence: `build/validation-2026-09-13/verify-round-3.jsonl`, `verify-fixes-3.log`, `verify-base-hp-mp.log`; the record also went into `docs/live-validation-checklist.md`, and `docs/api.md` documents the new field and the optional `item_ids`.

## Summary by Sourcery

Make scene-aware game-data lookups self-sufficient, clarify multi-page FTUE transitions, and expose unscaled enemy HP alongside live scaled values.

New Features:
- Allow get_relevant_game_data to derive relevant item IDs from the current game scene when item_ids is omitted.
- Expose nullable combat.enemies[].base_max_hp for the unscaled enemy HP roll in raw and compact state payloads.

Bug Fixes:
- Clarify pending responses for the paged combat-rules FTUE so callers know to confirm again while the modal remains open.
- Make scene-aware item ID derivation resilient to null or missing payloads, empty IDs, and fallback to run-level data when needed.
- Keep C# and Python scene item-source derivation behavior aligned.

Enhancements:
- Document scene-derived metadata lookups and the distinction between base and scaled enemy HP.
- Add behavioral and contract coverage for FTUE transitions, item-source derivation, mirror parity, and enemy base HP.

Documentation:
- Document the optional item_ids parameter and the new base_max_hp combat field.

Tests:
- Add coverage for scene-based item ID derivation, fallbacks, null payloads, empty IDs, and enemy base HP contracts.