### PR TITLE
Release v0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 > Release attribution is recorded against tags or release commits. Post-tag maintenance is listed separately; current validation limits are maintained in [PRODUCT_PLAN_CURRENT.md](https://github.com/CharTyr/STS2-Agent/blob/main/PRODUCT_PLAN_CURRENT.md).
 
-## Unreleased
+## v0.12.2 - 2026-09-13
 
-> Issue #85: the player who wants to fight their own character while an outside agent drives the
-> teammate window no longer has to fake a passing model test to get there. Inviting a teammate now
-> picks its route from whether the play model is verified, and the supported control entry moved to
-> the host window. Live: [docs/live-validation-checklist.md](docs/live-validation-checklist.md).
+> The co-op handoff: the player who wants to fight their own character while an outside agent drives the
+> teammate window no longer has to fake a passing model test to get there, and the state that agent reads
+> stopped contradicting itself. Live:
+> [docs/live-validation-checklist.md](docs/live-validation-checklist.md).
 
 ### Added
 
@@ -22,6 +22,12 @@
   `GET /state` and `POST /action` instead of guessing the port. The session token is not part of it.
 - `docs/api.md` documents the two co-op routes side by side, the new endpoint, and the new field; both
   READMEs gained an “Option C: hand the teammate window to an external agent”.
+- `combat.enemies[].base_max_hp` on both the raw and the compact enemy payload (#101). It carries
+  `Creature.MonsterMaxHpBeforeModification` — the same dimension as the `monsters` collection’s
+  `min_hp` / `max_hp` — while `max_hp` stays the scaled live value. Co-op multiplies monster HP by
+  `players × act factor` before it reaches the live creature, so a metadata lookup and a live enemy used to
+  read as a contradiction (metadata 7–11 next to a live 19) with nothing in the payload to resolve it.
+  Live two-player: `base_max_hp` 9 / 33 / 13 against live `max_hp` 19 / 72 / 28, both instances agreeing.
 
 ### Changed
 
@@ -34,6 +40,16 @@
 - The conditions both routes still enforce are unchanged and are now a named policy
   (`CoopLaunchPolicy.GetStructuralError`): not the companion instance, no auto-play already running on this
   character, main menu. The split is scoped to the model gate and is not a way around those.
+- **A paged tutorial now says where it is instead of looking stuck (#101).** `NCombatRulesFtue` is three
+  pages by design: one confirm advances a page and leaves the modal open, and only the click after the last
+  page closes it. A non-final page answered `pending` with the same wording as a stalled transition, which
+  reads as failure to a caller that treats `pending` that way. It now answers `Tutorial page advanced; the
+  modal is still open. Call confirm_modal again.`; every other modal keeps the old message.
+- **`get_relevant_game_data` works without `item_ids` (#101).** Omitting them derives the ids the current
+  screen is about from live state — the hand in a fight, the stock in a shop, the event you are in — and
+  falls back to the run-level ids when the scene has nothing to offer. Passing ids explicitly still answers
+  exactly those. The id sources exist once per implementation and a test keeps the two tables equal, keys and
+  paths, the same way the scene field sets are kept.
 
 ### Fixed
 
@@ -44,6 +60,16 @@
 - `/health` stopped advertising a companion API port after that process exited.
 - `teammate_control_failed` is `retryable: true`, matching what the docs already said; its causes (a launch in
   progress, an unfinished previous control, an unconfirmed pause) all clear on their own.
+- **The companion’s own `POST /session/control` skipped the play-model gate (#99).** The host’s Resume
+  button, `POST /companion/control` and `POST /teammate/control` all refused to start the loop without a
+  verified play model, while the teammate instance accepted `{"running": true}` and started one — the one
+  start entry that could begin a model loop every other entry rejects. Every start entry now shares
+  `FirstRunSetup.ReadyToInvite`; pausing is deliberately never gated, so nothing can be stuck unable to stop.
+- Deriving those ids stepped into JSON nulls (#101). `FAKE_MERCHANT` classifies as a shop screen, but the
+  `shop` payload is `null` there — the merchant room those ids come from does not exist on that screen — so
+  walking `shop.cards[].card_id` threw instead of answering. The walk is now guarded by JSON kind, and a
+  scene with nothing to offer falls back to the run-level ids rather than stopping at an empty answer. The two
+  derivations also agreed on empty-string ids, which they previously did not.
 
 ## v0.12.1 - 2026-09-13
 

--- a/STS2AIAgent/Server/Router.cs
+++ b/STS2AIAgent/Server/Router.cs
@@ -15,7 +15,7 @@ internal static class Router
 {
     private const string ServiceName = "sts2-ai-agent";
     private const string ProtocolVersion = "2026-03-11-v1";
-    internal const string ModVersion = "0.12.1";
+    internal const string ModVersion = "0.12.2";
     private const string LogPrefix = "[STS2AIAgent.Router]";
 
     private static long _requestCounter;

--- a/STS2AIAgent/mod_id.json
+++ b/STS2AIAgent/mod_id.json
@@ -3,7 +3,7 @@
   "name": "STS2 AI Agent",
   "author": "CharTyr",
   "description": "带一个 AI 一起爬塔。你打自己的角色，同一台电脑上 AI 可以打另一个。还在开发中，欢迎反馈。",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "min_game_version": "0.111.0",
   "has_pck": true,
   "has_dll": true,

--- a/STS2AIAgent/mod_manifest.json
+++ b/STS2AIAgent/mod_manifest.json
@@ -4,7 +4,7 @@
   "name": "STS2 AI Agent",
   "author": "CharTyr",
   "description": "带一个 AI 一起爬塔。你打自己的角色，同一台电脑上 AI 可以打另一个。还在开发中，欢迎反馈。",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "min_game_version": "0.111.0",
   "has_pck": true,
   "has_dll": true,

--- a/docs/api.md
+++ b/docs/api.md
@@ -143,7 +143,7 @@
   "request_id": "req_20260911_121549_7955_4",
   "data": {
     "service": "sts2-ai-agent",
-    "mod_version": "0.12.1",
+    "mod_version": "0.12.2",
     "protocol_version": "2026-03-11-v1",
     "game_version": "v0.111.0",
     "status": "ready",

--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sts2-ai-agent-mcp"
-version = "0.12.1"
+version = "0.12.2"
 description = "FastMCP wrapper for the local STS2 AI Agent mod"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/mcp_server/uv.lock
+++ b/mcp_server/uv.lock
@@ -1194,7 +1194,7 @@ wheels = [
 
 [[package]]
 name = "sts2-ai-agent-mcp"
-version = "0.12.1"
+version = "0.12.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/steam-workshop/workshop.json
+++ b/steam-workshop/workshop.json
@@ -1,7 +1,7 @@
 {
   "title": "STS2 AI Agent",
   "visibility": "public",
-  "changeNote": "v0.12.1: pausing is safe again. The pause menu and the pages opened from it (compendium, card library, settings) no longer read as a live room, so the agent stops offering actions the pause swallows and a page's own buttons stop arriving as options; a wrong --clientId can no longer eat a co-op save",
+  "changeNote": "v0.12.2: invite an AI teammate without configuring a model first - the teammate joins, then waits for you or an outside tool to drive it, and the main window's /teammate/control starts or pauses it. Also: enemy HP reports the pre-co-op roll next to the scaled one, metadata lookups work without naming ids, and the paged combat tutorial says so instead of looking stuck",
   "tags": [
     "Tools & APIs",
     "Utility",


### PR DESCRIPTION
Bumps the five version sources to **0.12.2** and closes out the changelog for it.

## What ships

Everything in this release was already on `main` and already had live evidence before the bump:

| Change | PR | Live evidence |
| --- | --- | --- |
| External-agent takeover: inviting a teammate no longer needs a verified play model; host-window `POST /teammate/control`; `/health` companion block | #97 | dead model endpoint, teammate parks with `session_requests: 0` |
| The companion's own `POST /session/control` goes through the same play-model gate | #99 | `{running:true}` → 409 `session_not_ready`, `{running:false}` → 200 |
| Paged-tutorial wording, optional `item_ids`, `combat.enemies[].base_max_hp` | #101 | FTUE `pending`/`pending`/`completed`; scene-derived ids; `base_max_hp` 9/33/13 vs live 19/72/28 |

The code is byte-identical to what those runs exercised — only docs moved since — so the live evidence is evidence for this candidate, not a historical result. Real Steam save: 183 files hashed identical before and after every run.

## In this PR

- five version sources → `0.12.2` (`mod_manifest.json`, `mod_id.json`, `Router.cs`, `pyproject.toml`, `uv.lock` via `uv lock`)
- `docs/api.md` health example → `0.12.2` (the `api-facts` gate checks this against the manifest)
- `CHANGELOG.md`: `## Unreleased` becomes `## v0.12.2 - 2026-09-13`; entries added for #99 and for #101's three items, which were still missing
- `steam-workshop/workshop.json` changeNote → v0.12.2

## Checks

- `powershell -ExecutionPolicy Bypass -File scripts/preflight-release.ps1` — every step green, including `check_release_metadata.py` reporting `0.12.2` in all five sources
- A fresh review of the changelog against `git log v0.12.1..HEAD` found all 13 user-visible changes covered and no claim the code does not back; it also re-derived the three claims that are easy to get wrong (the tutorial really is three pages at `NCombatRulesFtue.cs:165`, co-op scaling really is `players × act factor` per `Creature.cs:749`, and the two id tables are asserted equal field-by-field)

Next after merge: tag, `package-release.ps1`, GitHub Release, Workshop upload, and the record commit.

## Summary by Sourcery

Release version 0.12.2 with finalized documentation, synchronized package metadata, and the completed co-op, tutorial, item-data, and combat-payload improvements.

Bug Fixes:
- Ensure companion session control respects the verified play-model requirement while preserving unrestricted pause behavior.
- Prevent scene-based item ID discovery from failing on null payloads and provide run-level fallbacks when scene data is unavailable.

Enhancements:
- Clarify multi-page tutorial progress responses and allow relevant game data retrieval to derive item IDs from the active scene.
- Add enemy base maximum HP metadata to raw and compact combat payloads to distinguish unscaled values from live scaled HP.

Build:
- Bump all application and package version sources to 0.12.2 and regenerate the dependency lockfile.

Deployment:
- Update the Steam Workshop release note to v0.12.2.

Documentation:
- Finalize the v0.12.2 changelog and update the API version example.